### PR TITLE
Add invitation and membership management endpoints for superadmin panel

### DIFF
--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -40,12 +40,15 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo *superadmin.Repo, 
 			r.Get("/{id}", h.GetOrganization)
 			r.Patch("/{id}", h.UpdateOrganization)
 			r.Delete("/{id}", h.DeleteOrganization)
+			r.Get("/{id}/invitations", h.ListOrgInvitations)
 			r.Post("/{id}/invitations", h.CreateInvitation)
+			r.Get("/{id}/members", h.ListMembers)
 			r.Post("/{id}/members", h.AddMember)
 			r.Delete("/{id}/members/{userId}", h.RemoveMember)
 		})
 
 		s.Post("/invitations/{token}/consume", h.ConsumeInvitation)
+		s.Delete("/invitations/{id}", h.CancelInvitation)
 		s.Get("/users", h.SearchUsers)
 		s.Patch("/users/{id}/status", h.UpdateUserStatus)
 		s.Post("/api-keys", h.CreateAPIKey)
@@ -59,7 +62,9 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo *superadmin.Repo, 
 	fs := http.Dir("web")
 	r.Get("/*", func(w http.ResponseWriter, req *http.Request) {
 		up := req.URL.Path
-		if up == "/" { up = "/index.html" }
+		if up == "/" {
+			up = "/index.html"
+		}
 		f, err := fs.Open(up)
 		if err == nil {
 			defer f.Close()

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -4,13 +4,30 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
 
-// Usa RemoteAddr (confiando en chi/middleware.RealIP antes en la cadena).
+var rateLimitScript = redis.NewScript(`
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('PTTL', KEYS[1])
+return {count, ttl}
+`)
+
+// Usa X-Forwarded-For si está disponible, de lo contrario RemoteAddr (RealIP middleware debería haberlo normalizado).
 func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		ip := strings.TrimSpace(strings.Split(xff, ",")[0])
+		if ip != "" {
+			return ip
+		}
+	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err == nil && host != "" {
 		return host
@@ -37,19 +54,65 @@ func RateLimit(rdb *redis.Client, rps, burst int) func(http.Handler) http.Handle
 			key := fmt.Sprintf("rl:%s:%s:%s", r.Method, r.URL.Path, ip)
 
 			// INCR y setea expiración la primera vez
-			pipe := rdb.TxPipeline()
-			incr := pipe.Incr(r.Context(), key)
-			pipe.Expire(r.Context(), key, window)
-			_, _ = pipe.Exec(r.Context())
-
-			n, err := incr.Result()
-			if err == nil && n > limit {
-				// 429 con Retry-After aproximado
-				w.Header().Set("Retry-After", "1")
+			res, err := rateLimitScript.Run(r.Context(), rdb, []string{key}, window.Milliseconds()).Result()
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			vals, ok := res.([]interface{})
+			if !ok || len(vals) != 2 {
+				next.ServeHTTP(w, r)
+				return
+			}
+			current := toInt64(vals[0])
+			ttl := toInt64(vals[1])
+			remaining := limit - current
+			if remaining < 0 {
+				remaining = 0
+			}
+			resetUnix := time.Now().Add(time.Second)
+			if ttl > 0 {
+				resetUnix = time.Now().Add(time.Duration(ttl) * time.Millisecond)
+			}
+			w.Header().Set("X-RateLimit-Limit", strconv.FormatInt(limit, 10))
+			w.Header().Set("X-RateLimit-Remaining", strconv.FormatInt(max64(remaining, 0), 10))
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetUnix.Unix(), 10))
+			if current > limit {
+				retryAfter := 1
+				if ttl > 0 {
+					retryAfter = int(time.Duration(ttl) * time.Millisecond / time.Second)
+					if retryAfter <= 0 {
+						retryAfter = 1
+					}
+				}
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 				http.Error(w, "rate limit", http.StatusTooManyRequests)
 				return
 			}
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func toInt64(v interface{}) int64 {
+	switch t := v.(type) {
+	case int64:
+		return t
+	case int:
+		return int64(t)
+	case float64:
+		return int64(t)
+	case string:
+		n, _ := strconv.ParseInt(t, 10, 64)
+		return n
+	default:
+		return 0
+	}
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -10,15 +10,18 @@ type Organization struct {
 }
 
 type OrgInvitation struct {
-	ID        string     `json:"id"`
-	OrgID     string     `json:"org_id"`
-	Email     *string    `json:"email,omitempty"`
-	OrgRoleID string     `json:"org_role_id"`
-	Token     string     `json:"token"`
-	ExpiresAt time.Time  `json:"expires_at"`
-	UsedAt    *time.Time `json:"used_at,omitempty"`
-	CreatedBy *string    `json:"created_by,omitempty"`
-	CreatedAt time.Time  `json:"created_at"`
+	ID          string     `json:"id"`
+	OrgID       string     `json:"org_id"`
+	Email       *string    `json:"email,omitempty"`
+	OrgRoleID   string     `json:"org_role_id"`
+	OrgRoleCode string     `json:"org_role_code,omitempty"`
+	Token       string     `json:"token"`
+	ExpiresAt   time.Time  `json:"expires_at"`
+	UsedAt      *time.Time `json:"used_at,omitempty"`
+	RevokedAt   *time.Time `json:"revoked_at,omitempty"`
+	Status      string     `json:"status"`
+	CreatedBy   *string    `json:"created_by,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
 }
 
 type User struct {
@@ -40,14 +43,24 @@ type APIKey struct {
 	Revoked     bool       `json:"revoked"`
 }
 
-type AuditLog struct {
-	ID       string                 `json:"id"`
-	Action   string                 `json:"action"`
-	TS       time.Time              `json:"ts"`                       // antes "When"
-	UserID   *string                `json:"user_id,omitempty"`        // uuid -> string
-	Entity   *string                `json:"entity,omitempty"`         // p.ej. "api_key", "organization"
-	EntityID *string                `json:"entity_id,omitempty"`      // uuid -> string
-	Details  map[string]any         `json:"details,omitempty"`        // JSONB
-	IP       *string                `json:"ip,omitempty"`             // inet -> string
+type Membership struct {
+	OrgID        string    `json:"org_id"`
+	UserID       string    `json:"user_id"`
+	Email        string    `json:"email"`
+	Name         string    `json:"name"`
+	OrgRoleID    string    `json:"org_role_id"`
+	OrgRoleCode  string    `json:"org_role_code"`
+	OrgRoleLabel string    `json:"org_role_label"`
+	JoinedAt     time.Time `json:"joined_at"`
 }
 
+type AuditLog struct {
+	ID       string         `json:"id"`
+	Action   string         `json:"action"`
+	TS       time.Time      `json:"ts"`                  // antes "When"
+	UserID   *string        `json:"user_id,omitempty"`   // uuid -> string
+	Entity   *string        `json:"entity,omitempty"`    // p.ej. "api_key", "organization"
+	EntityID *string        `json:"entity_id,omitempty"` // uuid -> string
+	Details  map[string]any `json:"details,omitempty"`   // JSONB
+	IP       *string        `json:"ip,omitempty"`        // inet -> string
+}

--- a/backend/internal/superadmin/repo_test.go
+++ b/backend/internal/superadmin/repo_test.go
@@ -1,0 +1,189 @@
+package superadmin
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"heartguard-superadmin/internal/models"
+)
+
+type fakeRows struct {
+	data [][]any
+	idx  int
+	err  error
+}
+
+func (r *fakeRows) Close()                                       { r.idx = len(r.data) }
+func (r *fakeRows) Err() error                                   { return r.err }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) Next() bool {
+	if r.idx >= len(r.data) {
+		return false
+	}
+	r.idx++
+	return true
+}
+
+func assignValue(dest reflect.Value, val any) {
+	if dest.Kind() != reflect.Pointer {
+		return
+	}
+	elem := dest.Elem()
+	if !elem.CanSet() {
+		return
+	}
+	if elem.Kind() == reflect.Pointer {
+		if val == nil {
+			elem.Set(reflect.Zero(elem.Type()))
+			return
+		}
+		v := reflect.New(elem.Type().Elem())
+		assignValue(v, val)
+		elem.Set(v)
+		return
+	}
+	if val == nil {
+		elem.Set(reflect.Zero(elem.Type()))
+		return
+	}
+	vv := reflect.ValueOf(val)
+	if !vv.Type().AssignableTo(elem.Type()) {
+		if vv.Type().ConvertibleTo(elem.Type()) {
+			vv = vv.Convert(elem.Type())
+		} else {
+			panic("unsupported type assignment")
+		}
+	}
+	elem.Set(vv)
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.idx == 0 || r.idx > len(r.data) {
+		return errors.New("invalid scan state")
+	}
+	row := r.data[r.idx-1]
+	for i, d := range dest {
+		if d == nil {
+			continue
+		}
+		assignValue(reflect.ValueOf(d), row[i])
+	}
+	return nil
+}
+
+func (r *fakeRows) Values() ([]any, error) { return nil, nil }
+func (r *fakeRows) RawValues() [][]byte    { return nil }
+func (r *fakeRows) Conn() *pgx.Conn        { return nil }
+
+type stubPool struct {
+	rows      pgx.Rows
+	queryErr  error
+	execErr   error
+	execTag   pgconn.CommandTag
+	execArgs  []any
+	queryArgs []any
+}
+
+func (s *stubPool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	s.queryArgs = args
+	return s.rows, s.queryErr
+}
+
+func (s *stubPool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	s.queryArgs = args
+	return nil
+}
+
+func (s *stubPool) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	s.execArgs = args
+	return s.execTag, s.execErr
+}
+
+func (s *stubPool) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubPool) Ping(ctx context.Context) error { return nil }
+
+func TestListOrgInvitations(t *testing.T) {
+	fixed := time.Date(2024, 5, 15, 10, 0, 0, 0, time.UTC)
+	origNow := nowFn
+	nowFn = func() time.Time { return fixed }
+	t.Cleanup(func() { nowFn = origNow })
+
+	rows := &fakeRows{data: [][]any{
+		{"inv-1", "org-1", "demo@heartguard.com", "role-1", "org_admin", "tok1", fixed.Add(2 * time.Hour), nil, nil, nil, fixed.Add(-time.Hour)},
+		{"inv-2", "org-1", nil, "role-1", "org_admin", "tok2", fixed.Add(-time.Hour), fixed.Add(-30 * time.Minute), nil, nil, fixed.Add(-2 * time.Hour)},
+		{"inv-3", "org-1", "user@example.com", "role-1", "org_admin", "tok3", fixed.Add(2 * time.Hour), nil, fixed.Add(-10 * time.Minute), nil, fixed.Add(-3 * time.Hour)},
+	}}
+	stub := &stubPool{rows: rows}
+	repo := NewRepoWithPool(stub)
+
+	res, err := repo.ListOrgInvitations(context.Background(), "org-1", 25, 0)
+	if err != nil {
+		t.Fatalf("ListOrgInvitations: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(res))
+	}
+	if res[0].Status != "pending" || res[1].Status != "used" || res[2].Status != "revoked" {
+		t.Fatalf("unexpected statuses: %+v", res)
+	}
+}
+
+func TestCancelInvitation(t *testing.T) {
+	stub := &stubPool{execTag: pgconn.CommandTag("UPDATE 1")}
+	repo := NewRepoWithPool(stub)
+	if err := repo.CancelInvitation(context.Background(), "inv-ok"); err != nil {
+		t.Fatalf("cancel ok: %v", err)
+	}
+	if len(stub.execArgs) != 1 || stub.execArgs[0] != "inv-ok" {
+		t.Fatalf("unexpected exec args: %+v", stub.execArgs)
+	}
+
+	stubFail := &stubPool{execTag: pgconn.CommandTag("UPDATE 0")}
+	repoFail := NewRepoWithPool(stubFail)
+	if err := repoFail.CancelInvitation(context.Background(), "inv-missing"); err == nil {
+		t.Fatalf("expected error for missing invitation")
+	}
+}
+
+func TestListMembers(t *testing.T) {
+	joined := time.Date(2024, 5, 15, 9, 0, 0, 0, time.UTC)
+	rows := &fakeRows{data: [][]any{{"org-1", "user-1", "demo@heartguard.com", "Demo User", "role-1", "org_admin", "Org Admin", joined}}}
+	stub := &stubPool{rows: rows}
+	repo := NewRepoWithPool(stub)
+
+	res, err := repo.ListMembers(context.Background(), "org-1", 10, 0)
+	if err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(res))
+	}
+	if res[0].UserID != "user-1" || res[0].OrgRoleCode != "org_admin" {
+		t.Fatalf("unexpected payload: %+v", res[0])
+	}
+}
+
+func TestInvitationStatusHelper(t *testing.T) {
+	now := time.Unix(1000, 0)
+	inv := &models.OrgInvitation{ExpiresAt: now.Add(time.Hour)}
+	if s := invitationStatus(inv, now); s != "pending" {
+		t.Fatalf("expected pending, got %s", s)
+	}
+	inv.UsedAt = &now
+	if s := invitationStatus(inv, now); s != "used" {
+		t.Fatalf("expected used, got %s", s)
+	}
+	inv.UsedAt = nil
+	inv.RevokedAt = &now
+	if s := invitationStatus(inv, now); s != "revoked" {
+		t.Fatalf("expected revoked, got %s", s)
+	}
+}

--- a/db/init.sql
+++ b/db/init.sql
@@ -239,6 +239,7 @@ CREATE TABLE IF NOT EXISTS org_invitations (
   token        VARCHAR(120) NOT NULL UNIQUE,
   expires_at   TIMESTAMP NOT NULL,
   used_at      TIMESTAMP,
+  revoked_at   TIMESTAMP,
   created_by   UUID REFERENCES users(id) ON DELETE SET NULL,
   created_at   TIMESTAMP NOT NULL DEFAULT NOW()
 );

--- a/db/migrations/20240515_add_revoked_at_org_invitations.sql
+++ b/db/migrations/20240515_add_revoked_at_org_invitations.sql
@@ -1,0 +1,2 @@
+ALTER TABLE org_invitations
+    ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMP;

--- a/docs/backend_endpoints_new.md
+++ b/docs/backend_endpoints_new.md
@@ -1,0 +1,49 @@
+# Nuevos endpoints y extensiones del panel Superadmin
+
+## Invitaciones de organización
+
+### `GET /v1/superadmin/organizations/{id}/invitations`
+- **Query**: `limit` (opcional, <=200), `offset` (opcional).
+- **Respuesta 200**: arreglo de invitaciones con campos `status`, `revoked_at`, `org_role_code`.
+- **Errores**: `500 db_error` si falla la consulta.
+- **Auditoría**: solo lectura, no genera evento.
+- **Rate-limit**: encabezados `X-RateLimit-*` y `Retry-After` cuando aplica.
+
+### `DELETE /v1/superadmin/invitations/{id}`
+- **Acción**: marca una invitación como revocada cuando no fue usada.
+- **Respuesta 204**.
+- **Errores**:
+  - `404 not_found` si la invitación no existe o ya se usó/revocó.
+  - `500 db_error` en fallas inesperadas.
+- **Auditoría**: `INVITE_CANCEL` con `entity_id` la invitación revocada.
+
+### `POST /v1/superadmin/organizations/{id}/invitations`
+- **Extensión**: el payload existente ahora persiste `revoked_at` y expone `status` calculado en la respuesta.
+- **Auditoría**: `INVITE_CREATE` con `org_id`.
+
+## Membresías de organización
+
+### `GET /v1/superadmin/organizations/{id}/members`
+- **Query**: `limit`, `offset`.
+- **Respuesta 200**: arreglo de miembros con campos `email`, `name`, `org_role_code`, `joined_at`.
+- **Errores**: `500 db_error`.
+- **Auditoría**: solo lectura.
+
+### `POST /v1/superadmin/organizations/{id}/members`
+- **Extensión**: al crear/actualizar membresía se registra `user_id` en detalles de auditoría.
+
+### `DELETE /v1/superadmin/organizations/{id}/members/{userId}`
+- **Extensión**: auditoría incluye `user_id` en detalles.
+
+## Rate limit global
+- El middleware ahora agrega `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` en todas las respuestas.
+- En caso de exceso se devuelve `429` con `Retry-After` en segundos.
+
+## Auditoría
+- Nuevas acciones: `INVITE_CANCEL`, `MEMBER_ADD`/`MEMBER_REMOVE` incluyen `user_id` en los detalles.
+- Se centralizó la escritura de auditoría con helper que respeta `audit.Ctx`.
+
+## Seguridad
+- Todas las rutas siguen protegidas por `RequireSuperadmin` y el rate-limit descrito arriba.
+- El endpoint de revocación de invitación verifica que no esté usada ni revocada previamente.
+


### PR DESCRIPTION
## Summary
- add repository and handler support for listing and cancelling organization invitations, plus listing organization members
- harden rate-limiting middleware with response headers and expose new membership/invitation tooling in the web panel
- document the new endpoints and add migration for invitation revocation tracking

## Testing
- `go test ./...` *(fails: missing module downloads in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ded3316694832fbd7a7be4fcec269d