### PR TITLE
Refactor invitations module and add catalogs and metrics

### DIFF
--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -40,12 +40,30 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo *superadmin.Repo, 
 			r.Get("/{id}", h.GetOrganization)
 			r.Patch("/{id}", h.UpdateOrganization)
 			r.Delete("/{id}", h.DeleteOrganization)
-			r.Post("/{id}/invitations", h.CreateInvitation)
+			r.Get("/{id}/members", h.ListMembers)
 			r.Post("/{id}/members", h.AddMember)
 			r.Delete("/{id}/members/{userId}", h.RemoveMember)
 		})
 
-		s.Post("/invitations/{token}/consume", h.ConsumeInvitation)
+		s.Route("/invitations", func(r chi.Router) {
+			r.Get("/", h.ListInvitations)
+			r.Post("/", h.CreateInvitation)
+			r.Delete("/{id}", h.CancelInvitation)
+			r.Post("/{token}/consume", h.ConsumeInvitation)
+		})
+
+		s.Route("/catalogs", func(r chi.Router) {
+			r.Get("/", h.ListCatalogs)
+			r.Get("/{slug}", h.ListCatalogItems)
+			r.Post("/{slug}", h.CreateCatalogItem)
+			r.Patch("/{slug}/{id}", h.UpdateCatalogItem)
+			r.Delete("/{slug}/{id}", h.DeleteCatalogItem)
+		})
+
+		s.Route("/metrics", func(r chi.Router) {
+			r.Get("/overview", h.MetricsOverview)
+		})
+
 		s.Get("/users", h.SearchUsers)
 		s.Patch("/users/{id}/status", h.UpdateUserStatus)
 		s.Post("/api-keys", h.CreateAPIKey)
