### PR TITLE
Add care team and caregiver management

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -67,6 +67,28 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 			br.Post("/{id}/delete", uiHandlers.ContentBlockTypesDelete)
 		})
 
+		s.Route("/care-teams", func(cr chi.Router) {
+			cr.Get("/", uiHandlers.CareTeamsIndex)
+			cr.Post("/", uiHandlers.CareTeamsCreate)
+			cr.Post("/{id}/update", uiHandlers.CareTeamsUpdate)
+			cr.Post("/{id}/delete", uiHandlers.CareTeamsDelete)
+			cr.Post("/{id}/members", uiHandlers.CareTeamMembersAdd)
+			cr.Post("/{id}/members/{userID}/update", uiHandlers.CareTeamMembersUpdate)
+			cr.Post("/{id}/members/{userID}/delete", uiHandlers.CareTeamMembersDelete)
+			cr.Post("/{id}/patients", uiHandlers.CareTeamPatientsAdd)
+			cr.Post("/{id}/patients/{patientID}/delete", uiHandlers.CareTeamPatientsDelete)
+		})
+
+		s.Route("/caregivers", func(cr chi.Router) {
+			cr.Get("/", uiHandlers.CaregiversIndex)
+			cr.Post("/types", uiHandlers.CaregiverTypesCreate)
+			cr.Post("/types/{id}/update", uiHandlers.CaregiverTypesUpdate)
+			cr.Post("/types/{id}/delete", uiHandlers.CaregiverTypesDelete)
+			cr.Post("/assignments", uiHandlers.CaregiverAssignmentsCreate)
+			cr.Post("/assignments/{patientID}/{caregiverID}/update", uiHandlers.CaregiverAssignmentsUpdate)
+			cr.Post("/assignments/{patientID}/{caregiverID}/delete", uiHandlers.CaregiverAssignmentsDelete)
+		})
+
 		s.Route("/patients", func(pr chi.Router) {
 			pr.Get("/", uiHandlers.PatientsIndex)
 			pr.Post("/", uiHandlers.PatientsCreate)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -123,6 +123,86 @@ type PatientInput struct {
 	RiskLevel *string    `json:"risk_level,omitempty"`
 }
 
+type CareTeam struct {
+	ID        string    `json:"id"`
+	OrgID     *string   `json:"org_id,omitempty"`
+	OrgName   *string   `json:"org_name,omitempty"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type CareTeamInput struct {
+	OrgID *string `json:"org_id,omitempty"`
+	Name  string  `json:"name"`
+}
+
+type CareTeamUpdateInput struct {
+	OrgID *string `json:"org_id,omitempty"`
+	Name  *string `json:"name,omitempty"`
+}
+
+type CareTeamMember struct {
+	CareTeamID string    `json:"care_team_id"`
+	UserID     string    `json:"user_id"`
+	UserName   string    `json:"user_name"`
+	UserEmail  string    `json:"user_email"`
+	RoleInTeam string    `json:"role_in_team"`
+	JoinedAt   time.Time `json:"joined_at"`
+}
+
+type CareTeamMemberInput struct {
+	UserID     string `json:"user_id"`
+	RoleInTeam string `json:"role_in_team"`
+}
+
+type CareTeamPatient struct {
+	CareTeamID  string `json:"care_team_id"`
+	PatientID   string `json:"patient_id"`
+	PatientName string `json:"patient_name"`
+}
+
+type CaregiverRelationType struct {
+	ID    string `json:"id"`
+	Code  string `json:"code"`
+	Label string `json:"label"`
+}
+
+type CaregiverRelation struct {
+	PatientID         string     `json:"patient_id"`
+	PatientName       string     `json:"patient_name"`
+	CaregiverID       string     `json:"caregiver_id"`
+	CaregiverName     string     `json:"caregiver_name"`
+	CaregiverEmail    string     `json:"caregiver_email"`
+	RelationTypeID    *string    `json:"relation_type_id,omitempty"`
+	RelationTypeCode  *string    `json:"relation_type_code,omitempty"`
+	RelationTypeLabel *string    `json:"relation_type_label,omitempty"`
+	IsPrimary         bool       `json:"is_primary"`
+	StartedAt         time.Time  `json:"started_at"`
+	EndedAt           *time.Time `json:"ended_at,omitempty"`
+	Note              *string    `json:"note,omitempty"`
+}
+
+type CaregiverRelationInput struct {
+	PatientID      string     `json:"patient_id"`
+	CaregiverID    string     `json:"caregiver_id"`
+	RelationTypeID *string    `json:"relation_type_id,omitempty"`
+	IsPrimary      *bool      `json:"is_primary,omitempty"`
+	StartedAt      *time.Time `json:"started_at,omitempty"`
+	EndedAt        *time.Time `json:"ended_at,omitempty"`
+	Note           *string    `json:"note,omitempty"`
+}
+
+type CaregiverRelationUpdateInput struct {
+	RelationTypeID *string    `json:"relation_type_id,omitempty"`
+	ClearRelation  bool       `json:"clear_relation_type,omitempty"`
+	IsPrimary      *bool      `json:"is_primary,omitempty"`
+	StartedAt      *time.Time `json:"started_at,omitempty"`
+	EndedAt        *time.Time `json:"ended_at,omitempty"`
+	ClearEndedAt   bool       `json:"clear_ended_at,omitempty"`
+	Note           *string    `json:"note,omitempty"`
+	ClearNote      bool       `json:"clear_note,omitempty"`
+}
+
 type Device struct {
 	ID               string    `json:"id"`
 	OrgID            *string   `json:"org_id,omitempty"`

--- a/backend/internal/superadmin/repo_care_test.go
+++ b/backend/internal/superadmin/repo_care_test.go
@@ -1,0 +1,224 @@
+package superadmin
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type fakePool struct {
+	queryFn func(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+func (f *fakePool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	if f.queryFn == nil {
+		return nil, errors.New("query not implemented")
+	}
+	return f.queryFn(ctx, sql, args...)
+}
+
+func (f *fakePool) QueryRow(context.Context, string, ...any) pgx.Row {
+	panic("unexpected QueryRow call")
+}
+
+func (f *fakePool) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, errors.New("unexpected Exec call")
+}
+
+func (f *fakePool) Begin(context.Context) (pgx.Tx, error) {
+	return nil, errors.New("unexpected Begin call")
+}
+
+func (f *fakePool) Ping(context.Context) error { return nil }
+
+type fakeRows struct {
+	data [][]any
+	idx  int
+}
+
+func (f *fakeRows) Close() {}
+
+func (f *fakeRows) Err() error { return nil }
+
+func (f *fakeRows) CommandTag() pgconn.CommandTag { return pgconn.CommandTag{} }
+
+func (f *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+
+func (f *fakeRows) Next() bool {
+	if f.idx >= len(f.data) {
+		return false
+	}
+	f.idx++
+	return true
+}
+
+func (f *fakeRows) Scan(dest ...any) error {
+	if f.idx == 0 || f.idx > len(f.data) {
+		return errors.New("scan called without row")
+	}
+	row := f.data[f.idx-1]
+	if len(row) < len(dest) {
+		return fmt.Errorf("row has %d values, want %d", len(row), len(dest))
+	}
+	for i, d := range dest {
+		switch v := d.(type) {
+		case *string:
+			if row[i] == nil {
+				*v = ""
+			} else {
+				*v = row[i].(string)
+			}
+		case *sql.NullString:
+			if row[i] == nil {
+				v.Valid = false
+				v.String = ""
+			} else {
+				v.Valid = true
+				v.String = row[i].(string)
+			}
+		case *time.Time:
+			if row[i] == nil {
+				*v = time.Time{}
+			} else {
+				*v = row[i].(time.Time)
+			}
+		case *bool:
+			if row[i] == nil {
+				*v = false
+			} else {
+				*v = row[i].(bool)
+			}
+		case *sql.NullTime:
+			if row[i] == nil {
+				v.Valid = false
+				v.Time = time.Time{}
+			} else {
+				v.Valid = true
+				v.Time = row[i].(time.Time)
+			}
+		default:
+			return fmt.Errorf("unsupported dest type %T", d)
+		}
+	}
+	return nil
+}
+
+func (f *fakeRows) Values() ([]any, error) {
+	if f.idx == 0 || f.idx > len(f.data) {
+		return nil, errors.New("no current row")
+	}
+	return f.data[f.idx-1], nil
+}
+
+func (f *fakeRows) RawValues() [][]byte { return nil }
+
+func (f *fakeRows) Conn() *pgx.Conn { return nil }
+
+func TestListCareTeams(t *testing.T) {
+	createdAt := time.Now().UTC()
+	pool := &fakePool{
+		queryFn: func(ctx context.Context, query string, args ...any) (pgx.Rows, error) {
+			if !strings.Contains(query, "FROM care_teams") {
+				t.Fatalf("unexpected query: %s", query)
+			}
+			if len(args) != 2 || args[0] != 10 || args[1] != 0 {
+				t.Fatalf("unexpected args: %#v", args)
+			}
+			rows := [][]any{{"team-1", "org-1", "Org Uno", "Equipo Azul", createdAt}}
+			return &fakeRows{data: rows}, nil
+		},
+	}
+	repo := NewRepoWithPool(pool, nil)
+
+	teams, err := repo.ListCareTeams(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("ListCareTeams error: %v", err)
+	}
+	if len(teams) != 1 {
+		t.Fatalf("expected 1 team, got %d", len(teams))
+	}
+	got := teams[0]
+	if got.ID != "team-1" || got.Name != "Equipo Azul" {
+		t.Fatalf("unexpected team %+v", got)
+	}
+	if got.OrgID == nil || *got.OrgID != "org-1" {
+		t.Fatalf("unexpected org id: %v", got.OrgID)
+	}
+	if got.OrgName == nil || *got.OrgName != "Org Uno" {
+		t.Fatalf("unexpected org name: %v", got.OrgName)
+	}
+	if diff := got.CreatedAt.Sub(createdAt); diff > time.Second || diff < -time.Second {
+		t.Fatalf("createdAt mismatch: got %v want %v", got.CreatedAt, createdAt)
+	}
+}
+
+func TestListCaregiverRelations(t *testing.T) {
+	started := time.Now().Add(-24 * time.Hour)
+	ended := started.Add(12 * time.Hour)
+	pool := &fakePool{
+		queryFn: func(ctx context.Context, query string, args ...any) (pgx.Rows, error) {
+			if !strings.Contains(query, "FROM caregiver_patient") {
+				t.Fatalf("unexpected query: %s", query)
+			}
+			if len(args) != 2 || args[0] != 20 || args[1] != 0 {
+				t.Fatalf("unexpected args: %#v", args)
+			}
+			rows := [][]any{{
+				"patient-1",
+				"Juan",
+				"user-9",
+				"María",
+				"maria@example.com",
+				"rel-1",
+				"parent",
+				"Padre/Madre",
+				true,
+				started,
+				ended,
+				"Contacto principal",
+			}}
+			return &fakeRows{data: rows}, nil
+		},
+	}
+	repo := NewRepoWithPool(pool, nil)
+
+	relations, err := repo.ListCaregiverRelations(context.Background(), 20, 0)
+	if err != nil {
+		t.Fatalf("ListCaregiverRelations error: %v", err)
+	}
+	if len(relations) != 1 {
+		t.Fatalf("expected 1 relation, got %d", len(relations))
+	}
+	rel := relations[0]
+	if rel.PatientID != "patient-1" || rel.CaregiverID != "user-9" {
+		t.Fatalf("unexpected relation IDs: %+v", rel)
+	}
+	if rel.PatientName != "Juan" || rel.CaregiverName != "María" {
+		t.Fatalf("unexpected names: %+v", rel)
+	}
+	if rel.RelationTypeID == nil || *rel.RelationTypeID != "rel-1" {
+		t.Fatalf("unexpected relation type: %v", rel.RelationTypeID)
+	}
+	if !rel.IsPrimary {
+		t.Fatalf("expected relation to be primary")
+	}
+	if rel.Note == nil || *rel.Note != "Contacto principal" {
+		t.Fatalf("unexpected note: %v", rel.Note)
+	}
+	if diff := rel.StartedAt.Sub(started); diff > time.Second || diff < -time.Second {
+		t.Fatalf("unexpected startedAt: %v", rel.StartedAt)
+	}
+	if rel.EndedAt == nil {
+		t.Fatalf("expected endedAt")
+	}
+	if diff := rel.EndedAt.Sub(ended); diff > time.Second || diff < -time.Second {
+		t.Fatalf("unexpected endedAt: %v", *rel.EndedAt)
+	}
+}

--- a/backend/templates/layout.html
+++ b/backend/templates/layout.html
@@ -34,8 +34,10 @@
 					<li><a href="/superadmin/roles">Roles</a></li>
 					<li><a href="/superadmin/content">Contenido</a></li>
 					<li><a href="/superadmin/content-block-types">Tipos de bloque</a></li>
-					<li><a href="/superadmin/patients">Pacientes</a></li>
-					<li><a href="/superadmin/devices">Dispositivos</a></li>
+                                        <li><a href="/superadmin/patients">Pacientes</a></li>
+                                        <li><a href="/superadmin/care-teams">Equipos de cuidado</a></li>
+                                        <li><a href="/superadmin/caregivers">Cuidadores</a></li>
+                                        <li><a href="/superadmin/devices">Dispositivos</a></li>
 					<li><a href="/superadmin/signal-streams">Streams de señal</a></li>
 					<li><a href="/superadmin/models">Modelos ML</a></li>
 					<li><a href="/superadmin/event-types">Eventos</a></li>

--- a/backend/templates/superadmin/care_teams.html
+++ b/backend/templates/superadmin/care_teams.html
@@ -1,0 +1,184 @@
+{{define "superadmin/care_teams.html"}} {{template "layout" .}} {{end}}
+{{define "superadmin/care_teams.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Equipos de cuidado</h1>
+        </div>
+        <div class="hg-card">
+                <h3>Registrar equipo</h3>
+                <form method="post" action="/superadmin/care-teams" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label for="team-name">Nombre</label>
+                                <input id="team-name" name="name" type="text" required placeholder="Nombre del equipo" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="team-org">Organización</label>
+                                <select id="team-org" name="org_id">
+                                        <option value="">Sin organización</option>
+                                        {{range .Data.Organizations}}
+                                        <option value="{{.ID}}">{{.Name}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Crear equipo</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-grid">
+                {{range .Data.Teams}}
+                {{$team := .Team}}
+                <div class="hg-card">
+                        <div class="hg-flex-between hg-card-header">
+                                <div>
+                                        <h3>{{$team.Name}}</h3>
+                                        <p class="hg-muted">{{if $team.OrgName}}{{$team.OrgName}}{{else}}Sin organización{{end}}</p>
+                                </div>
+                                <form method="post" action="/superadmin/care-teams/{{$team.ID}}/delete" data-hg-confirm="¿Eliminar equipo?" class="hg-inline-form">
+                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                </form>
+                        </div>
+
+                        <details class="hg-details">
+                                <summary>Editar equipo</summary>
+                                <form method="post" action="/superadmin/care-teams/{{$team.ID}}/update" class="hg-form-grid">
+                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                        <div class="hg-form-field">
+                                                <label>Nombre</label>
+                                                <input name="name" type="text" value="{{$team.Name}}" required />
+                                        </div>
+                                        <div class="hg-form-field">
+                                                <label>Organización</label>
+                                                <select name="org_id">
+                                                        <option value="">Sin organización</option>
+                                                        {{range $.Data.Organizations}}
+                                                        <option value="{{.ID}}" {{if eq .ID (stringValue $team.OrgID)}}selected{{end}}>{{.Name}}</option>
+                                                        {{end}}
+                                                </select>
+                                        </div>
+                                        <div class="hg-form-actions">
+                                                <button type="submit">Guardar cambios</button>
+                                        </div>
+                                </form>
+                        </details>
+
+                        <div class="hg-subsection">
+                                <h4>Miembros</h4>
+                                <form method="post" action="/superadmin/care-teams/{{$team.ID}}/members" class="hg-form-inline">
+                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                        <label>
+                                                Usuario
+                                                <select name="user_id" required>
+                                                        <option value="">Selecciona usuario</option>
+                                                        {{range $.Data.Users}}
+                                                        <option value="{{.ID}}">{{.Name}} · {{.Email}}</option>
+                                                        {{end}}
+                                                </select>
+                                        </label>
+                                        <label>
+                                                Rol en equipo
+                                                <input type="text" name="role_in_team" required placeholder="Coordinador, Enfermería..." />
+                                        </label>
+                                        <button type="submit">Agregar</button>
+                                </form>
+                                <table class="hg-table">
+                                        <thead>
+                                                <tr>
+                                                        <th>Miembro</th>
+                                                        <th>Email</th>
+                                                        <th>Rol</th>
+                                                        <th>Ingreso</th>
+                                                        <th></th>
+                                                </tr>
+                                        </thead>
+                                        <tbody>
+                                                {{range .Members}}
+                                                <tr>
+                                                        <td>{{.UserName}}</td>
+                                                        <td>{{.UserEmail}}</td>
+                                                        <td>{{.RoleInTeam}}</td>
+                                                        <td>{{formatTime .JoinedAt}}</td>
+                                                        <td class="hg-flex">
+                                                                <details>
+                                                                        <summary>Editar</summary>
+                                                                        <form method="post" action="/superadmin/care-teams/{{.CareTeamID}}/members/{{.UserID}}/update" class="hg-form-grid">
+                                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                                <div class="hg-form-field">
+                                                                                        <label>Rol</label>
+                                                                                        <input type="text" name="role_in_team" value="{{.RoleInTeam}}" required />
+                                                                                </div>
+                                                                                <div class="hg-form-actions">
+                                                                                        <button type="submit">Guardar</button>
+                                                                                </div>
+                                                                        </form>
+                                                                </details>
+                                                                <form method="post" action="/superadmin/care-teams/{{.CareTeamID}}/members/{{.UserID}}/delete" class="hg-inline-form" data-hg-confirm="¿Quitar miembro?">
+                                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                        <button type="submit" class="hg-link hg-link-danger">Quitar</button>
+                                                                </form>
+                                                        </td>
+                                                </tr>
+                                                {{else}}
+                                                <tr>
+                                                        <td colspan="5" class="hg-empty-cell">Sin miembros registrados.</td>
+                                                </tr>
+                                                {{end}}
+                                        </tbody>
+                                </table>
+                        </div>
+
+                        <div class="hg-subsection">
+                                <h4>Pacientes asignados</h4>
+                                <form method="post" action="/superadmin/care-teams/{{$team.ID}}/patients" class="hg-form-inline">
+                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                        <label>
+                                                Paciente
+                                                <select name="patient_id" required>
+                                                        <option value="">Selecciona paciente</option>
+                                                        {{range $.Data.Patients}}
+                                                        <option value="{{.ID}}">{{.Name}}</option>
+                                                        {{end}}
+                                                </select>
+                                        </label>
+                                        <button type="submit">Asignar</button>
+                                </form>
+                                <table class="hg-table">
+                                        <thead>
+                                                <tr>
+                                                        <th>Paciente</th>
+                                                        <th></th>
+                                                </tr>
+                                        </thead>
+                                        <tbody>
+                                                {{range .Patients}}
+                                                <tr>
+                                                        <td>{{.PatientName}}</td>
+                                                        <td class="hg-flex-end">
+                                                                <form method="post" action="/superadmin/care-teams/{{.CareTeamID}}/patients/{{.PatientID}}/delete" class="hg-inline-form" data-hg-confirm="¿Remover paciente?">
+                                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                        <button type="submit" class="hg-link">Quitar</button>
+                                                                </form>
+                                                        </td>
+                                                </tr>
+                                                {{else}}
+                                                <tr>
+                                                        <td colspan="2" class="hg-empty-cell">Sin pacientes asignados.</td>
+                                                </tr>
+                                                {{end}}
+                                        </tbody>
+                                </table>
+                        </div>
+                </div>
+                {{else}}
+                <div class="hg-card">
+                        <p class="hg-empty-cell">No hay equipos registrados.</p>
+                </div>
+                {{end}}
+        </div>
+</section>
+{{end}}

--- a/backend/templates/superadmin/caregivers.html
+++ b/backend/templates/superadmin/caregivers.html
@@ -1,0 +1,212 @@
+{{define "superadmin/caregivers.html"}} {{template "layout" .}} {{end}}
+{{define "superadmin/caregivers.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Cuidadores</h1>
+        </div>
+        <div class="hg-card">
+                <h3>Nuevo tipo de relación</h3>
+                <form method="post" action="/superadmin/caregivers/types" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label for="rel-code">Código</label>
+                                <input id="rel-code" name="code" type="text" required placeholder="Ej. parent" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="rel-label">Etiqueta</label>
+                                <input id="rel-label" name="label" type="text" required placeholder="Descripción visible" />
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Crear tipo</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Tipos registrados</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Código</th>
+                                        <th>Etiqueta</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Types}}
+                                <tr>
+                                        <td>{{.Code}}</td>
+                                        <td>{{.Label}}</td>
+                                        <td class="hg-flex">
+                                                <details>
+                                                        <summary>Editar</summary>
+                                                        <form method="post" action="/superadmin/caregivers/types/{{.ID}}/update" class="hg-form-grid">
+                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                <div class="hg-form-field">
+                                                                        <label>Código</label>
+                                                                        <input type="text" name="code" value="{{.Code}}" />
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Etiqueta</label>
+                                                                        <input type="text" name="label" value="{{.Label}}" />
+                                                                </div>
+                                                                <div class="hg-form-actions">
+                                                                        <button type="submit">Guardar</button>
+                                                                </div>
+                                                        </form>
+                                                </details>
+                                                <form method="post" action="/superadmin/caregivers/types/{{.ID}}/delete" class="hg-inline-form" data-hg-confirm="¿Eliminar tipo?">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="3" class="hg-empty-cell">Sin tipos de relación configurados.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Asignar cuidador</h3>
+                <form method="post" action="/superadmin/caregivers/assignments" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label>Paciente</label>
+                                <select name="patient_id" required>
+                                        <option value="">Selecciona paciente</option>
+                                        {{range .Data.Patients}}
+                                        <option value="{{.ID}}">{{.Name}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Cuidador</label>
+                                <select name="caregiver_id" required>
+                                        <option value="">Selecciona cuidador</option>
+                                        {{range .Data.Caregivers}}
+                                        <option value="{{.ID}}">{{.Name}} · {{.Email}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Tipo de relación</label>
+                                <select name="relation_type_id">
+                                        <option value="">Sin especificar</option>
+                                        {{range .Data.Types}}
+                                        <option value="{{.ID}}">{{.Label}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Fecha inicio</label>
+                                <input type="datetime-local" name="started_at" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Fecha término</label>
+                                <input type="datetime-local" name="ended_at" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Nota</label>
+                                <input type="text" name="note" placeholder="Notas internas" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label class="hg-checkbox">
+                                        <input type="checkbox" name="is_primary" />
+                                        Principal
+                                </label>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Crear asignación</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Asignaciones activas</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Paciente</th>
+                                        <th>Cuidador</th>
+                                        <th>Tipo</th>
+                                        <th>Principal</th>
+                                        <th>Inicio</th>
+                                        <th>Fin</th>
+                                        <th>Nota</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                {{range .Data.Assignments}}
+                {{$rel := .}}
+                <tr>
+                        <td>{{$rel.PatientName}}</td>
+                        <td>{{$rel.CaregiverName}} · {{$rel.CaregiverEmail}}</td>
+                        <td>{{if $rel.RelationTypeLabel}}{{$rel.RelationTypeLabel}}{{else}}—{{end}}</td>
+                        <td>{{if $rel.IsPrimary}}Sí{{else}}No{{end}}</td>
+                        <td>{{formatTime $rel.StartedAt}}</td>
+                        <td>{{formatTimePtr $rel.EndedAt}}</td>
+                        <td>{{stringValue $rel.Note}}</td>
+                        <td class="hg-flex">
+                                <details>
+                                        <summary>Editar</summary>
+                                        <form method="post" action="/superadmin/caregivers/assignments/{{$rel.PatientID}}/{{$rel.CaregiverID}}/update" class="hg-form-grid">
+                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                <div class="hg-form-field">
+                                                        <label>Tipo de relación</label>
+                                                        <select name="relation_type_id">
+                                                                <option value="">Sin especificar</option>
+                                                                {{range $.Data.Types}}
+                                                                <option value="{{.ID}}" {{if eq .ID (stringValue $rel.RelationTypeID)}}selected{{end}}>{{.Label}}</option>
+                                                                {{end}}
+                                                        </select>
+                                                </div>
+                                                <div class="hg-form-field">
+                                                        <label>Fecha inicio</label>
+                                                        <input type="datetime-local" name="started_at" value="{{formatTimeLocal $rel.StartedAt}}" />
+                                                </div>
+                                                <div class="hg-form-field">
+                                                        <label>Fecha término</label>
+                                                        <input type="datetime-local" name="ended_at" value="{{formatTimeLocalPtr $rel.EndedAt}}" />
+                                                </div>
+                                                <div class="hg-form-field">
+                                                        <label>Nota</label>
+                                                        <input type="text" name="note" value="{{stringValue $rel.Note}}" />
+                                                </div>
+                                                <div class="hg-form-field">
+                                                        <label class="hg-checkbox">
+                                                                <input type="checkbox" name="is_primary" {{if $rel.IsPrimary}}checked{{end}} />
+                                                                Principal
+                                                        </label>
+                                                </div>
+                                                <div class="hg-form-actions">
+                                                        <button type="submit">Guardar</button>
+                                                </div>
+                                        </form>
+                                </details>
+                                <form method="post" action="/superadmin/caregivers/assignments/{{$rel.PatientID}}/{{$rel.CaregiverID}}/delete" class="hg-inline-form" data-hg-confirm="¿Eliminar asignación?">
+                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                </form>
+                        </td>
+                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="8" class="hg-empty-cell">Sin asignaciones registradas.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+{{end}}


### PR DESCRIPTION
## Summary
- add care team and caregiver domain models and repository CRUD helpers
- expose REST endpoints and UI handlers for care team, member, patient, and caregiver management
- build new superadmin templates and navigation for care teams and caregivers with validation and flash messaging
- cover repository list flows with targeted unit tests

## Testing
- (cd backend && go test ./...)

------
https://chatgpt.com/codex/tasks/task_e_68e9e6436350832f8afadce9a715a5ba