### PR TITLE
Add superadmin service management UI and API

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -74,6 +74,15 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 			pr.Post("/{id}/delete", uiHandlers.PatientsDelete)
 		})
 
+		s.Route("/services", func(sr chi.Router) {
+			sr.Get("/", uiHandlers.ServicesIndex)
+			sr.Post("/", uiHandlers.ServicesCreate)
+			sr.Post("/{id}/update", uiHandlers.ServicesUpdate)
+			sr.Post("/{id}/delete", uiHandlers.ServicesDelete)
+			sr.Post("/health", uiHandlers.ServiceHealthCreate)
+			sr.Post("/health/import", uiHandlers.ServiceHealthImport)
+		})
+
 		s.Route("/devices", func(dr chi.Router) {
 			dr.Get("/", uiHandlers.DevicesIndex)
 			dr.Post("/", uiHandlers.DevicesCreate)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -148,6 +148,31 @@ type DeviceInput struct {
 	Active         *bool   `json:"active,omitempty"`
 }
 
+type Service struct {
+	ID              string     `json:"id"`
+	Name            string     `json:"name"`
+	URL             string     `json:"url"`
+	Description     *string    `json:"description,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	LastStatusCode  *string    `json:"last_status_code,omitempty"`
+	LastStatusLabel *string    `json:"last_status_label,omitempty"`
+	LastCheckedAt   *time.Time `json:"last_checked_at,omitempty"`
+	LastLatencyMs   *int       `json:"last_latency_ms,omitempty"`
+	LastVersion     *string    `json:"last_version,omitempty"`
+}
+
+type ServiceHealth struct {
+	ID          string    `json:"id"`
+	ServiceID   string    `json:"service_id"`
+	ServiceName string    `json:"service_name"`
+	StatusID    string    `json:"status_id"`
+	StatusCode  string    `json:"status_code"`
+	StatusLabel string    `json:"status_label"`
+	CheckedAt   time.Time `json:"checked_at"`
+	LatencyMs   *int      `json:"latency_ms,omitempty"`
+	Version     *string   `json:"version,omitempty"`
+}
+
 type DeviceType struct {
 	ID          string  `json:"id"`
 	Code        string  `json:"code"`

--- a/backend/internal/superadmin/service_utils.go
+++ b/backend/internal/superadmin/service_utils.go
@@ -1,0 +1,25 @@
+package superadmin
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+func normalizeServiceURL(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", errors.New("empty url")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", errors.New("invalid scheme")
+	}
+	if parsed.Host == "" {
+		return "", errors.New("missing host")
+	}
+	return parsed.String(), nil
+}

--- a/backend/templates/layout.html
+++ b/backend/templates/layout.html
@@ -32,10 +32,11 @@
 					<li><a href="/superadmin/invitations">Invitaciones</a></li>
 					<li><a href="/superadmin/users">Usuarios</a></li>
 					<li><a href="/superadmin/roles">Roles</a></li>
-					<li><a href="/superadmin/content">Contenido</a></li>
-					<li><a href="/superadmin/content-block-types">Tipos de bloque</a></li>
-					<li><a href="/superadmin/patients">Pacientes</a></li>
-					<li><a href="/superadmin/devices">Dispositivos</a></li>
+                                        <li><a href="/superadmin/content">Contenido</a></li>
+                                        <li><a href="/superadmin/content-block-types">Tipos de bloque</a></li>
+                                        <li><a href="/superadmin/patients">Pacientes</a></li>
+                                        <li><a href="/superadmin/services">Servicios</a></li>
+                                        <li><a href="/superadmin/devices">Dispositivos</a></li>
 					<li><a href="/superadmin/signal-streams">Streams de señal</a></li>
 					<li><a href="/superadmin/models">Modelos ML</a></li>
 					<li><a href="/superadmin/event-types">Eventos</a></li>

--- a/backend/templates/superadmin/services.html
+++ b/backend/templates/superadmin/services.html
@@ -1,0 +1,183 @@
+{{define "superadmin/services.html"}} {{template "layout" .}} {{end}} {{define "superadmin/services.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Servicios</h1>
+        </div>
+        <div class="hg-card">
+                <h3>Registrar servicio</h3>
+                <form method="post" action="/superadmin/services" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label for="service-name">Nombre</label>
+                                <input id="service-name" name="name" type="text" required placeholder="Servicio principal" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="service-url">URL</label>
+                                <input id="service-url" name="url" type="url" required placeholder="https://api.example.com" />
+                        </div>
+                        <div class="hg-form-field hg-form-field-span2">
+                                <label for="service-desc">Descripción</label>
+                                <textarea id="service-desc" name="description" rows="2" placeholder="Uso o notas del servicio"></textarea>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Crear servicio</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Servicios configurados</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Nombre</th>
+                                        <th>URL</th>
+                                        <th>Descripción</th>
+                                        <th>Último estatus</th>
+                                        <th>Último check</th>
+                                        <th>Latencia</th>
+                                        <th>Versión</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Services}}
+                                {{$svc := .}}
+                                <tr>
+                                        <td>{{$svc.Name}}</td>
+                                        <td><a href="{{$svc.URL}}" target="_blank" rel="noopener">{{$svc.URL}}</a></td>
+                                        <td>{{stringValue $svc.Description}}</td>
+                                        <td>{{if $svc.LastStatusLabel}}{{$svc.LastStatusLabel}}{{else}}—{{end}}</td>
+                                        <td>{{if $svc.LastCheckedAt}}{{formatTime $svc.LastCheckedAt}}{{else}}—{{end}}</td>
+                                        <td>{{if $svc.LastLatencyMs}}{{$svc.LastLatencyMs}} ms{{else}}—{{end}}</td>
+                                        <td>{{stringValue $svc.LastVersion}}</td>
+                                        <td class="hg-flex">
+                                                <details>
+                                                        <summary>Editar</summary>
+                                                        <form method="post" action="/superadmin/services/{{$svc.ID}}/update" class="hg-form-grid">
+                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                <div class="hg-form-field">
+                                                                        <label>Nombre</label>
+                                                                        <input name="name" type="text" value="{{$svc.Name}}" required />
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>URL</label>
+                                                                        <input name="url" type="url" value="{{$svc.URL}}" required />
+                                                                </div>
+                                                                <div class="hg-form-field hg-form-field-span2">
+                                                                        <label>Descripción</label>
+                                                                        <textarea name="description" rows="2">{{if $svc.Description}}{{$svc.Description}}{{end}}</textarea>
+                                                                </div>
+                                                                <div class="hg-form-actions">
+                                                                        <button type="submit">Guardar</button>
+                                                                </div>
+                                                        </form>
+                                                </details>
+                                                <form method="post" action="/superadmin/services/{{$svc.ID}}/delete" data-hg-confirm="¿Eliminar servicio?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="8" class="hg-empty-cell">Sin servicios registrados.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-grid-2">
+                <div class="hg-card">
+                        <h3>Registrar check manual</h3>
+                        <form method="post" action="/superadmin/services/health" class="hg-form-grid">
+                                <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                                <div class="hg-form-field">
+                                        <label for="health-service">Servicio</label>
+                                        <select id="health-service" name="service_id" required>
+                                                <option value="">Selecciona servicio</option>
+                                                {{range .Data.Services}}
+                                                <option value="{{.ID}}">{{.Name}}</option>
+                                                {{end}}
+                                        </select>
+                                </div>
+                                <div class="hg-form-field">
+                                        <label for="health-status">Estatus</label>
+                                        <select id="health-status" name="status_code" required>
+                                                <option value="">Selecciona estatus</option>
+                                                {{range .Data.Statuses}}
+                                                <option value="{{.Code}}">{{.Label}}</option>
+                                                {{end}}
+                                        </select>
+                                </div>
+                                <div class="hg-form-field">
+                                        <label for="health-latency">Latencia (ms)</label>
+                                        <input id="health-latency" name="latency_ms" type="number" min="0" />
+                                </div>
+                                <div class="hg-form-field">
+                                        <label for="health-version">Versión</label>
+                                        <input id="health-version" name="version" type="text" maxlength="40" />
+                                </div>
+                                <div class="hg-form-field hg-form-field-span2">
+                                        <label for="health-checked">Fecha de check</label>
+                                        <input id="health-checked" name="checked_at" type="datetime-local" />
+                                </div>
+                                <div class="hg-form-actions">
+                                        <button type="submit">Registrar check</button>
+                                </div>
+                        </form>
+                </div>
+                <div class="hg-card">
+                        <h3>Importar historial (CSV)</h3>
+                        <form method="post" action="/superadmin/services/health/import" enctype="multipart/form-data" class="hg-form-grid">
+                                <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                                <div class="hg-form-field hg-form-field-span2">
+                                        <label for="health-file">Archivo CSV</label>
+                                        <input id="health-file" name="history_file" type="file" accept=".csv" required />
+                                        <p class="hg-field-hint">Columnas esperadas: service_id,status_code,latency_ms,checked_at,version</p>
+                                </div>
+                                <div class="hg-form-actions">
+                                        <button type="submit">Importar</button>
+                                </div>
+                        </form>
+                </div>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Historial reciente</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Servicio</th>
+                                        <th>Estatus</th>
+                                        <th>Latencia</th>
+                                        <th>Versión</th>
+                                        <th>Fecha</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.History}}
+                                <tr>
+                                        <td>{{.ServiceName}}</td>
+                                        <td>{{.StatusLabel}}</td>
+                                        <td>{{if .LatencyMs}}{{.LatencyMs}} ms{{else}}—{{end}}</td>
+                                        <td>{{stringValue .Version}}</td>
+                                        <td>{{formatTime .CheckedAt}}</td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="5" class="hg-empty-cell">Sin registros de health.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+{{end}}


### PR DESCRIPTION
## Summary
- add service models and repository support for CRUD plus health history operations
- expose REST handlers for managing services and recording or importing health checks with validation
- implement the superadmin UI, navigation entry, and templates for managing services and their health records

## Testing
- not run (go test ./... hung awaiting external dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e9e64e97ac832faca5b720f3215417