### PR TITLE
Add patient and user location management

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -70,8 +70,15 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 		s.Route("/patients", func(pr chi.Router) {
 			pr.Get("/", uiHandlers.PatientsIndex)
 			pr.Post("/", uiHandlers.PatientsCreate)
-			pr.Post("/{id}/update", uiHandlers.PatientsUpdate)
-			pr.Post("/{id}/delete", uiHandlers.PatientsDelete)
+			pr.Route("/{id}", func(pir chi.Router) {
+				pir.Post("/update", uiHandlers.PatientsUpdate)
+				pir.Post("/delete", uiHandlers.PatientsDelete)
+				pir.Route("/locations", func(lr chi.Router) {
+					lr.Get("/", uiHandlers.PatientLocationsIndex)
+					lr.Post("/", uiHandlers.PatientLocationsCreate)
+					lr.Post("/{locationID}/delete", uiHandlers.PatientLocationsDelete)
+				})
+			})
 		})
 
 		s.Route("/devices", func(dr chi.Router) {
@@ -124,7 +131,14 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 
 		s.Route("/users", func(ur chi.Router) {
 			ur.Get("/", uiHandlers.UsersIndex)
-			ur.Post("/{id}/status", uiHandlers.UsersUpdateStatus)
+			ur.Route("/{id}", func(usr chi.Router) {
+				usr.Post("/status", uiHandlers.UsersUpdateStatus)
+				usr.Route("/locations", func(lr chi.Router) {
+					lr.Get("/", uiHandlers.UserLocationsIndex)
+					lr.Post("/", uiHandlers.UserLocationsCreate)
+					lr.Post("/{locationID}/delete", uiHandlers.UserLocationsDelete)
+				})
+			})
 		})
 
 		s.Route("/roles", func(rr chi.Router) {

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -116,16 +116,57 @@ type Patient struct {
 }
 
 type PatientInput struct {
-	OrgID     *string    `json:"org_id,omitempty"`
-	Name      string     `json:"name"`
-	Birthdate *time.Time `json:"birthdate,omitempty"`
-	SexCode   *string    `json:"sex_code,omitempty"`
-	RiskLevel *string    `json:"risk_level,omitempty"`
+        OrgID     *string    `json:"org_id,omitempty"`
+        Name      string     `json:"name"`
+        Birthdate *time.Time `json:"birthdate,omitempty"`
+        SexCode   *string    `json:"sex_code,omitempty"`
+        RiskLevel *string    `json:"risk_level,omitempty"`
+}
+
+type LocationInput struct {
+        Timestamp      *time.Time `json:"timestamp,omitempty"`
+        Latitude       *float64   `json:"latitude,omitempty"`
+        Longitude      *float64   `json:"longitude,omitempty"`
+        WKT            *string    `json:"wkt,omitempty"`
+        WKB            []byte     `json:"-"`
+        Source         *string    `json:"source,omitempty"`
+        AccuracyMeters *float64   `json:"accuracy_meters,omitempty"`
+}
+
+type PatientLocationInput = LocationInput
+
+type UserLocationInput = LocationInput
+
+type PatientLocation struct {
+        ID             string     `json:"id"`
+        PatientID      string     `json:"patient_id"`
+        PatientName    *string    `json:"patient_name,omitempty"`
+        Timestamp      time.Time  `json:"timestamp"`
+        Latitude       float64    `json:"latitude"`
+        Longitude      float64    `json:"longitude"`
+        WKT            string     `json:"wkt"`
+        WKBHex         string     `json:"wkb_hex"`
+        Source         *string    `json:"source,omitempty"`
+        AccuracyMeters *float64   `json:"accuracy_meters,omitempty"`
+}
+
+type UserLocation struct {
+        ID             string     `json:"id"`
+        UserID         string     `json:"user_id"`
+        UserName       *string    `json:"user_name,omitempty"`
+        UserEmail      *string    `json:"user_email,omitempty"`
+        Timestamp      time.Time  `json:"timestamp"`
+        Latitude       float64    `json:"latitude"`
+        Longitude      float64    `json:"longitude"`
+        WKT            string     `json:"wkt"`
+        WKBHex         string     `json:"wkb_hex"`
+        Source         *string    `json:"source,omitempty"`
+        AccuracyMeters *float64   `json:"accuracy_meters,omitempty"`
 }
 
 type Device struct {
-	ID               string    `json:"id"`
-	OrgID            *string   `json:"org_id,omitempty"`
+        ID               string    `json:"id"`
+        OrgID            *string   `json:"org_id,omitempty"`
 	OrgName          *string   `json:"org_name,omitempty"`
 	Serial           string    `json:"serial"`
 	Brand            *string   `json:"brand,omitempty"`

--- a/backend/internal/superadmin/geometry_helpers.go
+++ b/backend/internal/superadmin/geometry_helpers.go
@@ -1,0 +1,40 @@
+package superadmin
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+func decodeWKBHex(raw string) ([]byte, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	trimmed = strings.TrimPrefix(trimmed, "0x")
+	trimmed = strings.TrimPrefix(trimmed, "0X")
+	trimmed = strings.TrimPrefix(trimmed, "\\x")
+	trimmed = strings.TrimPrefix(trimmed, "\\X")
+
+	var builder strings.Builder
+	builder.Grow(len(trimmed))
+	for _, r := range trimmed {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		builder.WriteRune(r)
+	}
+	normalized := builder.String()
+	if normalized == "" {
+		return nil, nil
+	}
+	if len(normalized)%2 != 0 {
+		return nil, fmt.Errorf("invalid hex length")
+	}
+	data, err := hex.DecodeString(normalized)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/backend/internal/ui/renderer.go
+++ b/backend/internal/ui/renderer.go
@@ -81,6 +81,16 @@ func NewRenderer() (*Renderer, error) {
 			}
 			return strconv.FormatFloat(float64(*v), 'f', 4, 32)
 		},
+		"formatFloat64": func(v *float64, precision int) string {
+			if v == nil {
+				return ""
+			}
+			prec := precision
+			if prec < 0 {
+				prec = 2
+			}
+			return strconv.FormatFloat(*v, 'f', prec, 64)
+		},
 		"stringValue": func(ptr *string) string {
 			if ptr == nil {
 				return ""

--- a/backend/templates/superadmin/patient_locations.html
+++ b/backend/templates/superadmin/patient_locations.html
@@ -1,0 +1,112 @@
+{{define "superadmin/patient_locations.html"}} {{template "layout" .}} {{end}}
+{{define "superadmin/patient_locations.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Ubicaciones de {{.Data.Patient.Name}}</h1>
+        </div>
+        <div class="hg-tabs">
+                <a href="/superadmin/patients">Pacientes</a>
+                <a class="active" href="/superadmin/patients/{{.Data.Patient.ID}}/locations">Ubicaciones</a>
+        </div>
+</section>
+
+<section class="hg-section hg-grid">
+        <div class="hg-card">
+                <h3>Resumen del paciente</h3>
+                <ul class="hg-list-compact">
+                        <li><strong>Organización:</strong> {{if .Data.Patient.OrgName}}{{.Data.Patient.OrgName}}{{else}}—{{end}}</li>
+                        <li><strong>Riesgo:</strong> {{if .Data.Patient.RiskLevel}}{{.Data.Patient.RiskLevel}}{{else}}—{{end}}</li>
+                        <li><strong>Sexo:</strong> {{if .Data.Patient.SexLabel}}{{.Data.Patient.SexLabel}}{{else}}—{{end}}</li>
+                        <li><strong>Nacimiento:</strong> {{formatDatePtr .Data.Patient.Birthdate}}</li>
+                        <li><strong>Creado:</strong> {{formatTime .Data.Patient.CreatedAt}}</li>
+                </ul>
+        </div>
+        <div class="hg-card">
+                <h3>Registrar ubicación</h3>
+                <form method="post" action="/superadmin/patients/{{.Data.Patient.ID}}/locations" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label for="location-timestamp">Fecha y hora</label>
+                                <input id="location-timestamp" name="timestamp" type="datetime-local" />
+                                <span class="hg-field-hint">Si se omite, se usará la hora actual.</span>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="location-lat">Latitud</label>
+                                <input id="location-lat" name="latitude" type="number" step="any" placeholder="19.4326" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="location-lon">Longitud</label>
+                                <input id="location-lon" name="longitude" type="number" step="any" placeholder="-99.1332" />
+                        </div>
+                        <div class="hg-form-field hg-form-field--full">
+                                <label for="location-wkt">WKT</label>
+                                <textarea id="location-wkt" name="wkt" rows="2" placeholder="POINT(-99.1332 19.4326)"></textarea>
+                        </div>
+                        <div class="hg-form-field hg-form-field--full">
+                                <label for="location-wkb">WKB (hex)</label>
+                                <textarea id="location-wkb" name="wkb_hex" rows="2" placeholder="0101000020E6100000..."></textarea>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="location-source">Fuente</label>
+                                <input id="location-source" name="source" type="text" placeholder="GPS, estimación, etc." />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="location-accuracy">Precisión (m)</label>
+                                <input id="location-accuracy" name="accuracy" type="number" step="0.1" min="0" placeholder="5" />
+                        </div>
+                        <div class="hg-form-field hg-form-field--plain hg-form-field--full">
+                                <p class="hg-field-hint">Formatos admitidos:</p>
+                                <ul class="hg-list-compact">
+                                        {{range .Data.FormatHelp}}
+                                        <li>{{.}}</li>
+                                        {{end}}
+                                </ul>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Guardar ubicación</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Historial de ubicaciones</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Fecha</th>
+                                        <th>Coordenadas</th>
+                                        <th>Fuente</th>
+                                        <th>Precisión</th>
+                                        <th>WKT</th>
+                                        <th>WKB</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Locations}}
+                                <tr>
+                                        <td>{{formatTime .Timestamp}}</td>
+                                        <td>{{printf "%.6f, %.6f" .Latitude .Longitude}}</td>
+                                        <td>{{if .Source}}{{.Source}}{{else}}—{{end}}</td>
+                                        <td>{{if .AccuracyMeters}}{{formatFloat64 .AccuracyMeters 2}} m{{else}}—{{end}}</td>
+                                        <td><code style="word-break: break-word;">{{.WKT}}</code></td>
+                                        <td><code style="word-break: break-word;">{{.WKBHex}}</code></td>
+                                        <td>
+                                                <form method="post" action="/superadmin/patients/{{$.Data.Patient.ID}}/locations/{{.ID}}/delete" class="hg-inline-form" data-hg-confirm="¿Eliminar ubicación?">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="7" class="hg-empty-cell">Sin ubicaciones registradas.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+{{end}}

--- a/backend/templates/superadmin/patients.html
+++ b/backend/templates/superadmin/patients.html
@@ -59,65 +59,68 @@
 					<th></th>
 				</tr>
 			</thead>
-			<tbody>
-				{{range .Data.Items}}
-				{{$patient := .}}
-				<tr>
-					<td>{{$patient.Name}}</td>
-					<td>{{if $patient.OrgName}}{{$patient.OrgName}}{{else}}—{{end}}</td>
-					<td>{{if $patient.SexLabel}}{{$patient.SexLabel}}{{else}}—{{end}}</td>
-					<td>{{if ne (stringValue $patient.RiskLevel) ""}}{{stringValue $patient.RiskLevel}}{{else}}—{{end}}</td>
-					<td>{{formatDatePtr $patient.Birthdate}}</td>
-					<td>{{formatTime $patient.CreatedAt}}</td>
-					<td class="hg-flex">
-						<details>
-							<summary>Editar</summary>
-							<form method="post" action="/superadmin/patients/{{$patient.ID}}/update" class="hg-form-grid">
-								<input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
-								<div class="hg-form-field">
-									<label>Nombre</label>
-									<input name="name" type="text" value="{{$patient.Name}}" required />
-								</div>
-								<div class="hg-form-field">
-									<label>Organización</label>
-									<select name="org_id">
-										<option value="">Sin organización</option>
-										{{range $.Data.Organizations}}
-										<option value="{{.ID}}" {{if eq .ID (stringValue $patient.OrgID)}}selected{{end}}>{{.Name}}</option>
-										{{end}}
-									</select>
-								</div>
-								<div class="hg-form-field">
-									<label>Fecha de nacimiento</label>
-									<input name="birthdate" type="date" value="{{formatDatePtr $patient.Birthdate}}" />
-								</div>
-								<div class="hg-form-field">
-									<label>Sexo</label>
-									<select name="sex_code">
-										<option value="">Sin especificar</option>
-										{{range $.Data.Sexes}}
-										<option value="{{.Code}}" {{if eq .Code (stringValue $patient.SexCode)}}selected{{end}}>{{.Label}}</option>
-										{{end}}
-									</select>
-								</div>
-								<div class="hg-form-field">
-									<label>Riesgo</label>
-									<input name="risk_level" type="text" value="{{stringValue $patient.RiskLevel}}" />
-								</div>
-								<div class="hg-form-actions">
-									<button type="submit">Guardar</button>
-								</div>
-							</form>
-						</details>
-						<form method="post" action="/superadmin/patients/{{$patient.ID}}/delete" data-hg-confirm="¿Eliminar paciente?" class="hg-inline-form">
-							<input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
-							<button type="submit" class="hg-link hg-link-danger">Eliminar</button>
-						</form>
-					</td>
-				</tr>
-				{{else}}
-				<tr>
-					<td colspan="7" class="hg-empty-cell">Sin pacientes registrados.</td>
+                <tbody>
+                        {{range .Data.Items}}
+                        {{$patient := .}}
+                        <tr>
+                                <td>{{$patient.Name}}</td>
+                                <td>{{if $patient.OrgName}}{{$patient.OrgName}}{{else}}—{{end}}</td>
+                                <td>{{if $patient.SexLabel}}{{$patient.SexLabel}}{{else}}—{{end}}</td>
+                                <td>{{if ne (stringValue $patient.RiskLevel) ""}}{{stringValue $patient.RiskLevel}}{{else}}—{{end}}</td>
+                                <td>{{formatDatePtr $patient.Birthdate}}</td>
+                                <td>{{formatTime $patient.CreatedAt}}</td>
+                                <td>
+                                        <div class="hg-flex hg-gap">
+                                                <a class="hg-link" href="/superadmin/patients/{{$patient.ID}}/locations">Ubicaciones</a>
+                                                <details>
+                                                        <summary>Editar</summary>
+                                                        <form method="post" action="/superadmin/patients/{{$patient.ID}}/update" class="hg-form-grid">
+                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                <div class="hg-form-field">
+                                                                        <label>Nombre</label>
+                                                                        <input name="name" type="text" value="{{$patient.Name}}" required />
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Organización</label>
+                                                                        <select name="org_id">
+                                                                                <option value="">Sin organización</option>
+                                                                                {{range $.Data.Organizations}}
+                                                                                <option value="{{.ID}}" {{if eq .ID (stringValue $patient.OrgID)}}selected{{end}}>{{.Name}}</option>
+                                                                                {{end}}
+                                                                        </select>
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Fecha de nacimiento</label>
+                                                                        <input name="birthdate" type="date" value="{{formatDatePtr $patient.Birthdate}}" />
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Sexo</label>
+                                                                        <select name="sex_code">
+                                                                                <option value="">Sin especificar</option>
+                                                                                {{range $.Data.Sexes}}
+                                                                                <option value="{{.Code}}" {{if eq .Code (stringValue $patient.SexCode)}}selected{{end}}>{{.Label}}</option>
+                                                                                {{end}}
+                                                                        </select>
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Riesgo</label>
+                                                                        <input name="risk_level" type="text" value="{{stringValue $patient.RiskLevel}}" />
+                                                                </div>
+                                                                <div class="hg-form-actions">
+                                                                        <button type="submit">Guardar</button>
+                                                                </div>
+                                                        </form>
+                                                </details>
+                                                <form method="post" action="/superadmin/patients/{{$patient.ID}}/delete" data-hg-confirm="¿Eliminar paciente?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </div>
+                                </td>
+                        </tr>
+                        {{else}}
+                        <tr>
+                                <td colspan="7" class="hg-empty-cell">Sin pacientes registrados.</td>
 				</tr>
 				{{end}}
 			</tbody>

--- a/backend/templates/superadmin/user_locations.html
+++ b/backend/templates/superadmin/user_locations.html
@@ -1,0 +1,110 @@
+{{define "superadmin/user_locations.html"}} {{template "layout" .}} {{end}}
+{{define "superadmin/user_locations.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Ubicaciones de {{.Data.User.Name}}</h1>
+        </div>
+        <div class="hg-tabs">
+                <a href="/superadmin/users">Usuarios</a>
+                <a class="active" href="/superadmin/users/{{.Data.User.ID}}/locations">Ubicaciones</a>
+        </div>
+</section>
+
+<section class="hg-section hg-grid">
+        <div class="hg-card">
+                <h3>Resumen del usuario</h3>
+                <ul class="hg-list-compact">
+                        <li><strong>Correo:</strong> {{.Data.User.Email}}</li>
+                        <li><strong>Estado:</strong> {{.Data.User.Status}}</li>
+                        <li><strong>Creado:</strong> {{formatTime .Data.User.CreatedAt}}</li>
+                </ul>
+        </div>
+        <div class="hg-card">
+                <h3>Registrar ubicación</h3>
+                <form method="post" action="/superadmin/users/{{.Data.User.ID}}/locations" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label for="user-location-timestamp">Fecha y hora</label>
+                                <input id="user-location-timestamp" name="timestamp" type="datetime-local" />
+                                <span class="hg-field-hint">Si se omite, se usará la hora actual.</span>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-location-lat">Latitud</label>
+                                <input id="user-location-lat" name="latitude" type="number" step="any" placeholder="19.4326" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-location-lon">Longitud</label>
+                                <input id="user-location-lon" name="longitude" type="number" step="any" placeholder="-99.1332" />
+                        </div>
+                        <div class="hg-form-field hg-form-field--full">
+                                <label for="user-location-wkt">WKT</label>
+                                <textarea id="user-location-wkt" name="wkt" rows="2" placeholder="POINT(-99.1332 19.4326)"></textarea>
+                        </div>
+                        <div class="hg-form-field hg-form-field--full">
+                                <label for="user-location-wkb">WKB (hex)</label>
+                                <textarea id="user-location-wkb" name="wkb_hex" rows="2" placeholder="0101000020E6100000..."></textarea>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-location-source">Fuente</label>
+                                <input id="user-location-source" name="source" type="text" placeholder="GPS, manual, etc." />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-location-accuracy">Precisión (m)</label>
+                                <input id="user-location-accuracy" name="accuracy" type="number" step="0.1" min="0" placeholder="5" />
+                        </div>
+                        <div class="hg-form-field hg-form-field--plain hg-form-field--full">
+                                <p class="hg-field-hint">Formatos admitidos:</p>
+                                <ul class="hg-list-compact">
+                                        {{range .Data.FormatHelp}}
+                                        <li>{{.}}</li>
+                                        {{end}}
+                                </ul>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Guardar ubicación</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Historial de ubicaciones</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Fecha</th>
+                                        <th>Coordenadas</th>
+                                        <th>Fuente</th>
+                                        <th>Precisión</th>
+                                        <th>WKT</th>
+                                        <th>WKB</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Locations}}
+                                <tr>
+                                        <td>{{formatTime .Timestamp}}</td>
+                                        <td>{{printf "%.6f, %.6f" .Latitude .Longitude}}</td>
+                                        <td>{{if .Source}}{{.Source}}{{else}}—{{end}}</td>
+                                        <td>{{if .AccuracyMeters}}{{formatFloat64 .AccuracyMeters 2}} m{{else}}—{{end}}</td>
+                                        <td><code style="word-break: break-word;">{{.WKT}}</code></td>
+                                        <td><code style="word-break: break-word;">{{.WKBHex}}</code></td>
+                                        <td>
+                                                <form method="post" action="/superadmin/users/{{$.Data.User.ID}}/locations/{{.ID}}/delete" class="hg-inline-form" data-hg-confirm="¿Eliminar ubicación?">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="7" class="hg-empty-cell">Sin ubicaciones registradas.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+{{end}}

--- a/backend/templates/superadmin/users.html
+++ b/backend/templates/superadmin/users.html
@@ -19,23 +19,24 @@
 
 <section class="hg-section">
 	<table class="hg-table">
-		<thead>
-			<tr>
-				<th>Nombre</th>
-				<th>Correo</th>
-				<th>Estado</th>
-				<th>Miembros</th>
-				<th>Roles actuales</th>
-				<th>Asignar rol</th>
-				<th>Creado</th>
-				<th>Cambiar estado</th>
-			</tr>
-		</thead>
-		<tbody>
-			{{range .Data.Users}} {{$user := .}}
-			<tr>
-				<td>{{.Name}}</td>
-				<td>{{.Email}}</td>
+                <thead>
+                        <tr>
+                                <th>Nombre</th>
+                                <th>Correo</th>
+                                <th>Estado</th>
+                                <th>Miembros</th>
+                                <th>Roles actuales</th>
+                                <th>Ubicaciones</th>
+                                <th>Asignar rol</th>
+                                <th>Creado</th>
+                                <th>Cambiar estado</th>
+                        </tr>
+                </thead>
+                <tbody>
+                        {{range .Data.Users}} {{$user := .}}
+                        <tr>
+                                <td>{{.Name}}</td>
+                                <td>{{.Email}}</td>
 				<td>
 					<span class="hg-status-chip {{if eq .Status "active"}}is-success{{else if eq .Status "blocked"}}is-danger{{else}}is-warn{{end}}">
 						{{if eq .Status "active"}}Activo{{else if eq .Status "blocked"}}Bloqueado{{else if eq .Status "pending"}}Pendiente{{else}}{{.Status}}{{end}}
@@ -59,25 +60,28 @@
 					</div>
 					{{else}}—{{end}}
 				</td>
-				<td>
-					<form method="post" action="/superadmin/roles/users/{{.ID}}" class="hg-autoform">
-						<input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
-						<input type="hidden" name="redirect" value="{{if $.Data.Query}}/superadmin/users?q={{urlquery $.Data.Query}}{{else}}/superadmin/users{{end}}" />
-						<select name="role_id" class="hg-role-select">
-							<option value="" {{if eq (len $user.Roles) 0}}selected{{end}}>Sin rol asignado</option>
+                                <td>
+                                        <a class="hg-link" href="/superadmin/users/{{.ID}}/locations">Ver ubicaciones</a>
+                                </td>
+                                <td>
+                                        <form method="post" action="/superadmin/roles/users/{{.ID}}" class="hg-autoform">
+                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                <input type="hidden" name="redirect" value="{{if $.Data.Query}}/superadmin/users?q={{urlquery $.Data.Query}}{{else}}/superadmin/users{{end}}" />
+                                                <select name="role_id" class="hg-role-select">
+                                                        <option value="" {{if eq (len $user.Roles) 0}}selected{{end}}>Sin rol asignado</option>
 							{{range $role := $.Data.Roles}}
 							<option value="{{$role.ID}}"{{range $user.Roles}}{{if eq .RoleID $role.ID}} selected{{end}}{{end}}>{{$role.Name}}</option>
 							{{end}}
 						</select>
 					</form>
 				</td>
-				<td>{{formatTime .CreatedAt}}</td>
-				<td>
-					<form method="post" action="/superadmin/users/{{.ID}}/status" class="hg-form-inline hg-autoform">
-						<input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
-						<input type="hidden" name="redirect" value="{{if $.Data.Query}}/superadmin/users?q={{urlquery $.Data.Query}}{{else}}/superadmin/users{{end}}" />
-						<select name="status">
-							{{range $.Data.Status}}
+                                <td>{{formatTime .CreatedAt}}</td>
+                                <td>
+                                        <form method="post" action="/superadmin/users/{{.ID}}/status" class="hg-form-inline hg-autoform">
+                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                <input type="hidden" name="redirect" value="{{if $.Data.Query}}/superadmin/users?q={{urlquery $.Data.Query}}{{else}}/superadmin/users{{end}}" />
+                                                <select name="status">
+                                                        {{range $.Data.Status}}
 							<option value="{{.Code}}" {{if eq .Code $user.Status}}selected{{end}}>{{.Label}}</option>
 							{{end}}
 						</select>
@@ -85,11 +89,11 @@
 				</td>
 			</tr>
 			{{else}}
-			<tr>
-				<td colspan="8" class="hg-empty-cell">No se encontraron usuarios.</td>
-			</tr>
-			{{end}}
-		</tbody>
-	</table>
+                        <tr>
+                                <td colspan="9" class="hg-empty-cell">No se encontraron usuarios.</td>
+                        </tr>
+                        {{end}}
+                </tbody>
+        </table>
 </section>
 {{end}}


### PR DESCRIPTION
## Summary
- add shared location DTOs for patients and users along with geometry helpers
- implement repository and handler flows for managing patient and user locations in the API and UI
- introduce dedicated superadmin pages and navigation links for viewing and recording locations

## Testing
- not run (requires PostGIS-backed database for integration tests)


------
https://chatgpt.com/codex/tasks/task_e_68e9e64c6f48832fb4f9ff4431933b40