@@ -59,7 +77,9 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo *superadmin.Repo, 
 	fs := http.Dir("web")
 	r.Get("/*", func(w http.ResponseWriter, req *http.Request) {
 		up := req.URL.Path
-		if up == "/" { up = "/index.html" }
+		if up == "/" {
+			up = "/index.html"
+		}
 		f, err := fs.Open(up)
 		if err == nil {
 			defer f.Close()

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -4,13 +4,30 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
 
-// Usa RemoteAddr (confiando en chi/middleware.RealIP antes en la cadena).
+var rateLimitScript = redis.NewScript(`
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('PTTL', KEYS[1])
+return {count, ttl}
+`)
+
+// Usa X-Forwarded-For si está disponible, de lo contrario RemoteAddr (RealIP middleware debería haberlo normalizado).
 func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		ip := strings.TrimSpace(strings.Split(xff, ",")[0])
+		if ip != "" {
+			return ip
+		}
+	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err == nil && host != "" {
 		return host
@@ -37,19 +54,65 @@ func RateLimit(rdb *redis.Client, rps, burst int) func(http.Handler) http.Handle
 			key := fmt.Sprintf("rl:%s:%s:%s", r.Method, r.URL.Path, ip)
 
 			// INCR y setea expiración la primera vez
-			pipe := rdb.TxPipeline()
-			incr := pipe.Incr(r.Context(), key)
-			pipe.Expire(r.Context(), key, window)
-			_, _ = pipe.Exec(r.Context())
-
-			n, err := incr.Result()
-			if err == nil && n > limit {
-				// 429 con Retry-After aproximado
-				w.Header().Set("Retry-After", "1")
+			res, err := rateLimitScript.Run(r.Context(), rdb, []string{key}, window.Milliseconds()).Result()
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			vals, ok := res.([]interface{})
+			if !ok || len(vals) != 2 {
+				next.ServeHTTP(w, r)
+				return
+			}
+			current := toInt64(vals[0])
+			ttl := toInt64(vals[1])
+			remaining := limit - current
+			if remaining < 0 {
+				remaining = 0
+			}
+			resetUnix := time.Now().Add(time.Second)
+			if ttl > 0 {
+				resetUnix = time.Now().Add(time.Duration(ttl) * time.Millisecond)
+			}
+			w.Header().Set("X-RateLimit-Limit", strconv.FormatInt(limit, 10))
+			w.Header().Set("X-RateLimit-Remaining", strconv.FormatInt(max64(remaining, 0), 10))
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetUnix.Unix(), 10))
+			if current > limit {
+				retryAfter := 1
+				if ttl > 0 {
+					retryAfter = int(time.Duration(ttl) * time.Millisecond / time.Second)
+					if retryAfter <= 0 {
+						retryAfter = 1
+					}
+				}
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 				http.Error(w, "rate limit", http.StatusTooManyRequests)
 				return
 			}
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func toInt64(v interface{}) int64 {
+	switch t := v.(type) {
+	case int64:
+		return t
+	case int:
+		return int64(t)
+	case float64:
+		return int64(t)
+	case string:
+		n, _ := strconv.ParseInt(t, 10, 64)
+		return n
+	default:
+		return 0
+	}
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -10,15 +10,32 @@ type Organization struct {
 }
 
 type OrgInvitation struct {
-	ID        string     `json:"id"`
-	OrgID     string     `json:"org_id"`
-	Email     *string    `json:"email,omitempty"`
-	OrgRoleID string     `json:"org_role_id"`
-	Token     string     `json:"token"`
-	ExpiresAt time.Time  `json:"expires_at"`
-	UsedAt    *time.Time `json:"used_at,omitempty"`
-	CreatedBy *string    `json:"created_by,omitempty"`
-	CreatedAt time.Time  `json:"created_at"`
+	ID          string     `json:"id"`
+	OrgID       string     `json:"org_id"`
+	Email       *string    `json:"email,omitempty"`
+	OrgRoleID   string     `json:"org_role_id"`
+	OrgRoleCode string     `json:"org_role_code,omitempty"`
+	Token       string     `json:"token"`
+	ExpiresAt   time.Time  `json:"expires_at"`
+	UsedAt      *time.Time `json:"used_at,omitempty"`
+	RevokedAt   *time.Time `json:"revoked_at,omitempty"`
+	Status      string     `json:"status"`
+	CreatedBy   *string    `json:"created_by,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+type CatalogItem struct {
+	ID     string `json:"id"`
+	Code   string `json:"code"`
+	Label  string `json:"label"`
+	Weight *int   `json:"weight,omitempty"`
+}
+
+type CatalogDefinition struct {
+	Slug        string `json:"slug"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	HasWeight   bool   `json:"has_weight"`
 }
 
 type User struct {
@@ -40,14 +57,47 @@ type APIKey struct {
 	Revoked     bool       `json:"revoked"`
 }
 
-type AuditLog struct {
-	ID       string                 `json:"id"`
-	Action   string                 `json:"action"`
-	TS       time.Time              `json:"ts"`                       // antes "When"
-	UserID   *string                `json:"user_id,omitempty"`        // uuid -> string
-	Entity   *string                `json:"entity,omitempty"`         // p.ej. "api_key", "organization"
-	EntityID *string                `json:"entity_id,omitempty"`      // uuid -> string
-	Details  map[string]any         `json:"details,omitempty"`        // JSONB
-	IP       *string                `json:"ip,omitempty"`             // inet -> string
+type Membership struct {
+	OrgID        string    `json:"org_id"`
+	UserID       string    `json:"user_id"`
+	Email        string    `json:"email"`
+	Name         string    `json:"name"`
+	OrgRoleID    string    `json:"org_role_id"`
+	OrgRoleCode  string    `json:"org_role_code"`
+	OrgRoleLabel string    `json:"org_role_label"`
+	JoinedAt     time.Time `json:"joined_at"`
 }
 
+type AuditLog struct {
+	ID       string         `json:"id"`
+	Action   string         `json:"action"`
+	TS       time.Time      `json:"ts"`                  // antes "When"
+	UserID   *string        `json:"user_id,omitempty"`   // uuid -> string
+	Entity   *string        `json:"entity,omitempty"`    // p.ej. "api_key", "organization"
+	EntityID *string        `json:"entity_id,omitempty"` // uuid -> string
+	Details  map[string]any `json:"details,omitempty"`   // JSONB
+	IP       *string        `json:"ip,omitempty"`        // inet -> string
+}
+
+type OperationCount struct {
+	Action string `json:"action"`
+	Count  int    `json:"count"`
+}
+
+type ActivityEntry struct {
+	TS     time.Time `json:"ts"`
+	Action string    `json:"action"`
+	Entity *string   `json:"entity,omitempty"`
+	UserID *string   `json:"user_id,omitempty"`
+}
+
+type MetricsOverview struct {
+	AverageResponseMS   float64          `json:"average_response_ms"`
+	OperationCounts     []OperationCount `json:"operation_counts"`
+	ActiveUsers         int              `json:"active_users"`
+	ActiveOrganizations int              `json:"active_organizations"`
+	TotalUsers          int              `json:"total_users"`
+	TotalOrganizations  int              `json:"total_organizations"`
+	PendingInvitations  int              `json:"pending_invitations"`
+	RecentActivity      []ActivityEntry  `json:"recent_activity"`
+}

--- a/backend/internal/superadmin/handlers_test.go
+++ b/backend/internal/superadmin/handlers_test.go
@@ -1,0 +1,195 @@
+package superadmin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.uber.org/zap"
+	"heartguard-superadmin/internal/models"
+)
+
+type handlersStubRepo struct {
+	catalogDefs []models.CatalogDefinition
+	catalogItem *models.CatalogItem
+	catalogErr  error
+	overview    *models.MetricsOverview
+	recent      []models.ActivityEntry
+	metricsErr  error
+	recentErr   error
+}
+
+func (s *handlersStubRepo) AuditPool() *pgxpool.Pool   { return nil }
+func (s *handlersStubRepo) Ping(context.Context) error { return nil }
+func (s *handlersStubRepo) CreateOrganization(context.Context, string, string) (*models.Organization, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) ListOrganizations(context.Context, int, int) ([]models.Organization, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) GetOrganization(context.Context, string) (*models.Organization, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) UpdateOrganization(context.Context, string, *string, *string) (*models.Organization, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) DeleteOrganization(context.Context, string) error {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) CreateInvitation(context.Context, string, string, *string, time.Duration, *string) (*models.OrgInvitation, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) ListInvitations(context.Context, *string, *string, int, int) ([]models.OrgInvitation, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) ConsumeInvitation(context.Context, string, string) error {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) CancelInvitation(context.Context, string) error { panic("not implemented") }
+func (s *handlersStubRepo) AddMember(context.Context, string, string, string) error {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) RemoveMember(context.Context, string, string) error {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) ListMembers(context.Context, string, int, int) ([]models.Membership, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) CatalogDefinitions() []models.CatalogDefinition { return s.catalogDefs }
+func (s *handlersStubRepo) GetCatalogDefinition(slug string) (models.CatalogDefinition, bool) {
+	for _, d := range s.catalogDefs {
+		if d.Slug == slug {
+			return d, true
+		}
+	}
+	return models.CatalogDefinition{}, false
+}
+func (s *handlersStubRepo) ListCatalogItems(context.Context, string, int, int) ([]models.CatalogItem, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) CreateCatalogItem(ctx context.Context, slug, code, label string, weight *int) (*models.CatalogItem, error) {
+	if s.catalogErr != nil {
+		return nil, s.catalogErr
+	}
+	s.catalogItem = &models.CatalogItem{ID: "item-1", Code: code, Label: label, Weight: weight}
+	return s.catalogItem, nil
+}
+func (s *handlersStubRepo) UpdateCatalogItem(ctx context.Context, slug, id string, code, label *string, weight *int) (*models.CatalogItem, error) {
+	if s.catalogErr != nil {
+		return nil, s.catalogErr
+	}
+	return &models.CatalogItem{ID: id, Code: getOrDefault(code, "updated"), Label: getOrDefault(label, "label"), Weight: weight}, nil
+}
+func (s *handlersStubRepo) DeleteCatalogItem(context.Context, string, string) error {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) MetricsOverview(context.Context, int) (*models.MetricsOverview, error) {
+	if s.metricsErr != nil {
+		return nil, s.metricsErr
+	}
+	return s.overview, nil
+}
+func (s *handlersStubRepo) RecentActivity(context.Context, int) ([]models.ActivityEntry, error) {
+	if s.recentErr != nil {
+		return nil, s.recentErr
+	}
+	return s.recent, nil
+}
+func (s *handlersStubRepo) SearchUsers(context.Context, string, int, int) ([]models.User, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) UpdateUserStatus(context.Context, string, string) error {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) CreateAPIKey(context.Context, string, *time.Time, string, *string) (string, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) SetAPIKeyPermissions(context.Context, string, []string) error {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) RevokeAPIKey(context.Context, string) error { panic("not implemented") }
+func (s *handlersStubRepo) ListAPIKeys(context.Context, bool, int, int) ([]models.APIKey, error) {
+	panic("not implemented")
+}
+func (s *handlersStubRepo) ListAudit(context.Context, *time.Time, *time.Time, *string, int, int) ([]models.AuditLog, error) {
+	panic("not implemented")
+}
+
+func getOrDefault(v *string, def string) string {
+	if v != nil {
+		return *v
+	}
+	return def
+}
+
+func newHandlerWithRepo(repo Repository) *Handlers {
+	return NewHandlers(repo, zap.NewNop())
+}
+
+func TestCreateCatalogItemRequiresWeight(t *testing.T) {
+	repo := &handlersStubRepo{catalogDefs: []models.CatalogDefinition{{Slug: "alert_levels", Label: "Alert Levels", HasWeight: true}}}
+	h := newHandlerWithRepo(repo)
+
+	body := bytes.NewBufferString(`{"code":"HIGH","label":"High"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/superadmin/catalogs/alert_levels", body)
+	rr := httptest.NewRecorder()
+
+	h.CreateCatalogItem(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", rr.Code)
+	}
+}
+
+func TestCreateCatalogItemSuccess(t *testing.T) {
+	repo := &handlersStubRepo{catalogDefs: []models.CatalogDefinition{{Slug: "alert_levels", Label: "Alert Levels", HasWeight: true}}}
+	h := newHandlerWithRepo(repo)
+
+	body := bytes.NewBufferString(`{"code":"LOW","label":"Low","weight":1}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/superadmin/catalogs/alert_levels", body)
+	rr := httptest.NewRecorder()
+
+	h.CreateCatalogItem(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+
+	var item models.CatalogItem
+	if err := json.NewDecoder(rr.Body).Decode(&item); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if item.Code != "LOW" || item.Weight == nil || *item.Weight != 1 {
+		t.Fatalf("unexpected payload: %+v", item)
+	}
+}
+
+func TestMetricsOverviewHandler(t *testing.T) {
+	repo := &handlersStubRepo{
+		overview: &models.MetricsOverview{AverageResponseMS: 12.5, OperationCounts: []models.OperationCount{{Action: "ORG_CREATE", Count: 2}}, ActiveUsers: 3, ActiveOrganizations: 1},
+		recent:   []models.ActivityEntry{{Action: "ORG_CREATE", TS: time.Unix(100, 0)}},
+	}
+	h := newHandlerWithRepo(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/superadmin/metrics/overview?window_minutes=60&recent_limit=5", nil)
+	rr := httptest.NewRecorder()
+
+	h.MetricsOverview(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp models.MetricsOverview
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.RecentActivity) != 1 || resp.OperationCounts[0].Action != "ORG_CREATE" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}

--- a/backend/internal/superadmin/repo_test.go
+++ b/backend/internal/superadmin/repo_test.go
@@ -1,0 +1,269 @@
+package superadmin
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"heartguard-superadmin/internal/models"
+)
+
+type fakeRows struct {
+	data [][]any
+	idx  int
+	err  error
+}
+
+func (r *fakeRows) Close()                                       { r.idx = len(r.data) }
+func (r *fakeRows) Err() error                                   { return r.err }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) Next() bool {
+	if r.idx >= len(r.data) {
+		return false
+	}
+	r.idx++
+	return true
+}
+
+func assignValue(dest reflect.Value, val any) {
+	if dest.Kind() != reflect.Pointer {
+		return
+	}
+	elem := dest.Elem()
+	if !elem.CanSet() {
+		return
+	}
+	if elem.Kind() == reflect.Pointer {
+		if val == nil {
+			elem.Set(reflect.Zero(elem.Type()))
+			return
+		}
+		v := reflect.New(elem.Type().Elem())
+		assignValue(v, val)
+		elem.Set(v)
+		return
+	}
+	if val == nil {
+		elem.Set(reflect.Zero(elem.Type()))
+		return
+	}
+	vv := reflect.ValueOf(val)
+	if !vv.Type().AssignableTo(elem.Type()) {
+		if vv.Type().ConvertibleTo(elem.Type()) {
+			vv = vv.Convert(elem.Type())
+		} else {
+			panic("unsupported type assignment")
+		}
+	}
+	elem.Set(vv)
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.idx == 0 || r.idx > len(r.data) {
+		return errors.New("invalid scan state")
+	}
+	row := r.data[r.idx-1]
+	for i, d := range dest {
+		if d == nil {
+			continue
+		}
+		assignValue(reflect.ValueOf(d), row[i])
+	}
+	return nil
+}
+
+func (r *fakeRows) Values() ([]any, error) { return nil, nil }
+func (r *fakeRows) RawValues() [][]byte    { return nil }
+func (r *fakeRows) Conn() *pgx.Conn        { return nil }
+
+type fakeRow struct {
+	values []any
+	err    error
+}
+
+func (r *fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	for i, d := range dest {
+		if d == nil {
+			continue
+		}
+		if i < len(r.values) {
+			assignValue(reflect.ValueOf(d), r.values[i])
+		}
+	}
+	return nil
+}
+
+type stubPool struct {
+	rows      pgx.Rows
+	queryErr  error
+	execErr   error
+	execTag   pgconn.CommandTag
+	execArgs  []any
+	queryArgs []any
+	rowValues []any
+	rowErr    error
+}
+
+func (s *stubPool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	s.queryArgs = args
+	return s.rows, s.queryErr
+}
+
+func (s *stubPool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	s.queryArgs = args
+	return &fakeRow{values: s.rowValues, err: s.rowErr}
+}
+
+func (s *stubPool) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	s.execArgs = args
+	return s.execTag, s.execErr
+}
+
+func (s *stubPool) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubPool) Ping(ctx context.Context) error { return nil }
+
+func TestListInvitations(t *testing.T) {
+	fixed := time.Date(2024, 5, 15, 10, 0, 0, 0, time.UTC)
+	origNow := nowFn
+	nowFn = func() time.Time { return fixed }
+	t.Cleanup(func() { nowFn = origNow })
+
+	rows := &fakeRows{data: [][]any{
+		{"inv-1", "org-1", "demo@heartguard.com", "role-1", "org_admin", "tok1", fixed.Add(2 * time.Hour), nil, nil, nil, fixed.Add(-time.Hour)},
+		{"inv-2", "org-1", nil, "role-1", "org_admin", "tok2", fixed.Add(-time.Hour), fixed.Add(-30 * time.Minute), nil, nil, fixed.Add(-2 * time.Hour)},
+		{"inv-3", "org-1", "user@example.com", "role-1", "org_admin", "tok3", fixed.Add(2 * time.Hour), nil, fixed.Add(-10 * time.Minute), nil, fixed.Add(-3 * time.Hour)},
+	}}
+	stub := &stubPool{rows: rows}
+	repo := NewRepoWithPool(stub)
+
+	orgID := "org-1"
+	res, err := repo.ListInvitations(context.Background(), &orgID, nil, 25, 0)
+	if err != nil {
+		t.Fatalf("ListInvitations: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(res))
+	}
+	if res[0].Status != "pending" || res[1].Status != "used" || res[2].Status != "revoked" {
+		t.Fatalf("unexpected statuses: %+v", res)
+	}
+}
+
+func TestCancelInvitation(t *testing.T) {
+	stub := &stubPool{rowValues: []any{true}}
+	repo := NewRepoWithPool(stub)
+	if err := repo.CancelInvitation(context.Background(), "inv-ok"); err != nil {
+		t.Fatalf("cancel ok: %v", err)
+	}
+	if len(stub.queryArgs) != 1 || stub.queryArgs[0] != "inv-ok" {
+		t.Fatalf("unexpected query args: %+v", stub.queryArgs)
+	}
+
+	stubFail := &stubPool{rowValues: []any{false}}
+	repoFail := NewRepoWithPool(stubFail)
+	if err := repoFail.CancelInvitation(context.Background(), "inv-missing"); err == nil {
+		t.Fatalf("expected error for missing invitation")
+	}
+}
+
+func TestListMembers(t *testing.T) {
+	joined := time.Date(2024, 5, 15, 9, 0, 0, 0, time.UTC)
+	rows := &fakeRows{data: [][]any{{"org-1", "user-1", "demo@heartguard.com", "Demo User", "role-1", "org_admin", "Org Admin", joined}}}
+	stub := &stubPool{rows: rows}
+	repo := NewRepoWithPool(stub)
+
+	res, err := repo.ListMembers(context.Background(), "org-1", 10, 0)
+	if err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(res))
+	}
+	if res[0].UserID != "user-1" || res[0].OrgRoleCode != "org_admin" {
+		t.Fatalf("unexpected payload: %+v", res[0])
+	}
+}
+
+func TestCatalogDefinitions(t *testing.T) {
+	repo := NewRepoWithPool(&stubPool{})
+	defs := repo.CatalogDefinitions()
+	if len(defs) == 0 {
+		t.Fatalf("expected catalog definitions")
+	}
+	found := false
+	for _, d := range defs {
+		if d.Slug == "alert_levels" && d.HasWeight {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected alert_levels definition in %+v", defs)
+	}
+}
+
+func TestMetricsOverview(t *testing.T) {
+	jsonOps := []byte(`[{"action":"ORG_CREATE","count":2}]`)
+	stub := &stubPool{rowValues: []any{sql.NullFloat64{Float64: 42.5, Valid: true}, jsonOps, 5, 3, 2, 20, 7}}
+	repo := NewRepoWithPool(stub)
+
+	overview, err := repo.MetricsOverview(context.Background(), 60)
+	if err != nil {
+		t.Fatalf("MetricsOverview: %v", err)
+	}
+	if overview.AverageResponseMS != 42.5 {
+		t.Fatalf("unexpected avg response: %v", overview.AverageResponseMS)
+	}
+	if len(overview.OperationCounts) != 1 || overview.OperationCounts[0].Action != "ORG_CREATE" {
+		t.Fatalf("unexpected operation counts: %+v", overview.OperationCounts)
+	}
+	if overview.ActiveUsers != 5 || overview.PendingInvitations != 2 {
+		t.Fatalf("unexpected counters: %+v", overview)
+	}
+}
+
+func TestRecentActivity(t *testing.T) {
+	uid := uuid.New()
+	rows := &fakeRows{data: [][]any{{time.Unix(100, 0), "ACTION", "entity", uid}}}
+	stub := &stubPool{rows: rows}
+	repo := NewRepoWithPool(stub)
+
+	res, err := repo.RecentActivity(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("RecentActivity: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 entry")
+	}
+	if res[0].UserID == nil || *res[0].UserID != uid.String() {
+		t.Fatalf("unexpected user id: %+v", res[0])
+	}
+}
+
+func TestInvitationStatusHelper(t *testing.T) {
+	now := time.Unix(1000, 0)
+	inv := &models.OrgInvitation{ExpiresAt: now.Add(time.Hour)}
+	if s := invitationStatus(inv, now); s != "pending" {
+		t.Fatalf("expected pending, got %s", s)
+	}
+	inv.UsedAt = &now
+	if s := invitationStatus(inv, now); s != "used" {
+		t.Fatalf("expected used, got %s", s)
+	}
+	inv.UsedAt = nil
+	inv.RevokedAt = &now
+	if s := invitationStatus(inv, now); s != "revoked" {
+		t.Fatalf("expected revoked, got %s", s)
+	}
+}

--- a/backend/web/assets/css/styles.css
+++ b/backend/web/assets/css/styles.css
@@ -155,6 +155,41 @@ body {
   border-radius: 0 12px 12px 12px; padding: 14px;
 }
 
+.mt { margin-top: 12px; }
+
+.catalog-layout { display: grid; grid-template-columns: 260px 1fr; gap: 18px; }
+.catalog-grid { display: flex; flex-direction: column; gap: 10px; }
+.catalog-card {
+  display: flex; align-items: center; gap: 12px; padding: 12px;
+  border-radius: 12px; border: 1px solid rgba(255,255,255,.08);
+  background: var(--surface); cursor: pointer; text-align: left;
+  transition: transform .08s ease, border .2s ease;
+}
+.catalog-card .material-symbols-rounded { color: var(--primary); }
+.catalog-card .title { font-weight: 600; }
+.catalog-card .desc { font-size: 12px; color: var(--muted); }
+.catalog-card.active { border-color: var(--primary); box-shadow: var(--ring); transform: translateX(2px); }
+.catalog-detail { background: var(--surface); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 16px; }
+.catalog-header { margin-bottom: 10px; }
+.catalog-header h3 { margin: 0; }
+
+.metrics-wrap { display: flex; flex-direction: column; gap: 20px; }
+.kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; }
+.kpi-card {
+  background: var(--surface); border-radius: 14px; padding: 16px;
+  border: 1px solid rgba(255,255,255,.08); box-shadow: var(--shadow);
+}
+.kpi-card .label { font-size: 13px; color: var(--muted); }
+.kpi-card .value { font-size: 26px; font-weight: 700; margin-top: 6px; }
+.kpi-card .sub { font-size: 12px; color: var(--muted); }
+.metric-section { background: var(--surface); border-radius: 14px; border: 1px solid rgba(255,255,255,.08); padding: 16px; box-shadow: var(--shadow); }
+.metric-section h3 { margin: 0 0 12px; }
+.bar-chart { display: flex; flex-direction: column; gap: 10px; }
+.bar { display: grid; grid-template-columns: 160px 1fr auto; gap: 10px; align-items: center; font-size: 14px; }
+.bar span { color: var(--muted); }
+.bar-track { background: rgba(255,255,255,.08); border-radius: 999px; height: 10px; overflow: hidden; }
+.bar-fill { background: var(--primary); height: 100%; border-radius: 999px; box-shadow: 0 0 8px rgba(58,160,255,.4); }
+
 /* Forms, inputs */
 .form-grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 14px; }
 .form-field { grid-column: span 6; display: flex; flex-direction: column; gap: 6px; }

--- a/db/migrations/20240515_add_revoked_at_org_invitations.sql
+++ b/db/migrations/20240515_add_revoked_at_org_invitations.sql
@@ -1,0 +1,2 @@
+ALTER TABLE org_invitations
+    ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMP;

--- a/docs/backend_endpoints_new.md
+++ b/docs/backend_endpoints_new.md
@@ -1,0 +1,92 @@
+# Nuevos endpoints y extensiones del panel Superadmin
+
+## Invitaciones de organización
+
+### `GET /v1/superadmin/invitations`
+- **Query**: `org_id` (requerido para filtrar por organización), `status` (`pending|used|revoked|expired`), `limit` (<=200), `offset`.
+- **Respuesta 200**: arreglo de invitaciones con `status`, `org_role_code`, `expires_at`, `created_at` y campos de auditoría (`used_at`, `revoked_at`).
+- **Errores**: `400 bad_request` por filtros inválidos, `500 db_error` ante fallos de consulta.
+- **Auditoría**: solo lectura, sin registro.
+- **Seguridad**: requiere sesión superadmin y respeta encabezados `X-RateLimit-*`/`Retry-After`.
+- **Implementación**: utiliza la función `heartguard.fn_invitation_list` para resolver filtros y paginación.
+
+### `POST /v1/superadmin/invitations`
+- **Body**: `{ org_id (uuid), org_role_id (uuid), email?, ttl_hours (1-720) }`.
+- **Validaciones**: `uuid4`, email opcional, TTL dentro del rango permitido.
+- **Respuesta 201**: invitación creada con `status` calculado y token generado en servidor.
+- **Errores**: `422 invalid_fields` si falta `weight` según rol, `500 db_error` en errores de inserción, `409 conflict` en colisiones de token.
+- **Auditoría**: `INVITE_CREATE` con detalles `{ org_id }` y `duration_ms`.
+- **Stored procedure**: `heartguard.fn_invitation_create` encapsula la lógica (token aleatorio, TTL y retorno atomizado).
+
+### `DELETE /v1/superadmin/invitations/{id}`
+- **Acción**: marca invitación como revocada si está vigente.
+- **Respuesta 204**.
+- **Errores**: `404 not_found` cuando ya fue usada/revocada, `500 db_error` en fallos inesperados.
+- **Auditoría**: `INVITE_CANCEL` con `entity_id` y `duration_ms`.
+- **Stored procedure**: `heartguard.fn_invitation_cancel` asegura idempotencia.
+
+### `POST /v1/superadmin/invitations/{token}/consume`
+- **Body**: `{ user_id }` (uuid).
+- **Respuesta 204** al vincular o actualizar la membresía.
+- **Errores**: `400 invalid_token` cuando expiró o fue usada, `500 db_error` para fallos.
+- **Auditoría**: `INVITE_CONSUME` con token y duración.
+
+## Catálogos administrativos
+
+### `GET /v1/superadmin/catalogs`
+- **Acción**: devuelve el catálogo de catálogos (slug, label, descripción, `has_weight`).
+- **Auditoría**: lectura, sin registro.
+- **Stored procedure**: `heartguard.fn_catalog_resolve` centraliza la resolución de slugs.
+
+### `GET /v1/superadmin/catalogs/{slug}`
+- **Query**: `limit`, `offset`.
+- **Respuesta**: filas `{ id, code, label, weight? }` ordenadas por label.
+- **Errores**: `404 not_found` si el slug es inválido, `500 db_error` en fallos.
+- **Stored procedure**: `heartguard.fn_catalog_list` aplica la lógica de paginación y peso opcional.
+
+### `POST /v1/superadmin/catalogs/{slug}`
+- **Body**: `{ code, label, weight? }` (`weight` obligatorio cuando `has_weight=true`).
+- **Respuesta 201** con la fila creada.
+- **Errores**: `422 invalid_fields` si falta `weight`, `409 conflict` en duplicados, `500 db_error` para otros casos.
+- **Auditoría**: `CATALOG_CREATE` con `duration_ms` y `code`.
+- **Stored procedure**: `heartguard.fn_catalog_create` asegura inserciones tipadas por slug.
+
+### `PATCH /v1/superadmin/catalogs/{slug}/{id}`
+- **Body**: campos opcionales `code`, `label`, `weight`.
+- **Respuesta 200** con valores actualizados.
+- **Errores**: `404 not_found` si la fila no existe, `409 conflict` por códigos duplicados, `500 db_error` en fallos.
+- **Auditoría**: `CATALOG_UPDATE` con `entity_id` y `duration_ms`.
+- **Stored procedure**: `heartguard.fn_catalog_update` maneja columnas condicionales.
+
+### `DELETE /v1/superadmin/catalogs/{slug}/{id}`
+- **Acción**: elimina elemento del catálogo.
+- **Respuesta 204**.
+- **Errores**: `404 not_found` si no existe, `500 db_error` para fallos.
+- **Auditoría**: `CATALOG_DELETE` registra la eliminación con duración.
+- **Stored procedure**: `heartguard.fn_catalog_delete` devuelve bool para idempotencia.
+
+## Métricas y actividad reciente
+
+### `GET /v1/superadmin/metrics/overview`
+- **Query**: `window_minutes` (>=5, default 1440), `recent_limit` (1-50).
+- **Respuesta 200**:
+  ```json
+  {
+    "average_response_ms": 42.5,
+    "operation_counts": [{"action": "ORG_CREATE", "count": 3}],
+    "active_users": 5,
+    "active_organizations": 3,
+    "total_users": 20,
+    "total_organizations": 7,
+    "pending_invitations": 2,
+    "recent_activity": [{"ts": "2024-05-15T12:34:00Z", "action": "APIKEY_CREATE", "entity": "api_key", "user_id": "..."}]
+  }
+  ```
+- **Errores**: `500 db_error` ante fallos en agregados.
+- **Auditoría**: sólo lectura.
+- **Stored procedures**: `heartguard.fn_metrics_overview` consolida promedios/conteos usando `audit_logs`; `heartguard.fn_metrics_recent_activity` entrega la ventana de eventos.
+
+## Notas de auditoría y seguridad
+- Todas las mutaciones usan `writeAuditWithDuration`, agregando `duration_ms` a los detalles.
+- `RequireSuperadmin` continúa protegiendo las rutas; el middleware de rate-limit añade `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` y `Retry-After` cuando corresponde.
+- Las funciones almacenadas viven en el esquema `heartguard` y se otorgan a `:dbuser`, permitiendo reutilización desde otras herramientas administrativas.


### PR DESCRIPTION
## Summary
- move invitation endpoints under /v1/superadmin/invitations and introduce catalog and metrics APIs backed by new stored procedures
- extend repository, handlers, and tests to cover invitation filters, catalog CRUD, and metrics aggregation with duration auditing
- wire the web panel to the new invitations, catalog management, and metrics sections and document the endpoints

## Testing
- `GO111MODULE=on go test ./...` *(fails: missing go.sum entries in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ded3316694832fbd7a7be4fcec269d