### PR TITLE
Add ground truth management layer and UI

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -74,6 +74,13 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 			pr.Post("/{id}/delete", uiHandlers.PatientsDelete)
 		})
 
+		s.Route("/ground-truth", func(gr chi.Router) {
+			gr.Get("/", uiHandlers.GroundTruthIndex)
+			gr.Post("/", uiHandlers.GroundTruthCreate)
+			gr.Post("/{id}/update", uiHandlers.GroundTruthUpdate)
+			gr.Post("/{id}/delete", uiHandlers.GroundTruthDelete)
+		})
+
 		s.Route("/devices", func(dr chi.Router) {
 			dr.Get("/", uiHandlers.DevicesIndex)
 			dr.Post("/", uiHandlers.DevicesCreate)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -239,6 +239,43 @@ type InferenceInput struct {
 	FeatureSnapshot *string   `json:"feature_snapshot,omitempty"`
 }
 
+type GroundTruthLabel struct {
+	ID                string     `json:"id"`
+	PatientID         string     `json:"patient_id"`
+	PatientName       string     `json:"patient_name"`
+	EventTypeID       string     `json:"event_type_id"`
+	EventTypeCode     string     `json:"event_type_code"`
+	EventTypeLabel    string     `json:"event_type_label"`
+	Onset             time.Time  `json:"onset"`
+	OffsetAt          *time.Time `json:"offset_at,omitempty"`
+	AnnotatedByUserID *string    `json:"annotated_by_user_id,omitempty"`
+	AnnotatedByName   *string    `json:"annotated_by_name,omitempty"`
+	Source            *string    `json:"source,omitempty"`
+	Note              *string    `json:"note,omitempty"`
+}
+
+type GroundTruthLabelCreateInput struct {
+	EventTypeID       string     `json:"event_type_id"`
+	Onset             time.Time  `json:"onset"`
+	OffsetAt          *time.Time `json:"offset_at,omitempty"`
+	AnnotatedByUserID *string    `json:"annotated_by_user_id,omitempty"`
+	Source            *string    `json:"source,omitempty"`
+	Note              *string    `json:"note,omitempty"`
+}
+
+type GroundTruthLabelUpdateInput struct {
+	EventTypeID          *string    `json:"event_type_id,omitempty"`
+	Onset                *time.Time `json:"onset,omitempty"`
+	OffsetAt             *time.Time `json:"offset_at,omitempty"`
+	OffsetAtSet          bool       `json:"-"`
+	AnnotatedByUserID    *string    `json:"annotated_by_user_id,omitempty"`
+	AnnotatedByUserIDSet bool       `json:"-"`
+	Source               *string    `json:"source,omitempty"`
+	SourceSet            bool       `json:"-"`
+	Note                 *string    `json:"note,omitempty"`
+	NoteSet              bool       `json:"-"`
+}
+
 type Alert struct {
 	ID             string    `json:"id"`
 	OrgID          *string   `json:"org_id,omitempty"`

--- a/backend/internal/superadmin/repo.go
+++ b/backend/internal/superadmin/repo.go
@@ -1162,6 +1162,175 @@ func (r *Repo) DeleteInference(ctx context.Context, id string) error {
 	return nil
 }
 
+type groundTruthScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanGroundTruthLabel(scan groundTruthScanner) (models.GroundTruthLabel, error) {
+	var (
+		label         models.GroundTruthLabel
+		eventLabel    sql.NullString
+		offset        sql.NullTime
+		annotatedID   sql.NullString
+		annotatedName sql.NullString
+		source        sql.NullString
+		note          sql.NullString
+	)
+	if err := scan.Scan(&label.ID, &label.PatientID, &label.PatientName, &label.EventTypeID, &label.EventTypeCode, &eventLabel, &label.Onset, &offset, &annotatedID, &annotatedName, &source, &note); err != nil {
+		return models.GroundTruthLabel{}, err
+	}
+	if eventLabel.Valid && eventLabel.String != "" {
+		label.EventTypeLabel = eventLabel.String
+	} else {
+		label.EventTypeLabel = label.EventTypeCode
+	}
+	if offset.Valid {
+		ts := offset.Time
+		label.OffsetAt = &ts
+	}
+	if annotatedID.Valid {
+		v := annotatedID.String
+		label.AnnotatedByUserID = &v
+	}
+	if annotatedName.Valid {
+		v := annotatedName.String
+		label.AnnotatedByName = &v
+	}
+	if source.Valid {
+		v := source.String
+		label.Source = &v
+	}
+	if note.Valid {
+		v := note.String
+		label.Note = &v
+	}
+	return label, nil
+}
+
+// ------------------------------
+// Ground truth labels
+// ------------------------------
+
+func (r *Repo) ListGroundTruthByPatient(ctx context.Context, patientID string, limit, offset int) ([]models.GroundTruthLabel, error) {
+	rows, err := r.pool.Query(ctx, `
+SELECT g.id::text,
+       g.patient_id::text,
+       p.person_name,
+       g.event_type_id::text,
+       et.code::text,
+       et.description,
+       g.onset,
+       g.offset_at,
+       g.annotated_by_user_id::text,
+       u.name,
+       g.source,
+       g.note
+FROM heartguard.ground_truth_labels g
+JOIN heartguard.patients p ON p.id = g.patient_id
+JOIN heartguard.event_types et ON et.id = g.event_type_id
+LEFT JOIN heartguard.users u ON u.id = g.annotated_by_user_id
+WHERE g.patient_id = $1
+ORDER BY g.onset DESC
+LIMIT $2 OFFSET $3
+`, patientID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]models.GroundTruthLabel, 0, limit)
+	for rows.Next() {
+		label, err := scanGroundTruthLabel(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, label)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *Repo) CreateGroundTruthLabel(ctx context.Context, patientID string, input models.GroundTruthLabelCreateInput) (*models.GroundTruthLabel, error) {
+	row := r.pool.QueryRow(ctx, `
+WITH inserted AS (
+    INSERT INTO heartguard.ground_truth_labels (patient_id, event_type_id, onset, offset_at, annotated_by_user_id, source, note)
+    VALUES ($1, $2, $3, $4, $5, $6, $7)
+    RETURNING id, patient_id, event_type_id, onset, offset_at, annotated_by_user_id, source, note
+)
+SELECT i.id::text,
+       i.patient_id::text,
+       p.person_name,
+       i.event_type_id::text,
+       et.code::text,
+       et.description,
+       i.onset,
+       i.offset_at,
+       i.annotated_by_user_id::text,
+       u.name,
+       i.source,
+       i.note
+FROM inserted i
+JOIN heartguard.patients p ON p.id = i.patient_id
+JOIN heartguard.event_types et ON et.id = i.event_type_id
+LEFT JOIN heartguard.users u ON u.id = i.annotated_by_user_id
+`, patientID, input.EventTypeID, input.Onset, timeParam(input.OffsetAt), stringParam(input.AnnotatedByUserID, true), stringParam(input.Source, true), stringParam(input.Note, true))
+	label, err := scanGroundTruthLabel(row)
+	if err != nil {
+		return nil, err
+	}
+	return &label, nil
+}
+
+func (r *Repo) UpdateGroundTruthLabel(ctx context.Context, id string, input models.GroundTruthLabelUpdateInput) (*models.GroundTruthLabel, error) {
+	row := r.pool.QueryRow(ctx, `
+WITH updated AS (
+    UPDATE heartguard.ground_truth_labels SET
+        event_type_id = COALESCE($2, event_type_id),
+        onset = COALESCE($3, onset),
+        offset_at = CASE WHEN $4 THEN $5 ELSE offset_at END,
+        annotated_by_user_id = CASE WHEN $6 THEN $7 ELSE annotated_by_user_id END,
+        source = CASE WHEN $8 THEN $9 ELSE source END,
+        note = CASE WHEN $10 THEN $11 ELSE note END
+    WHERE id = $1
+    RETURNING id, patient_id, event_type_id, onset, offset_at, annotated_by_user_id, source, note
+)
+SELECT u.id::text,
+       u.patient_id::text,
+       p.person_name,
+       u.event_type_id::text,
+       et.code::text,
+       et.description,
+       u.onset,
+       u.offset_at,
+       u.annotated_by_user_id::text,
+       usr.name,
+       u.source,
+       u.note
+FROM updated u
+JOIN heartguard.patients p ON p.id = u.patient_id
+JOIN heartguard.event_types et ON et.id = u.event_type_id
+LEFT JOIN heartguard.users usr ON usr.id = u.annotated_by_user_id
+`, id, input.EventTypeID, input.Onset, input.OffsetAtSet, timeParam(input.OffsetAt), input.AnnotatedByUserIDSet, stringParam(input.AnnotatedByUserID, true), input.SourceSet, stringParam(input.Source, true), input.NoteSet, stringParam(input.Note, true))
+	label, err := scanGroundTruthLabel(row)
+	if err != nil {
+		return nil, err
+	}
+	return &label, nil
+}
+
+func (r *Repo) DeleteGroundTruthLabel(ctx context.Context, id string) error {
+	ct, err := r.pool.Exec(ctx, `DELETE FROM heartguard.ground_truth_labels WHERE id=$1`, id)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
 // ------------------------------
 // Alerts
 // ------------------------------

--- a/backend/internal/superadmin/repo_ground_truth_test.go
+++ b/backend/internal/superadmin/repo_ground_truth_test.go
@@ -1,0 +1,309 @@
+package superadmin
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"heartguard-superadmin/internal/models"
+)
+
+func TestRepo_ListGroundTruthByPatient(t *testing.T) {
+	ctx := context.Background()
+	onset := time.Date(2024, 5, 1, 10, 0, 0, 0, time.UTC)
+	offset := onset.Add(30 * time.Minute)
+
+	rows := &fakeRows{records: [][]any{{
+		"lbl-1",
+		"pat-1",
+		"Paciente Uno",
+		"evt-1",
+		"EVT",
+		nullableString("Arritmia"),
+		onset,
+		nullableTime(offset),
+		nullableString("user-1"),
+		nullableString("Ana"),
+		nullableString("manual"),
+		nullableString("Observación"),
+	}, {
+		"lbl-2",
+		"pat-1",
+		"Paciente Uno",
+		"evt-2",
+		"ALT",
+		sqlNullString{},
+		onset.Add(-2 * time.Hour),
+		sqlNullTime{},
+		sqlNullString{},
+		sqlNullString{},
+		sqlNullString{},
+		sqlNullString{},
+	}}}
+
+	stub := &stubPool{queryRows: rows}
+	repo := NewRepoWithPool(stub, nil)
+
+	got, err := repo.ListGroundTruthByPatient(ctx, "pat-1", 20, 0)
+	if err != nil {
+		t.Fatalf("ListGroundTruthByPatient: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 labels, got %d", len(got))
+	}
+	if got[0].ID != "lbl-1" || got[0].EventTypeLabel != "Arritmia" {
+		t.Fatalf("unexpected first label: %+v", got[0])
+	}
+	if got[0].OffsetAt == nil || !got[0].OffsetAt.Equal(offset) {
+		t.Fatalf("expected offset %v, got %+v", offset, got[0].OffsetAt)
+	}
+	if got[1].EventTypeLabel != "ALT" {
+		t.Fatalf("expected fallback label ALT, got %q", got[1].EventTypeLabel)
+	}
+	if !strings.Contains(stub.querySQL, "FROM heartguard.ground_truth_labels") {
+		t.Fatalf("unexpected query: %s", stub.querySQL)
+	}
+}
+
+func TestRepo_CreateGroundTruthLabel(t *testing.T) {
+	ctx := context.Background()
+	onset := time.Date(2024, 6, 10, 15, 0, 0, 0, time.UTC)
+	offset := onset.Add(45 * time.Minute)
+	source := "Manual"
+	note := "Revisión clínica"
+	annotated := "user-9"
+
+	row := &fakeRow{record: []any{
+		"lbl-new",
+		"pat-7",
+		"Paciente",
+		"evt-3",
+		"EV3",
+		nullableString("Evento"),
+		onset,
+		nullableTime(offset),
+		nullableString(annotated),
+		nullableString("Dra. Pérez"),
+		nullableString(source),
+		nullableString(note),
+	}}
+	stub := &stubPool{queryRowRow: row}
+	repo := NewRepoWithPool(stub, nil)
+
+	input := models.GroundTruthLabelCreateInput{
+		EventTypeID:       "evt-3",
+		Onset:             onset,
+		OffsetAt:          &offset,
+		AnnotatedByUserID: &annotated,
+		Source:            &source,
+		Note:              &note,
+	}
+	label, err := repo.CreateGroundTruthLabel(ctx, "pat-7", input)
+	if err != nil {
+		t.Fatalf("CreateGroundTruthLabel: %v", err)
+	}
+	if label.ID != "lbl-new" || label.PatientName != "Paciente" {
+		t.Fatalf("unexpected label: %+v", label)
+	}
+	if label.AnnotatedByName == nil || *label.AnnotatedByName != "Dra. Pérez" {
+		t.Fatalf("expected annotator name, got %+v", label.AnnotatedByName)
+	}
+	if !strings.Contains(stub.queryRowSQL, "INSERT INTO heartguard.ground_truth_labels") {
+		t.Fatalf("unexpected SQL: %s", stub.queryRowSQL)
+	}
+	if len(stub.queryRowArgs) != 7 {
+		t.Fatalf("unexpected arg count: %d", len(stub.queryRowArgs))
+	}
+}
+
+func TestRepo_UpdateGroundTruthLabel(t *testing.T) {
+	ctx := context.Background()
+	onset := time.Date(2024, 7, 3, 9, 0, 0, 0, time.UTC)
+	offset := onset.Add(90 * time.Minute)
+	source := "Sensor"
+	note := "Actualización"
+	row := &fakeRow{record: []any{
+		"lbl-77",
+		"pat-1",
+		"Paciente",
+		"evt-9",
+		"EV9",
+		nullableString("Evento crónico"),
+		onset,
+		nullableTime(offset),
+		sqlNullString{},
+		sqlNullString{},
+		nullableString(source),
+		nullableString(note),
+	}}
+	stub := &stubPool{queryRowRow: row}
+	repo := NewRepoWithPool(stub, nil)
+
+	eventType := "evt-9"
+	input := models.GroundTruthLabelUpdateInput{
+		EventTypeID:          &eventType,
+		Onset:                &onset,
+		OffsetAt:             &offset,
+		OffsetAtSet:          true,
+		AnnotatedByUserID:    nil,
+		AnnotatedByUserIDSet: true,
+		Source:               &source,
+		SourceSet:            true,
+		Note:                 &note,
+		NoteSet:              true,
+	}
+	label, err := repo.UpdateGroundTruthLabel(ctx, "lbl-77", input)
+	if err != nil {
+		t.Fatalf("UpdateGroundTruthLabel: %v", err)
+	}
+	if label.EventTypeID != "evt-9" || label.Source == nil || *label.Source != "Sensor" {
+		t.Fatalf("unexpected label after update: %+v", label)
+	}
+	if !strings.Contains(stub.queryRowSQL, "UPDATE heartguard.ground_truth_labels") {
+		t.Fatalf("unexpected SQL: %s", stub.queryRowSQL)
+	}
+}
+
+func TestRepo_DeleteGroundTruthLabel(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubPool{execTag: pgconn.NewCommandTag("DELETE 1")}
+	repo := NewRepoWithPool(stub, nil)
+
+	if err := repo.DeleteGroundTruthLabel(ctx, "lbl-10"); err != nil {
+		t.Fatalf("DeleteGroundTruthLabel: %v", err)
+	}
+
+	stub.execTag = pgconn.NewCommandTag("DELETE 0")
+	if err := repo.DeleteGroundTruthLabel(ctx, "missing"); err == nil || !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("expected pgx.ErrNoRows, got %v", err)
+	}
+	if !strings.Contains(stub.execSQL, "DELETE FROM heartguard.ground_truth_labels") {
+		t.Fatalf("unexpected delete SQL: %s", stub.execSQL)
+	}
+}
+
+// --- test helpers ---
+
+type stubPool struct {
+	querySQL     string
+	queryArgs    []any
+	queryRows    pgx.Rows
+	queryErr     error
+	queryRowSQL  string
+	queryRowArgs []any
+	queryRowRow  pgx.Row
+	execSQL      string
+	execArgs     []any
+	execTag      pgconn.CommandTag
+	execErr      error
+}
+
+func (s *stubPool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	s.querySQL = sql
+	s.queryArgs = args
+	return s.queryRows, s.queryErr
+}
+
+func (s *stubPool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	s.queryRowSQL = sql
+	s.queryRowArgs = args
+	if s.queryRowRow == nil {
+		return &fakeRow{err: errors.New("no row")}
+	}
+	return s.queryRowRow
+}
+
+func (s *stubPool) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	s.execSQL = sql
+	s.execArgs = args
+	return s.execTag, s.execErr
+}
+
+func (s *stubPool) Begin(context.Context) (pgx.Tx, error) { return nil, errors.New("not implemented") }
+func (s *stubPool) Ping(context.Context) error            { return nil }
+
+type fakeRow struct {
+	record []any
+	err    error
+}
+
+func (r *fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	for i := range dest {
+		assignValue(dest[i], r.record[i])
+	}
+	return nil
+}
+
+type fakeRows struct {
+	records [][]any
+	idx     int
+	err     error
+}
+
+func (r *fakeRows) Close() {}
+
+func (r *fakeRows) Err() error { return r.err }
+
+func (r *fakeRows) CommandTag() pgconn.CommandTag { return pgconn.CommandTag{} }
+
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+
+func (r *fakeRows) Next() bool {
+	if r.idx >= len(r.records) {
+		return false
+	}
+	r.idx++
+	return true
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.idx == 0 || r.idx > len(r.records) {
+		return errors.New("scan called without next")
+	}
+	row := r.records[r.idx-1]
+	for i := range dest {
+		assignValue(dest[i], row[i])
+	}
+	return nil
+}
+
+func (r *fakeRows) Values() ([]any, error) { return nil, nil }
+func (r *fakeRows) RawValues() [][]byte    { return nil }
+func (r *fakeRows) Conn() *pgx.Conn        { return nil }
+
+type sqlNullString = sql.NullString
+type sqlNullTime = sql.NullTime
+
+func nullableString(s string) sqlNullString { return sqlNullString{String: s, Valid: true} }
+func nullableTime(t time.Time) sqlNullTime  { return sqlNullTime{Time: t, Valid: true} }
+
+func assignValue(dest any, value any) {
+	switch d := dest.(type) {
+	case *string:
+		*d = value.(string)
+	case *time.Time:
+		*d = value.(time.Time)
+	case *sqlNullString:
+		*d = value.(sqlNullString)
+	case *sqlNullTime:
+		*d = value.(sqlNullTime)
+	default:
+		switch v := value.(type) {
+		case nil:
+			// leave zero
+		default:
+			if setter, ok := d.(interface{ Scan(any) error }); ok {
+				_ = setter.Scan(v)
+			}
+		}
+	}
+}

--- a/backend/templates/layout.html
+++ b/backend/templates/layout.html
@@ -34,8 +34,9 @@
 					<li><a href="/superadmin/roles">Roles</a></li>
 					<li><a href="/superadmin/content">Contenido</a></li>
 					<li><a href="/superadmin/content-block-types">Tipos de bloque</a></li>
-					<li><a href="/superadmin/patients">Pacientes</a></li>
-					<li><a href="/superadmin/devices">Dispositivos</a></li>
+                                        <li><a href="/superadmin/patients">Pacientes</a></li>
+                                        <li><a href="/superadmin/ground-truth">Ground Truth</a></li>
+                                        <li><a href="/superadmin/devices">Dispositivos</a></li>
 					<li><a href="/superadmin/signal-streams">Streams de señal</a></li>
 					<li><a href="/superadmin/models">Modelos ML</a></li>
 					<li><a href="/superadmin/event-types">Eventos</a></li>

--- a/backend/templates/superadmin/ground_truth.html
+++ b/backend/templates/superadmin/ground_truth.html
@@ -1,0 +1,153 @@
+{{define "superadmin/ground_truth.html"}} {{template "layout" .}} {{end}}
+{{define "superadmin/ground_truth.html:content"}}
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Seleccionar paciente</h3>
+                <form method="get" action="/superadmin/ground-truth" class="hg-form-grid">
+                        <div class="hg-form-field">
+                                <label for="gt-patient">Paciente</label>
+                                <select id="gt-patient" name="patient_id">
+                                        <option value="">-- Selecciona --</option>
+                                        {{range .Data.Patients}}
+                                        <option value="{{.ID}}" {{if eq $.Data.SelectedPatientID .ID}}selected{{end}}>{{.Name}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Ver etiquetas</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+{{if .Data.SelectedPatient}}
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Nueva etiqueta</h3>
+                <form method="post" action="/superadmin/ground-truth" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <input type="hidden" name="patient_id" value="{{.Data.SelectedPatient.ID}}" />
+                        <div class="hg-form-field">
+                                <label for="gt-event">Evento</label>
+                                <select id="gt-event" name="event_type_id" required>
+                                        <option value="">-- Selecciona --</option>
+                                        {{range .Data.EventTypes}}
+                                        <option value="{{.ID}}">{{if .Description}}{{.Description}}{{else}}{{.Code}}{{end}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="gt-onset">Inicio</label>
+                                <input id="gt-onset" name="onset" type="datetime-local" required />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="gt-offset">Fin</label>
+                                <input id="gt-offset" name="offset_at" type="datetime-local" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="gt-annotated">Usuario anotador (UUID)</label>
+                                <input id="gt-annotated" name="annotated_by_user_id" type="text" placeholder="Opcional" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="gt-source">Fuente</label>
+                                <input id="gt-source" name="source" type="text" placeholder="p. ej. Manual" />
+                        </div>
+                        <div class="hg-form-field hg-form-field-span">
+                                <label for="gt-note">Nota</label>
+                                <textarea id="gt-note" name="note" rows="3" placeholder="Observaciones"></textarea>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Registrar etiqueta</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Etiquetas registradas</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Inicio</th>
+                                        <th>Fin</th>
+                                        <th>Evento</th>
+                                        <th>Fuente</th>
+                                        <th>Anotador</th>
+                                        <th>Nota</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Labels}}
+                                {{$label := .}}
+                                <tr>
+                                        <td>{{formatTimeLocal $label.Onset}}</td>
+                                        <td>{{formatTimeLocalPtr $label.OffsetAt}}</td>
+                                        <td>{{$label.EventTypeLabel}}</td>
+                                        <td>{{if $label.Source}}{{*$label.Source}}{{else}}—{{end}}</td>
+                                        <td>{{if $label.AnnotatedByName}}{{$label.AnnotatedByName}}{{else if $label.AnnotatedByUserID}}{{stringValue $label.AnnotatedByUserID}}{{else}}—{{end}}</td>
+                                        <td>{{if $label.Note}}{{*$label.Note}}{{else}}—{{end}}</td>
+                                        <td class="hg-flex">
+                                                <details>
+                                                        <summary>Editar</summary>
+                                                        <form method="post" action="/superadmin/ground-truth/{{$label.ID}}/update" class="hg-form-grid">
+                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                <input type="hidden" name="patient_id" value="{{$.Data.SelectedPatient.ID}}" />
+                                                                <div class="hg-form-field">
+                                                                        <label>Evento</label>
+                                                                        <select name="event_type_id" required>
+                                                                                {{range $.Data.EventTypes}}
+                                                                                <option value="{{.ID}}" {{if eq .ID $label.EventTypeID}}selected{{end}}>{{if .Description}}{{.Description}}{{else}}{{.Code}}{{end}}</option>
+                                                                                {{end}}
+                                                                        </select>
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Inicio</label>
+                                                                        <input name="onset" type="datetime-local" value="{{formatTimeLocal $label.Onset}}" required />
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Fin</label>
+                                                                        <input name="offset_at" type="datetime-local" value="{{formatTimeLocalPtr $label.OffsetAt}}" />
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Anotador (UUID)</label>
+                                                                        <input name="annotated_by_user_id" type="text" value="{{stringValue $label.AnnotatedByUserID}}" />
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Fuente</label>
+                                                                        <input name="source" type="text" value="{{stringValue $label.Source}}" />
+                                                                </div>
+                                                                <div class="hg-form-field hg-form-field-span">
+                                                                        <label>Nota</label>
+                                                                        <textarea name="note" rows="3">{{stringValue $label.Note}}</textarea>
+                                                                </div>
+                                                                <div class="hg-form-actions">
+                                                                        <button type="submit">Guardar</button>
+                                                                </div>
+                                                        </form>
+                                                </details>
+                                                <form method="post" action="/superadmin/ground-truth/{{$label.ID}}/delete" data-hg-confirm="¿Eliminar etiqueta?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <input type="hidden" name="patient_id" value="{{$.Data.SelectedPatient.ID}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="7" class="hg-empty-cell">Sin etiquetas registradas.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+{{else if .Data.SelectedPatientID}}
+<section class="hg-section">
+        <div class="hg-card">
+                <p>No se encontró información para el paciente seleccionado.</p>
+        </div>
+</section>
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary
- define ground truth label models and expose CRUD repository operations
- add REST and UI handlers plus routing for managing ground truth labels in the superadmin panel
- provide new ground truth management template, navigation link, and repository tests

## Testing
- GOPROXY=off GOSUMDB=off go test ./internal/superadmin

------
https://chatgpt.com/codex/tasks/task_e_68e9e64a291c832f9712ff0a875ad11f