### PR TITLE
Add push device management

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -81,6 +81,13 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 			dr.Post("/{id}/delete", uiHandlers.DevicesDelete)
 		})
 
+		s.Route("/push-devices", func(pr chi.Router) {
+			pr.Get("/", uiHandlers.PushDevicesIndex)
+			pr.Post("/", uiHandlers.PushDevicesCreate)
+			pr.Post("/{id}/update", uiHandlers.PushDevicesUpdate)
+			pr.Post("/{id}/delete", uiHandlers.PushDevicesDelete)
+		})
+
 		s.Route("/signal-streams", func(sr chi.Router) {
 			sr.Get("/", uiHandlers.SignalStreamsIndex)
 			sr.Post("/", uiHandlers.SignalStreamsCreate)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -138,6 +138,18 @@ type Device struct {
 	Active           bool      `json:"active"`
 }
 
+type PushDevice struct {
+	ID            string    `json:"id"`
+	UserID        string    `json:"user_id"`
+	UserName      string    `json:"user_name"`
+	UserEmail     string    `json:"user_email"`
+	PlatformCode  string    `json:"platform_code"`
+	PlatformLabel string    `json:"platform_label"`
+	PushToken     string    `json:"push_token"`
+	LastSeenAt    time.Time `json:"last_seen_at"`
+	Active        bool      `json:"active"`
+}
+
 type DeviceInput struct {
 	OrgID          *string `json:"org_id,omitempty"`
 	Serial         string  `json:"serial"`
@@ -146,6 +158,14 @@ type DeviceInput struct {
 	DeviceTypeCode string  `json:"device_type_code"`
 	OwnerPatientID *string `json:"owner_patient_id,omitempty"`
 	Active         *bool   `json:"active,omitempty"`
+}
+
+type PushDeviceInput struct {
+	UserID       string     `json:"user_id"`
+	PlatformCode string     `json:"platform_code"`
+	PushToken    string     `json:"push_token"`
+	LastSeenAt   *time.Time `json:"last_seen_at,omitempty"`
+	Active       *bool      `json:"active,omitempty"`
 }
 
 type DeviceType struct {

--- a/backend/internal/superadmin/handlers.go
+++ b/backend/internal/superadmin/handlers.go
@@ -65,6 +65,11 @@ type Repository interface {
 	UpdatePatient(ctx context.Context, id string, input models.PatientInput) (*models.Patient, error)
 	DeletePatient(ctx context.Context, id string) error
 
+	ListPushDevices(ctx context.Context, userID, platformCode *string, limit, offset int) ([]models.PushDevice, error)
+	CreatePushDevice(ctx context.Context, input models.PushDeviceInput) (*models.PushDevice, error)
+	UpdatePushDevice(ctx context.Context, id string, input models.PushDeviceInput) (*models.PushDevice, error)
+	DeletePushDevice(ctx context.Context, id string) error
+
 	ListDevices(ctx context.Context, limit, offset int) ([]models.Device, error)
 	CreateDevice(ctx context.Context, input models.DeviceInput) (*models.Device, error)
 	UpdateDevice(ctx context.Context, id string, input models.DeviceInput) (*models.Device, error)
@@ -244,6 +249,9 @@ var operationLabels = map[string]string{
 	"APIKEY_CREATE":      "Creación de API Key",
 	"APIKEY_SET_PERMS":   "Configuración de permisos de API Key",
 	"APIKEY_REVOKE":      "Revocación de API Key",
+	"PUSH_DEVICE_CREATE": "Registro de dispositivo push",
+	"PUSH_DEVICE_UPDATE": "Actualización de dispositivo push",
+	"PUSH_DEVICE_DELETE": "Eliminación de dispositivo push",
 	"CATALOG_CREATE":     "Alta en catálogo",
 	"CATALOG_UPDATE":     "Actualización de catálogo",
 	"CATALOG_DELETE":     "Eliminación de catálogo",
@@ -1752,6 +1760,141 @@ func (h *Handlers) UpdateSystemSettings(w http.ResponseWriter, r *http.Request) 
 	var entityID string = "singleton"
 	h.writeAudit(ctx, r, "SYSTEM_SETTINGS_UPDATE", entity, &entityID, map[string]any{"brand_name": updated.BrandName, "maintenance_mode": updated.MaintenanceMode})
 	writeJSON(w, 200, updated)
+}
+
+// Push devices
+
+type pushDeviceReq struct {
+	UserID       string     `json:"user_id" validate:"required,uuid4"`
+	PlatformCode string     `json:"platform_code" validate:"required"`
+	PushToken    string     `json:"push_token" validate:"required"`
+	LastSeenAt   *time.Time `json:"last_seen_at"`
+	Active       *bool      `json:"active"`
+}
+
+func (h *Handlers) CreatePushDevice(w http.ResponseWriter, r *http.Request) {
+	var req pushDeviceReq
+	fields, err := decodeAndValidate(r, &req, h.validate)
+	if err != nil {
+		writeProblem(w, 400, "bad_request", "invalid payload", fields)
+		return
+	}
+	req.PlatformCode = strings.TrimSpace(req.PlatformCode)
+	req.PushToken = strings.TrimSpace(req.PushToken)
+	req.UserID = strings.TrimSpace(req.UserID)
+	if req.PlatformCode == "" {
+		writeProblem(w, 422, "validation_error", "platform is required", map[string]string{"platform_code": "required"})
+		return
+	}
+	if req.PushToken == "" {
+		writeProblem(w, 422, "validation_error", "push token is required", map[string]string{"push_token": "required"})
+		return
+	}
+	input := models.PushDeviceInput{
+		UserID:       req.UserID,
+		PlatformCode: req.PlatformCode,
+		PushToken:    req.PushToken,
+		LastSeenAt:   req.LastSeenAt,
+		Active:       req.Active,
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	device, err := h.repo.CreatePushDevice(ctx, input)
+	if err != nil {
+		if errors.Is(err, errInvalidPlatform) {
+			writeProblem(w, 400, "invalid_platform", "platform not found", map[string]string{"platform_code": "invalid"})
+			return
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeProblem(w, 400, "invalid_platform", "platform not found", map[string]string{"platform_code": "invalid"})
+			return
+		}
+		writeProblem(w, 400, "db_error", err.Error(), nil)
+		return
+	}
+	h.writeAudit(ctx, r, "PUSH_DEVICE_CREATE", "push_device", &device.ID, map[string]any{"user_id": device.UserID, "platform": device.PlatformCode})
+	writeJSON(w, 201, device)
+}
+
+func (h *Handlers) UpdatePushDevice(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req pushDeviceReq
+	fields, err := decodeAndValidate(r, &req, h.validate)
+	if err != nil {
+		writeProblem(w, 400, "bad_request", "invalid payload", fields)
+		return
+	}
+	req.PlatformCode = strings.TrimSpace(req.PlatformCode)
+	req.PushToken = strings.TrimSpace(req.PushToken)
+	req.UserID = strings.TrimSpace(req.UserID)
+	if req.PlatformCode == "" {
+		writeProblem(w, 422, "validation_error", "platform is required", map[string]string{"platform_code": "required"})
+		return
+	}
+	if req.PushToken == "" {
+		writeProblem(w, 422, "validation_error", "push token is required", map[string]string{"push_token": "required"})
+		return
+	}
+	input := models.PushDeviceInput{
+		UserID:       req.UserID,
+		PlatformCode: req.PlatformCode,
+		PushToken:    req.PushToken,
+		LastSeenAt:   req.LastSeenAt,
+		Active:       req.Active,
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	device, err := h.repo.UpdatePushDevice(ctx, id, input)
+	if err != nil {
+		if errors.Is(err, errInvalidPlatform) {
+			writeProblem(w, 400, "invalid_platform", "platform not found", map[string]string{"platform_code": "invalid"})
+			return
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeProblem(w, 404, "not_found", "push device not found", nil)
+			return
+		}
+		writeProblem(w, 400, "db_error", err.Error(), nil)
+		return
+	}
+	h.writeAudit(ctx, r, "PUSH_DEVICE_UPDATE", "push_device", &device.ID, map[string]any{"user_id": device.UserID, "platform": device.PlatformCode})
+	writeJSON(w, 200, device)
+}
+
+func (h *Handlers) DeletePushDevice(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	if err := h.repo.DeletePushDevice(ctx, id); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeProblem(w, 404, "not_found", "push device not found", nil)
+			return
+		}
+		writeProblem(w, 400, "db_error", err.Error(), nil)
+		return
+	}
+	h.writeAudit(ctx, r, "PUSH_DEVICE_DELETE", "push_device", &id, nil)
+	w.WriteHeader(204)
+}
+
+func (h *Handlers) ListPushDevices(w http.ResponseWriter, r *http.Request) {
+	limit, offset := parseLimitOffset(r)
+	q := r.URL.Query()
+	var userID, platform *string
+	if v := strings.TrimSpace(q.Get("user_id")); v != "" {
+		userID = &v
+	}
+	if v := strings.TrimSpace(q.Get("platform")); v != "" {
+		platform = &v
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	list, err := h.repo.ListPushDevices(ctx, userID, platform, limit, offset)
+	if err != nil {
+		writeProblem(w, 500, "db_error", err.Error(), nil)
+		return
+	}
+	writeJSON(w, 200, list)
 }
 
 // API Keys

--- a/backend/internal/superadmin/repo_push_devices_test.go
+++ b/backend/internal/superadmin/repo_push_devices_test.go
@@ -1,0 +1,208 @@
+package superadmin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"heartguard-superadmin/internal/models"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type stubPool struct {
+	queryRow func(ctx context.Context, sql string, args ...any) pgx.Row
+	query    func(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+func (s *stubPool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	if s.query != nil {
+		return s.query(ctx, sql, args...)
+	}
+	return nil, errors.New("unexpected query call")
+}
+
+func (s *stubPool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	if s.queryRow != nil {
+		return s.queryRow(ctx, sql, args...)
+	}
+	return mockRow{err: errors.New("unexpected queryrow call")}
+}
+
+func (s *stubPool) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, errors.New("unexpected exec call")
+}
+
+func (s *stubPool) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, errors.New("unexpected begin call")
+}
+
+func (s *stubPool) Ping(ctx context.Context) error { return nil }
+
+type mockRow struct {
+	values []any
+	err    error
+}
+
+func (r mockRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if len(dest) != len(r.values) {
+		return fmt.Errorf("unexpected dest count: %d", len(dest))
+	}
+	for i := range dest {
+		switch d := dest[i].(type) {
+		case *string:
+			if v, ok := r.values[i].(string); ok {
+				*d = v
+				continue
+			}
+			return fmt.Errorf("expected string at %d", i)
+		case *time.Time:
+			if v, ok := r.values[i].(time.Time); ok {
+				*d = v
+				continue
+			}
+			return fmt.Errorf("expected time at %d", i)
+		case *bool:
+			if v, ok := r.values[i].(bool); ok {
+				*d = v
+				continue
+			}
+			return fmt.Errorf("expected bool at %d", i)
+		default:
+			return fmt.Errorf("unsupported dest type %T", dest[i])
+		}
+	}
+	return nil
+}
+
+type mockRows struct {
+	data [][]any
+	idx  int
+	err  error
+}
+
+func (m *mockRows) Next() bool {
+	if m.idx < len(m.data) {
+		m.idx++
+		return true
+	}
+	return false
+}
+
+func (m *mockRows) Scan(dest ...any) error {
+	if m.idx == 0 || m.idx > len(m.data) {
+		return errors.New("no row")
+	}
+	row := mockRow{values: m.data[m.idx-1]}
+	return row.Scan(dest...)
+}
+
+func (m *mockRows) Err() error { return m.err }
+
+func (m *mockRows) Close() {}
+
+func (m *mockRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+
+func (m *mockRows) Values() ([]any, error) { return nil, errors.New("not implemented") }
+
+func (m *mockRows) RawValues() [][]byte { return nil }
+
+func (m *mockRows) CommandTag() pgconn.CommandTag { return pgconn.CommandTag{} }
+
+func (m *mockRows) Conn() *pgx.Conn { return nil }
+
+func TestRepoCreatePushDevice(t *testing.T) {
+	active := true
+	now := time.Now()
+	pool := &stubPool{}
+	pool.queryRow = func(ctx context.Context, sql string, args ...any) pgx.Row {
+		return mockRow{values: []any{"pd-1", "user-1", "Alice", "alice@example.com", "ios", "iOS", "tok-123", now, true}}
+	}
+	repo := NewRepoWithPool(pool, nil)
+	input := models.PushDeviceInput{UserID: "user-1", PlatformCode: "ios", PushToken: "tok-123", LastSeenAt: &now, Active: &active}
+	device, err := repo.CreatePushDevice(context.Background(), input)
+	if err != nil {
+		t.Fatalf("CreatePushDevice: %v", err)
+	}
+	if device.PlatformLabel != "iOS" || device.UserEmail != "alice@example.com" {
+		t.Fatalf("unexpected device: %#v", device)
+	}
+}
+
+func TestRepoCreatePushDeviceInvalidPlatform(t *testing.T) {
+	active := true
+	now := time.Now()
+	calls := 0
+	pool := &stubPool{}
+	pool.queryRow = func(ctx context.Context, sql string, args ...any) pgx.Row {
+		calls++
+		if calls == 1 {
+			return mockRow{err: pgx.ErrNoRows}
+		}
+		return mockRow{values: []any{false}}
+	}
+	repo := NewRepoWithPool(pool, nil)
+	input := models.PushDeviceInput{UserID: "user-1", PlatformCode: "bad", PushToken: "tok-123", LastSeenAt: &now, Active: &active}
+	if _, err := repo.CreatePushDevice(context.Background(), input); !errors.Is(err, errInvalidPlatform) {
+		t.Fatalf("expected errInvalidPlatform, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 QueryRow calls, got %d", calls)
+	}
+}
+
+func TestRepoUpdatePushDeviceInvalidPlatform(t *testing.T) {
+	active := false
+	now := time.Now()
+	calls := 0
+	pool := &stubPool{}
+	pool.queryRow = func(ctx context.Context, sql string, args ...any) pgx.Row {
+		calls++
+		if calls == 1 {
+			return mockRow{err: pgx.ErrNoRows}
+		}
+		return mockRow{values: []any{false}}
+	}
+	repo := NewRepoWithPool(pool, nil)
+	input := models.PushDeviceInput{UserID: "user-1", PlatformCode: "bad", PushToken: "tok-456", LastSeenAt: &now, Active: &active}
+	if _, err := repo.UpdatePushDevice(context.Background(), "pd-1", input); !errors.Is(err, errInvalidPlatform) {
+		t.Fatalf("expected errInvalidPlatform, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 QueryRow calls, got %d", calls)
+	}
+}
+
+func TestRepoListPushDevices(t *testing.T) {
+	now := time.Now()
+	pool := &stubPool{}
+	pool.query = func(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+		expected := []any{"user-1", "ios", 10, 0}
+		if len(args) != len(expected) {
+			t.Fatalf("unexpected args len %d", len(args))
+		}
+		for i := range expected {
+			if args[i] != expected[i] {
+				t.Fatalf("unexpected arg %d: %v", i, args[i])
+			}
+		}
+		rows := &mockRows{data: [][]any{{"pd-1", "user-1", "Alice", "alice@example.com", "ios", "iOS", "tok-123", now, true}}}
+		return rows, nil
+	}
+	repo := NewRepoWithPool(pool, nil)
+	userID := "user-1"
+	platform := "ios"
+	devices, err := repo.ListPushDevices(context.Background(), &userID, &platform, 10, 0)
+	if err != nil {
+		t.Fatalf("ListPushDevices: %v", err)
+	}
+	if len(devices) != 1 || devices[0].ID != "pd-1" {
+		t.Fatalf("unexpected devices: %#v", devices)
+	}
+}

--- a/backend/templates/layout.html
+++ b/backend/templates/layout.html
@@ -33,10 +33,11 @@
 					<li><a href="/superadmin/users">Usuarios</a></li>
 					<li><a href="/superadmin/roles">Roles</a></li>
 					<li><a href="/superadmin/content">Contenido</a></li>
-					<li><a href="/superadmin/content-block-types">Tipos de bloque</a></li>
-					<li><a href="/superadmin/patients">Pacientes</a></li>
-					<li><a href="/superadmin/devices">Dispositivos</a></li>
-					<li><a href="/superadmin/signal-streams">Streams de señal</a></li>
+                                        <li><a href="/superadmin/content-block-types">Tipos de bloque</a></li>
+                                        <li><a href="/superadmin/patients">Pacientes</a></li>
+                                        <li><a href="/superadmin/devices">Dispositivos</a></li>
+                                        <li><a href="/superadmin/push-devices">Dispositivos push</a></li>
+                                        <li><a href="/superadmin/signal-streams">Streams de señal</a></li>
 					<li><a href="/superadmin/models">Modelos ML</a></li>
 					<li><a href="/superadmin/event-types">Eventos</a></li>
 					<li><a href="/superadmin/inferences">Inferencias</a></li>

--- a/backend/templates/superadmin/push_devices.html
+++ b/backend/templates/superadmin/push_devices.html
@@ -1,0 +1,149 @@
+{{define "superadmin/push_devices.html"}} {{template "layout" .}} {{end}} {{define "superadmin/push_devices.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Dispositivos push</h1>
+        </div>
+        <div class="hg-card">
+                <h3>Registrar dispositivo</h3>
+                <form method="post" action="/superadmin/push-devices" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label for="push-user">Usuario</label>
+                                <select id="push-user" name="user_id" required>
+                                        <option value="">Selecciona usuario</option>
+                                        {{range .Data.Users}}
+                                        <option value="{{.ID}}">{{.Name}} · {{.Email}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="push-platform">Plataforma</label>
+                                <select id="push-platform" name="platform_code" required>
+                                        <option value="">Selecciona plataforma</option>
+                                        {{range .Data.Platforms}}
+                                        <option value="{{.Code}}">{{.Label}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field hg-form-field-span2">
+                                <label for="push-token">Token</label>
+                                <textarea id="push-token" name="push_token" rows="2" required placeholder="Token FCM o APNS"></textarea>
+                        </div>
+                        <div class="hg-form-field">
+                                <label class="hg-checkbox">
+                                        <input type="checkbox" name="active" value="1" checked />
+                                        <span>Activo</span>
+                                </label>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Registrar</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Filtros</h3>
+                <form method="get" action="/superadmin/push-devices" class="hg-form-grid">
+                        <div class="hg-form-field">
+                                <label for="filter-user">Usuario</label>
+                                <select id="filter-user" name="user_id">
+                                        <option value="">Todos</option>
+                                        {{range .Data.Users}}
+                                        <option value="{{.ID}}" {{if eq $.Data.FilterUserID .ID}}selected{{end}}>{{.Name}} · {{.Email}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="filter-platform">Plataforma</label>
+                                <select id="filter-platform" name="platform">
+                                        <option value="">Todas</option>
+                                        {{range .Data.Platforms}}
+                                        <option value="{{.Code}}" {{if eq $.Data.FilterPlatform .Code}}selected{{end}}>{{.Label}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Aplicar filtros</button>
+                                <a class="hg-link" href="/superadmin/push-devices">Limpiar</a>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Dispositivos registrados</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Usuario</th>
+                                        <th>Plataforma</th>
+                                        <th>Token</th>
+                                        <th>Última conexión</th>
+                                        <th>Activo</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Items}}
+                                {{$device := .}}
+                                <tr>
+                                        <td>{{$device.UserName}}<br /><small>{{$device.UserEmail}}</small></td>
+                                        <td>{{$device.PlatformLabel}}</td>
+                                        <td><span class="hg-mono">{{$device.PushToken}}</span></td>
+                                        <td>{{formatTime $device.LastSeenAt}}</td>
+                                        <td>{{if $device.Active}}Sí{{else}}No{{end}}</td>
+                                        <td class="hg-flex">
+                                                <details>
+                                                        <summary>Editar</summary>
+                                                        <form method="post" action="/superadmin/push-devices/{{$device.ID}}/update" class="hg-form-grid">
+                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                <div class="hg-form-field">
+                                                                        <label>Usuario</label>
+                                                                        <select name="user_id" required>
+                                                                                {{range $.Data.Users}}
+                                                                                <option value="{{.ID}}" {{if eq .ID $device.UserID}}selected{{end}}>{{.Name}} · {{.Email}}</option>
+                                                                                {{end}}
+                                                                        </select>
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Plataforma</label>
+                                                                        <select name="platform_code" required>
+                                                                                {{range $.Data.Platforms}}
+                                                                                <option value="{{.Code}}" {{if eq .Code $device.PlatformCode}}selected{{end}}>{{.Label}}</option>
+                                                                                {{end}}
+                                                                        </select>
+                                                                </div>
+                                                                <div class="hg-form-field hg-form-field-span2">
+                                                                        <label>Token</label>
+                                                                        <textarea name="push_token" rows="2" required>{{$device.PushToken}}</textarea>
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label class="hg-checkbox">
+                                                                                <input type="checkbox" name="active" value="1" {{if $device.Active}}checked{{end}} />
+                                                                                <span>Activo</span>
+                                                                        </label>
+                                                                </div>
+                                                                <div class="hg-form-actions">
+                                                                        <button type="submit">Guardar</button>
+                                                                </div>
+                                                        </form>
+                                                </details>
+                                                <form method="post" action="/superadmin/push-devices/{{$device.ID}}/delete" data-hg-confirm="¿Eliminar dispositivo?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="6" class="hg-empty-cell">Sin registros.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+{{end}}


### PR DESCRIPTION
## Summary
- add push notification device models and repository CRUD with validation and filtering support
- expose push device REST and UI handlers, navigation, and rendering template for management flows
- cover repository behaviour with unit tests for platform validation and listing logic

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e9e3b03310832fa95cdc1f0aa1b848