### PR TITLE
Add alert event tracking UI and repository support

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -113,6 +113,10 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 			ar.Get("/", uiHandlers.AlertsIndex)
 			ar.Post("/", uiHandlers.AlertsCreate)
 			ar.Post("/{id}/update", uiHandlers.AlertsUpdate)
+			ar.Post("/{id}/assignments", uiHandlers.AlertAssignmentsCreate)
+			ar.Post("/{id}/acks", uiHandlers.AlertAcksCreate)
+			ar.Post("/{id}/resolutions", uiHandlers.AlertResolutionsCreate)
+			ar.Post("/{id}/deliveries", uiHandlers.AlertDeliveriesCreate)
 			ar.Post("/{id}/delete", uiHandlers.AlertsDelete)
 		})
 

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -279,6 +279,48 @@ type AlertStatus struct {
 	StepOrder   int    `json:"step_order"`
 }
 
+type AlertAssignment struct {
+	AlertID          string    `json:"alert_id"`
+	AssigneeUserID   string    `json:"assignee_user_id"`
+	AssigneeName     *string   `json:"assignee_name,omitempty"`
+	AssignedByUserID *string   `json:"assigned_by_user_id,omitempty"`
+	AssignedByName   *string   `json:"assigned_by_name,omitempty"`
+	AssignedAt       time.Time `json:"assigned_at"`
+}
+
+type AlertAck struct {
+	ID          string    `json:"id"`
+	AlertID     string    `json:"alert_id"`
+	AckByUserID *string   `json:"ack_by_user_id,omitempty"`
+	AckByName   *string   `json:"ack_by_name,omitempty"`
+	AckAt       time.Time `json:"ack_at"`
+	Note        *string   `json:"note,omitempty"`
+}
+
+type AlertResolution struct {
+	ID               string    `json:"id"`
+	AlertID          string    `json:"alert_id"`
+	ResolvedByUserID *string   `json:"resolved_by_user_id,omitempty"`
+	ResolvedByName   *string   `json:"resolved_by_name,omitempty"`
+	ResolvedAt       time.Time `json:"resolved_at"`
+	Outcome          *string   `json:"outcome,omitempty"`
+	Note             *string   `json:"note,omitempty"`
+}
+
+type AlertDelivery struct {
+	ID                  string    `json:"id"`
+	AlertID             string    `json:"alert_id"`
+	ChannelID           string    `json:"channel_id"`
+	ChannelCode         string    `json:"channel_code"`
+	ChannelLabel        string    `json:"channel_label"`
+	Target              string    `json:"target"`
+	SentAt              time.Time `json:"sent_at"`
+	DeliveryStatusID    string    `json:"delivery_status_id"`
+	DeliveryStatusCode  string    `json:"delivery_status_code"`
+	DeliveryStatusLabel string    `json:"delivery_status_label"`
+	ResponsePayload     *string   `json:"response_payload,omitempty"`
+}
+
 type ContentRoleActivity struct {
 	Role  string `json:"role"`
 	Count int    `json:"count"`

--- a/backend/internal/superadmin/repo.go
+++ b/backend/internal/superadmin/repo.go
@@ -1307,6 +1307,362 @@ func (r *Repo) ListAlertStatuses(ctx context.Context) ([]models.AlertStatus, err
 	return out, rows.Err()
 }
 
+func (r *Repo) ListAlertAssignments(ctx context.Context, alertID string) ([]models.AlertAssignment, error) {
+	rows, err := r.pool.Query(ctx, `
+SELECT aa.alert_id::text,
+       aa.assignee_user_id::text,
+       assignee.name,
+       aa.assigned_by_user_id::text,
+       assigned_by.name,
+       aa.assigned_at
+FROM heartguard.alert_assignment aa
+LEFT JOIN heartguard.users assignee ON assignee.id = aa.assignee_user_id
+LEFT JOIN heartguard.users assigned_by ON assigned_by.id = aa.assigned_by_user_id
+WHERE aa.alert_id = $1
+ORDER BY aa.assigned_at DESC
+`, alertID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.AlertAssignment
+	for rows.Next() {
+		var (
+			assignment     models.AlertAssignment
+			assigneeName   sql.NullString
+			assignedByID   sql.NullString
+			assignedByName sql.NullString
+		)
+		if err := rows.Scan(&assignment.AlertID, &assignment.AssigneeUserID, &assigneeName, &assignedByID, &assignedByName, &assignment.AssignedAt); err != nil {
+			return nil, err
+		}
+		if assigneeName.Valid {
+			name := assigneeName.String
+			assignment.AssigneeName = &name
+		}
+		if assignedByID.Valid {
+			id := assignedByID.String
+			assignment.AssignedByUserID = &id
+		}
+		if assignedByName.Valid {
+			name := assignedByName.String
+			assignment.AssignedByName = &name
+		}
+		out = append(out, assignment)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repo) CreateAlertAssignment(ctx context.Context, alertID, assigneeUserID string, assignedBy *string) (*models.AlertAssignment, error) {
+	var (
+		assignment     models.AlertAssignment
+		assigneeName   sql.NullString
+		assignedByID   sql.NullString
+		assignedByName sql.NullString
+	)
+	err := r.pool.QueryRow(ctx, `
+INSERT INTO heartguard.alert_assignment (alert_id, assignee_user_id, assigned_by_user_id)
+VALUES ($1, $2, $3)
+RETURNING alert_id::text,
+          assignee_user_id::text,
+          (SELECT name FROM heartguard.users WHERE id = assignee_user_id),
+          assigned_by_user_id::text,
+          (SELECT name FROM heartguard.users WHERE id = assigned_by_user_id),
+          assigned_at
+`, alertID, assigneeUserID, stringParam(assignedBy, true)).
+		Scan(&assignment.AlertID, &assignment.AssigneeUserID, &assigneeName, &assignedByID, &assignedByName, &assignment.AssignedAt)
+	if err != nil {
+		return nil, err
+	}
+	if assigneeName.Valid {
+		name := assigneeName.String
+		assignment.AssigneeName = &name
+	}
+	if assignedByID.Valid {
+		id := assignedByID.String
+		assignment.AssignedByUserID = &id
+	}
+	if assignedByName.Valid {
+		name := assignedByName.String
+		assignment.AssignedByName = &name
+	}
+	return &assignment, nil
+}
+
+func (r *Repo) ListAlertAcks(ctx context.Context, alertID string) ([]models.AlertAck, error) {
+	rows, err := r.pool.Query(ctx, `
+SELECT aa.id::text,
+       aa.alert_id::text,
+       aa.ack_by_user_id::text,
+       ack_user.name,
+       aa.ack_at,
+       aa.note
+FROM heartguard.alert_ack aa
+LEFT JOIN heartguard.users ack_user ON ack_user.id = aa.ack_by_user_id
+WHERE aa.alert_id = $1
+ORDER BY aa.ack_at DESC
+`, alertID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.AlertAck
+	for rows.Next() {
+		var (
+			ack        models.AlertAck
+			ackByID    sql.NullString
+			ackByName  sql.NullString
+			noteString sql.NullString
+		)
+		if err := rows.Scan(&ack.ID, &ack.AlertID, &ackByID, &ackByName, &ack.AckAt, &noteString); err != nil {
+			return nil, err
+		}
+		if ackByID.Valid {
+			id := ackByID.String
+			ack.AckByUserID = &id
+		}
+		if ackByName.Valid {
+			name := ackByName.String
+			ack.AckByName = &name
+		}
+		if noteString.Valid {
+			note := noteString.String
+			ack.Note = &note
+		}
+		out = append(out, ack)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repo) CreateAlertAck(ctx context.Context, alertID string, ackBy *string, note *string) (*models.AlertAck, error) {
+	var (
+		ack        models.AlertAck
+		ackByID    sql.NullString
+		ackByName  sql.NullString
+		noteString sql.NullString
+	)
+	err := r.pool.QueryRow(ctx, `
+INSERT INTO heartguard.alert_ack (alert_id, ack_by_user_id, note)
+VALUES ($1, $2, $3)
+RETURNING id::text,
+          alert_id::text,
+          ack_by_user_id::text,
+          (SELECT name FROM heartguard.users WHERE id = ack_by_user_id),
+          ack_at,
+          note
+`, alertID, stringParam(ackBy, true), stringParam(note, true)).
+		Scan(&ack.ID, &ack.AlertID, &ackByID, &ackByName, &ack.AckAt, &noteString)
+	if err != nil {
+		return nil, err
+	}
+	if ackByID.Valid {
+		id := ackByID.String
+		ack.AckByUserID = &id
+	}
+	if ackByName.Valid {
+		name := ackByName.String
+		ack.AckByName = &name
+	}
+	if noteString.Valid {
+		noteVal := noteString.String
+		ack.Note = &noteVal
+	}
+	return &ack, nil
+}
+
+func (r *Repo) ListAlertResolutions(ctx context.Context, alertID string) ([]models.AlertResolution, error) {
+	rows, err := r.pool.Query(ctx, `
+SELECT ar.id::text,
+       ar.alert_id::text,
+       ar.resolved_by_user_id::text,
+       resolver.name,
+       ar.resolved_at,
+       ar.outcome,
+       ar.note
+FROM heartguard.alert_resolution ar
+LEFT JOIN heartguard.users resolver ON resolver.id = ar.resolved_by_user_id
+WHERE ar.alert_id = $1
+ORDER BY ar.resolved_at DESC
+`, alertID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.AlertResolution
+	for rows.Next() {
+		var (
+			res          models.AlertResolution
+			resolvedID   sql.NullString
+			resolvedName sql.NullString
+			outcomeStr   sql.NullString
+			noteStr      sql.NullString
+		)
+		if err := rows.Scan(&res.ID, &res.AlertID, &resolvedID, &resolvedName, &res.ResolvedAt, &outcomeStr, &noteStr); err != nil {
+			return nil, err
+		}
+		if resolvedID.Valid {
+			id := resolvedID.String
+			res.ResolvedByUserID = &id
+		}
+		if resolvedName.Valid {
+			name := resolvedName.String
+			res.ResolvedByName = &name
+		}
+		if outcomeStr.Valid {
+			outcome := outcomeStr.String
+			res.Outcome = &outcome
+		}
+		if noteStr.Valid {
+			note := noteStr.String
+			res.Note = &note
+		}
+		out = append(out, res)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repo) CreateAlertResolution(ctx context.Context, alertID string, resolvedBy *string, outcome, note *string) (*models.AlertResolution, error) {
+	var (
+		res          models.AlertResolution
+		resolvedID   sql.NullString
+		resolvedName sql.NullString
+		outcomeStr   sql.NullString
+		noteStr      sql.NullString
+	)
+	err := r.pool.QueryRow(ctx, `
+INSERT INTO heartguard.alert_resolution (alert_id, resolved_by_user_id, outcome, note)
+VALUES ($1, $2, $3, $4)
+RETURNING id::text,
+          alert_id::text,
+          resolved_by_user_id::text,
+          (SELECT name FROM heartguard.users WHERE id = resolved_by_user_id),
+          resolved_at,
+          outcome,
+          note
+`, alertID, stringParam(resolvedBy, true), stringParam(outcome, true), stringParam(note, true)).
+		Scan(&res.ID, &res.AlertID, &resolvedID, &resolvedName, &res.ResolvedAt, &outcomeStr, &noteStr)
+	if err != nil {
+		return nil, err
+	}
+	if resolvedID.Valid {
+		id := resolvedID.String
+		res.ResolvedByUserID = &id
+	}
+	if resolvedName.Valid {
+		name := resolvedName.String
+		res.ResolvedByName = &name
+	}
+	if outcomeStr.Valid {
+		outcomeVal := outcomeStr.String
+		res.Outcome = &outcomeVal
+	}
+	if noteStr.Valid {
+		noteVal := noteStr.String
+		res.Note = &noteVal
+	}
+	return &res, nil
+}
+
+func (r *Repo) ListAlertDeliveries(ctx context.Context, alertID string) ([]models.AlertDelivery, error) {
+	rows, err := r.pool.Query(ctx, `
+SELECT ad.id::text,
+       ad.alert_id::text,
+       ad.channel_id::text,
+       ac.code,
+       ac.label,
+       ad.target,
+       ad.sent_at,
+       ad.delivery_status_id::text,
+       ds.code,
+       ds.label,
+       ad.response_payload::text
+FROM heartguard.alert_delivery ad
+JOIN heartguard.alert_channels ac ON ac.id = ad.channel_id
+JOIN heartguard.delivery_statuses ds ON ds.id = ad.delivery_status_id
+WHERE ad.alert_id = $1
+ORDER BY ad.sent_at DESC
+`, alertID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.AlertDelivery
+	for rows.Next() {
+		var (
+			delivery        models.AlertDelivery
+			responsePayload sql.NullString
+		)
+		if err := rows.Scan(
+			&delivery.ID,
+			&delivery.AlertID,
+			&delivery.ChannelID,
+			&delivery.ChannelCode,
+			&delivery.ChannelLabel,
+			&delivery.Target,
+			&delivery.SentAt,
+			&delivery.DeliveryStatusID,
+			&delivery.DeliveryStatusCode,
+			&delivery.DeliveryStatusLabel,
+			&responsePayload,
+		); err != nil {
+			return nil, err
+		}
+		if responsePayload.Valid {
+			payload := responsePayload.String
+			delivery.ResponsePayload = &payload
+		}
+		out = append(out, delivery)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repo) CreateAlertDelivery(ctx context.Context, alertID, channelID, target, deliveryStatusID string, responsePayload *string) (*models.AlertDelivery, error) {
+	var (
+		delivery   models.AlertDelivery
+		payloadStr sql.NullString
+	)
+	err := r.pool.QueryRow(ctx, `
+INSERT INTO heartguard.alert_delivery (alert_id, channel_id, target, delivery_status_id, response_payload)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id::text,
+          alert_id::text,
+          channel_id::text,
+          (SELECT code FROM heartguard.alert_channels WHERE id = channel_id),
+          (SELECT label FROM heartguard.alert_channels WHERE id = channel_id),
+          target,
+          sent_at,
+          delivery_status_id::text,
+          (SELECT code FROM heartguard.delivery_statuses WHERE id = delivery_status_id),
+          (SELECT label FROM heartguard.delivery_statuses WHERE id = delivery_status_id),
+          response_payload::text
+`, alertID, channelID, target, deliveryStatusID, jsonParam(responsePayload)).
+		Scan(
+			&delivery.ID,
+			&delivery.AlertID,
+			&delivery.ChannelID,
+			&delivery.ChannelCode,
+			&delivery.ChannelLabel,
+			&delivery.Target,
+			&delivery.SentAt,
+			&delivery.DeliveryStatusID,
+			&delivery.DeliveryStatusCode,
+			&delivery.DeliveryStatusLabel,
+			&payloadStr,
+		)
+	if err != nil {
+		return nil, err
+	}
+	if payloadStr.Valid {
+		payload := payloadStr.String
+		delivery.ResponsePayload = &payload
+	}
+	return &delivery, nil
+}
+
 func (r *Repo) ListContentBlockTypes(ctx context.Context, limit, offset int) ([]models.ContentBlockType, error) {
 	if limit <= 0 {
 		limit = 100

--- a/backend/templates/superadmin/alerts.html
+++ b/backend/templates/superadmin/alerts.html
@@ -101,49 +101,200 @@
 					<td>{{$alert.StatusLabel}}</td>
 					<td>{{if $alert.OrgName}}{{$alert.OrgName}}{{else}}—{{end}}</td>
 					<td>{{formatTime $alert.CreatedAt}}</td>
-					<td class="hg-flex">
-						<details>
-							<summary>Editar</summary>
-							<form method="post" action="/superadmin/alerts/{{$alert.ID}}/update" class="hg-form-grid">
-								<input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
-								<div class="hg-form-field">
-									<label>Tipo</label>
-									<select name="alert_type" required>
-										{{range $.Data.AlertTypes}}
-										<option value="{{.Code}}" {{if eq .Code $alert.AlertTypeCode}}selected{{end}}>{{.Code}}</option>
-										{{end}}
-									</select>
-								</div>
-								<div class="hg-form-field">
-									<label>Nivel</label>
-									<select name="alert_level" required>
-										{{range $.Data.AlertLevels}}
-										<option value="{{.Code}}" {{if eq .Code $alert.LevelCode}}selected{{end}}>{{.Label}}</option>
-										{{end}}
-									</select>
-								</div>
-								<div class="hg-form-field">
-									<label>Estatus</label>
-									<select name="status" required>
-										{{range $.Data.AlertStatuses}}
-										<option value="{{.Code}}" {{if eq .Code $alert.StatusCode}}selected{{end}}>{{.Description}}</option>
-										{{end}}
-									</select>
-								</div>
-								<div class="hg-form-field">
-									<label>Descripción</label>
-									<textarea name="description" rows="2">{{if $alert.Description}}{{$alert.Description}}{{end}}</textarea>
-								</div>
-								<div class="hg-form-actions">
-									<button type="submit">Guardar</button>
-								</div>
-							</form>
-						</details>
-						<form method="post" action="/superadmin/alerts/{{$alert.ID}}/delete" data-hg-confirm="¿Eliminar alerta?" class="hg-inline-form">
-							<input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
-							<button type="submit" class="hg-link hg-link-danger">Eliminar</button>
-						</form>
-					</td>
+                                        <td class="hg-flex">
+                                                <details>
+                                                        <summary>Gestionar</summary>
+                                                        <div class="hg-alert-manage">
+                                                                <div class="hg-alert-section">
+                                                                        <h4>Actualizar alerta</h4>
+                                                                        <form method="post" action="/superadmin/alerts/{{$alert.ID}}/update" class="hg-form-grid">
+                                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Tipo</label>
+                                                                                        <select name="alert_type" required>
+                                                                                                {{range $.Data.AlertTypes}}
+                                                                                                <option value="{{.Code}}" {{if eq .Code $alert.AlertTypeCode}}selected{{end}}>{{.Code}}</option>
+                                                                                                {{end}}
+                                                                                        </select>
+                                                                                </div>
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Nivel</label>
+                                                                                        <select name="alert_level" required>
+                                                                                                {{range $.Data.AlertLevels}}
+                                                                                                <option value="{{.Code}}" {{if eq .Code $alert.LevelCode}}selected{{end}}>{{.Label}}</option>
+                                                                                                {{end}}
+                                                                                        </select>
+                                                                                </div>
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Estatus</label>
+                                                                                        <select name="status" required>
+                                                                                                {{range $.Data.AlertStatuses}}
+                                                                                                <option value="{{.Code}}" {{if eq .Code $alert.StatusCode}}selected{{end}}>{{.Description}}</option>
+                                                                                                {{end}}
+                                                                                        </select>
+                                                                                </div>
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Descripción</label>
+                                                                                        <textarea name="description" rows="2">{{if $alert.Description}}{{$alert.Description}}{{end}}</textarea>
+                                                                                </div>
+                                                                                <div class="hg-form-actions">
+                                                                                        <button type="submit">Guardar</button>
+                                                                                </div>
+                                                                        </form>
+                                                                </div>
+                                                                <div class="hg-alert-section">
+                                                                        <h4>Asignaciones</h4>
+                                                                        <form method="post" action="/superadmin/alerts/{{$alert.ID}}/assignments" class="hg-form-inline hg-gap">
+                                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                                <select name="assignee_user_id" required>
+                                                                                        <option value="">Selecciona responsable</option>
+                                                                                        {{range $user := $.Data.Users}}
+                                                                                        <option value="{{$user.ID}}">{{$user.Name}} · {{$user.Email}}</option>
+                                                                                        {{end}}
+                                                                                </select>
+                                                                                <button type="submit">Asignar</button>
+                                                                        </form>
+                                                                        {{$assignments := index $.Data.Assignments $alert.ID}}
+                                                                        {{if $assignments}}
+                                                                        <ul class="hg-list-compact">
+                                                                                {{range $assignments}}
+                                                                                <li>
+                                                                                        {{if .AssigneeName}}{{.AssigneeName}}{{else}}Usuario {{.AssigneeUserID}}{{end}}
+                                                                                        {{if .AssignedByName}} · asignado por {{.AssignedByName}}{{else if .AssignedByUserID}} · asignado por {{.AssignedByUserID}}{{end}}
+                                                                                        · {{formatTime .AssignedAt}}
+                                                                                </li>
+                                                                                {{end}}
+                                                                        </ul>
+                                                                        {{else}}
+                                                                        <p class="hg-empty-cell">Sin asignaciones registradas.</p>
+                                                                        {{end}}
+                                                                </div>
+                                                                <div class="hg-alert-section">
+                                                                        <h4>Acuses</h4>
+                                                                        <form method="post" action="/superadmin/alerts/{{$alert.ID}}/acks" class="hg-form-inline hg-gap">
+                                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                                <select name="ack_by_user_id">
+                                                                                        <option value="" {{if eq $.Data.CurrentUserID ""}}selected{{end}}>Yo mismo</option>
+                                                                                        {{range $user := $.Data.Users}}
+                                                                                        <option value="{{$user.ID}}" {{if eq $user.ID $.Data.CurrentUserID}}selected{{end}}>{{$user.Name}} · {{$user.Email}}</option>
+                                                                                        {{end}}
+                                                                                </select>
+                                                                                <input name="note" placeholder="Nota (opcional)" />
+                                                                                <button type="submit">Registrar acuse</button>
+                                                                        </form>
+                                                                        {{$acks := index $.Data.Acks $alert.ID}}
+                                                                        {{if $acks}}
+                                                                        <ul class="hg-list-compact">
+                                                                                {{range $acks}}
+                                                                                <li>
+                                                                                        {{if .AckByName}}{{.AckByName}}{{else if .AckByUserID}}Usuario {{.AckByUserID}}{{else}}—{{end}}
+                                                                                        · {{formatTime .AckAt}}
+                                                                                        {{if .Note}} — {{.Note}}{{end}}
+                                                                                </li>
+                                                                                {{end}}
+                                                                        </ul>
+                                                                        {{else}}
+                                                                        <p class="hg-empty-cell">Sin acuses registrados.</p>
+                                                                        {{end}}
+                                                                </div>
+                                                                <div class="hg-alert-section">
+                                                                        <h4>Resoluciones</h4>
+                                                                        <form method="post" action="/superadmin/alerts/{{$alert.ID}}/resolutions" class="hg-form-grid">
+                                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Resuelto por</label>
+                                                                                        <select name="resolved_by_user_id">
+                                                                                                <option value="">Yo mismo</option>
+                                                                                                {{range $user := $.Data.Users}}
+                                                                                                <option value="{{$user.ID}}" {{if eq $user.ID $.Data.CurrentUserID}}selected{{end}}>{{$user.Name}} · {{$user.Email}}</option>
+                                                                                                {{end}}
+                                                                                        </select>
+                                                                                </div>
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Resultado</label>
+                                                                                        <input name="outcome" placeholder="Resultado" />
+                                                                                </div>
+                                                                                <div class="hg-form-field hg-form-field--full">
+                                                                                        <label>Nota</label>
+                                                                                        <textarea name="note" rows="2"></textarea>
+                                                                                </div>
+                                                                                <div class="hg-form-actions">
+                                                                                        <button type="submit">Registrar resolución</button>
+                                                                                </div>
+                                                                        </form>
+                                                                        {{$res := index $.Data.Resolutions $alert.ID}}
+                                                                        {{if $res}}
+                                                                        <ul class="hg-list-compact">
+                                                                                {{range $res}}
+                                                                                <li>
+                                                                                        {{if .ResolvedByName}}{{.ResolvedByName}}{{else if .ResolvedByUserID}}Usuario {{.ResolvedByUserID}}{{else}}—{{end}}
+                                                                                        · {{formatTime .ResolvedAt}}
+                                                                                        {{if .Outcome}} · {{.Outcome}}{{end}}
+                                                                                        {{if .Note}} — {{.Note}}{{end}}
+                                                                                </li>
+                                                                                {{end}}
+                                                                        </ul>
+                                                                        {{else}}
+                                                                        <p class="hg-empty-cell">Sin resoluciones registradas.</p>
+                                                                        {{end}}
+                                                                </div>
+                                                                <div class="hg-alert-section">
+                                                                        <h4>Entregas</h4>
+                                                                        <form method="post" action="/superadmin/alerts/{{$alert.ID}}/deliveries" class="hg-form-grid">
+                                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Canal</label>
+                                                                                        <select name="channel_id" required>
+                                                                                                <option value="">Selecciona canal</option>
+                                                                                                {{range $.Data.AlertChannels}}
+                                                                                                <option value="{{.ID}}">{{.Label}} ({{.Code}})</option>
+                                                                                                {{end}}
+                                                                                        </select>
+                                                                                </div>
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Estado</label>
+                                                                                        <select name="delivery_status_id" required>
+                                                                                                <option value="">Selecciona estado</option>
+                                                                                                {{range $.Data.DeliveryStatuses}}
+                                                                                                <option value="{{.ID}}">{{.Label}} ({{.Code}})</option>
+                                                                                                {{end}}
+                                                                                        </select>
+                                                                                </div>
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Destino</label>
+                                                                                        <input name="target" required placeholder="Destino" />
+                                                                                </div>
+                                                                                <div class="hg-form-field hg-form-field--full">
+                                                                                        <label>Respuesta (JSON)</label>
+                                                                                        <textarea name="response_payload" rows="2" placeholder="{&quot;status&quot;:&quot;sent&quot;}"></textarea>
+                                                                                </div>
+                                                                                <div class="hg-form-actions">
+                                                                                        <button type="submit">Registrar entrega</button>
+                                                                                </div>
+                                                                        </form>
+                                                                        {{$deliveries := index $.Data.Deliveries $alert.ID}}
+                                                                        {{if $deliveries}}
+                                                                        <ul class="hg-list-compact">
+                                                                                {{range $deliveries}}
+                                                                                <li>
+                                                                                        {{.ChannelLabel}} → {{.Target}} · {{.DeliveryStatusLabel}} · {{formatTime .SentAt}}
+                                                                                        {{if .ResponsePayload}}
+                                                                                        <pre>{{.ResponsePayload}}</pre>
+                                                                                        {{end}}
+                                                                                </li>
+                                                                                {{end}}
+                                                                        </ul>
+                                                                        {{else}}
+                                                                        <p class="hg-empty-cell">Sin entregas registradas.</p>
+                                                                        {{end}}
+                                                                </div>
+                                                        </div>
+                                                </details>
+                                                <form method="post" action="/superadmin/alerts/{{$alert.ID}}/delete" data-hg-confirm="¿Eliminar alerta?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
 				</tr>
 				{{else}}
 				<tr>


### PR DESCRIPTION
## Summary
- add models for alert assignments, acknowledgements, resolutions, and deliveries
- implement repository, API, and UI handlers plus routes to manage new alert events
- extend the superadmin alerts page with management sections for assignments, acks, resolutions, and deliveries

## Testing
- go test ./... *(fails: module downloads are blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9e64baa54832fa7abd46dc4747b0c