### PR TITLE
Add care team and caregiver management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+-   Gestión de equipos de cuidado, miembros y cuidadores desde el panel superadmin (API y vistas).
+
 ### Changed
 
 -   Backend HTTP server ahora acepta únicamente conexiones desde localhost, bloqueando cualquier acceso remoto.

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -74,6 +74,28 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 			pr.Post("/{id}/delete", uiHandlers.PatientsDelete)
 		})
 
+		s.Route("/care-teams", func(ct chi.Router) {
+			ct.Get("/", uiHandlers.CareTeamsIndex)
+			ct.Post("/", uiHandlers.CareTeamsCreate)
+			ct.Post("/{id}/update", uiHandlers.CareTeamsUpdate)
+			ct.Post("/{id}/delete", uiHandlers.CareTeamsDelete)
+			ct.Post("/{id}/members", uiHandlers.CareTeamMembersAdd)
+			ct.Post("/{id}/members/{userID}/update", uiHandlers.CareTeamMembersUpdate)
+			ct.Post("/{id}/members/{userID}/delete", uiHandlers.CareTeamMembersDelete)
+			ct.Post("/{id}/patients", uiHandlers.CareTeamPatientsAdd)
+			ct.Post("/{id}/patients/{patientID}/delete", uiHandlers.CareTeamPatientsDelete)
+		})
+
+		s.Route("/caregivers", func(cr chi.Router) {
+			cr.Get("/", uiHandlers.CaregiversIndex)
+			cr.Post("/assignments", uiHandlers.CaregiversAssignmentsCreate)
+			cr.Post("/assignments/{patientID}/{caregiverID}/update", uiHandlers.CaregiversAssignmentsUpdate)
+			cr.Post("/assignments/{patientID}/{caregiverID}/delete", uiHandlers.CaregiversAssignmentsDelete)
+			cr.Post("/relationship-types", uiHandlers.CaregiversRelationshipTypeCreate)
+			cr.Post("/relationship-types/{id}/update", uiHandlers.CaregiversRelationshipTypeUpdate)
+			cr.Post("/relationship-types/{id}/delete", uiHandlers.CaregiversRelationshipTypeDelete)
+		})
+
 		s.Route("/ground-truth", func(gr chi.Router) {
 			gr.Get("/", uiHandlers.GroundTruthIndex)
 			gr.Post("/", uiHandlers.GroundTruthCreate)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -123,6 +123,100 @@ type PatientInput struct {
 	RiskLevel *string    `json:"risk_level,omitempty"`
 }
 
+type CareTeam struct {
+	ID        string    `json:"id"`
+	OrgID     *string   `json:"org_id,omitempty"`
+	OrgName   *string   `json:"org_name,omitempty"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type CareTeamInput struct {
+	OrgID *string `json:"org_id,omitempty"`
+	Name  string  `json:"name"`
+}
+
+type CareTeamUpdateInput struct {
+	OrgID *string `json:"org_id,omitempty"`
+	Name  *string `json:"name,omitempty"`
+}
+
+type CareTeamMember struct {
+	CareTeamID   string    `json:"care_team_id"`
+	CareTeamName string    `json:"care_team_name"`
+	UserID       string    `json:"user_id"`
+	UserName     string    `json:"user_name"`
+	UserEmail    string    `json:"user_email"`
+	RoleInTeam   string    `json:"role_in_team"`
+	JoinedAt     time.Time `json:"joined_at"`
+}
+
+type CareTeamMemberInput struct {
+	UserID     string `json:"user_id"`
+	RoleInTeam string `json:"role_in_team"`
+}
+
+type CareTeamMemberUpdateInput struct {
+	RoleInTeam *string `json:"role_in_team,omitempty"`
+}
+
+type PatientCareTeamLink struct {
+	CareTeamID   string `json:"care_team_id"`
+	CareTeamName string `json:"care_team_name"`
+	PatientID    string `json:"patient_id"`
+	PatientName  string `json:"patient_name"`
+}
+
+type CaregiverRelationshipType struct {
+	ID    string `json:"id"`
+	Code  string `json:"code"`
+	Label string `json:"label"`
+}
+
+type CaregiverRelationshipTypeInput struct {
+	Code  string `json:"code"`
+	Label string `json:"label"`
+}
+
+type CaregiverRelationshipTypeUpdateInput struct {
+	Code  *string `json:"code,omitempty"`
+	Label *string `json:"label,omitempty"`
+}
+
+type CaregiverAssignment struct {
+	PatientID             string     `json:"patient_id"`
+	PatientName           string     `json:"patient_name"`
+	CaregiverID           string     `json:"caregiver_id"`
+	CaregiverName         string     `json:"caregiver_name"`
+	CaregiverEmail        string     `json:"caregiver_email"`
+	RelationshipTypeID    *string    `json:"relationship_type_id,omitempty"`
+	RelationshipTypeCode  *string    `json:"relationship_type_code,omitempty"`
+	RelationshipTypeLabel *string    `json:"relationship_type_label,omitempty"`
+	IsPrimary             bool       `json:"is_primary"`
+	StartedAt             time.Time  `json:"started_at"`
+	EndedAt               *time.Time `json:"ended_at,omitempty"`
+	Note                  *string    `json:"note,omitempty"`
+}
+
+type CaregiverAssignmentInput struct {
+	PatientID          string     `json:"patient_id"`
+	CaregiverID        string     `json:"caregiver_id"`
+	RelationshipTypeID *string    `json:"relationship_type_id,omitempty"`
+	IsPrimary          *bool      `json:"is_primary,omitempty"`
+	StartedAt          *time.Time `json:"started_at,omitempty"`
+	EndedAt            *time.Time `json:"ended_at,omitempty"`
+	Note               *string    `json:"note,omitempty"`
+}
+
+type CaregiverAssignmentUpdateInput struct {
+	RelationshipTypeID *string    `json:"relationship_type_id,omitempty"`
+	IsPrimary          *bool      `json:"is_primary,omitempty"`
+	StartedAt          *time.Time `json:"started_at,omitempty"`
+	EndedAt            *time.Time `json:"ended_at,omitempty"`
+	Note               *string    `json:"note,omitempty"`
+	ClearEndedAt       bool       `json:"clear_ended_at"`
+}
+
 type Device struct {
 	ID               string    `json:"id"`
 	OrgID            *string   `json:"org_id,omitempty"`

--- a/backend/internal/superadmin/repo_care_teams_test.go
+++ b/backend/internal/superadmin/repo_care_teams_test.go
@@ -1,0 +1,126 @@
+package superadmin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"heartguard-superadmin/internal/models"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestRepoUpdateCareTeamParams(t *testing.T) {
+	pool := &stubPool{}
+	now := time.Now()
+	pool.queryRow = func(ctx context.Context, sql string, args ...any) pgx.Row {
+		if len(args) != 4 {
+			t.Fatalf("expected 4 args, got %d", len(args))
+		}
+		if args[0] != "team-1" {
+			t.Fatalf("unexpected id arg: %v", args[0])
+		}
+		if args[1] != "org-1" {
+			t.Fatalf("unexpected org arg: %v", args[1])
+		}
+		if flag, ok := args[2].(bool); !ok || flag {
+			t.Fatalf("expected clearOrg false, got %v", args[2])
+		}
+		if name, ok := args[3].(*string); !ok || *name != "Equipo" {
+			t.Fatalf("unexpected name arg: %v", args[3])
+		}
+		return mockRow{values: []any{"team-1", "org-1", "Org", "Equipo", now}}
+	}
+	repo := NewRepoWithPool(pool, nil)
+	name := "Equipo"
+	org := "org-1"
+	team, err := repo.UpdateCareTeam(context.Background(), "team-1", models.CareTeamUpdateInput{OrgID: &org, Name: &name})
+	if err != nil {
+		t.Fatalf("UpdateCareTeam: %v", err)
+	}
+	if team.OrgName == nil || *team.OrgName != "Org" {
+		t.Fatalf("expected org name 'Org', got %#v", team.OrgName)
+	}
+}
+
+func TestRepoUpdateCareTeamClearOrg(t *testing.T) {
+	pool := &stubPool{}
+	now := time.Now()
+	pool.queryRow = func(ctx context.Context, sql string, args ...any) pgx.Row {
+		if len(args) != 4 {
+			t.Fatalf("expected 4 args, got %d", len(args))
+		}
+		if flag, ok := args[2].(bool); !ok || !flag {
+			t.Fatalf("expected clearOrg true, got %v", args[2])
+		}
+		if args[1] != nil {
+			t.Fatalf("expected nil org param, got %v", args[1])
+		}
+		return mockRow{values: []any{"team-1", nil, nil, "Equipo", now}}
+	}
+	repo := NewRepoWithPool(pool, nil)
+	empty := ""
+	name := "Equipo"
+	team, err := repo.UpdateCareTeam(context.Background(), "team-1", models.CareTeamUpdateInput{OrgID: &empty, Name: &name})
+	if err != nil {
+		t.Fatalf("UpdateCareTeam: %v", err)
+	}
+	if team.OrgID != nil {
+		t.Fatalf("expected nil org id, got %#v", team.OrgID)
+	}
+}
+
+func TestRepoUpdateCaregiverAssignmentParams(t *testing.T) {
+	pool := &stubPool{}
+	now := time.Now()
+	pool.queryRow = func(ctx context.Context, sql string, args ...any) pgx.Row {
+		if len(args) != 12 {
+			t.Fatalf("expected 12 args, got %d", len(args))
+		}
+		if args[0] != "patient-1" || args[1] != "caregiver-1" {
+			t.Fatalf("unexpected ids: %v %v", args[0], args[1])
+		}
+		if setRel, ok := args[2].(bool); !ok || !setRel {
+			t.Fatalf("expected setRel true, got %v", args[2])
+		}
+		if clearRel, ok := args[3].(bool); !ok || clearRel {
+			t.Fatalf("expected clearRel false, got %v", args[3])
+		}
+		if relVal, ok := args[4].(string); !ok || relVal != "rel-1" {
+			t.Fatalf("unexpected rel value: %v", args[4])
+		}
+		if _, ok := args[6].(*time.Time); !ok {
+			t.Fatalf("expected started_at pointer, got %T", args[6])
+		}
+		if clearEnded, ok := args[7].(bool); !ok || !clearEnded {
+			t.Fatalf("expected clear ended true, got %v", args[7])
+		}
+		if args[8] != nil {
+			t.Fatalf("expected nil ended_at when clearing, got %v", args[8])
+		}
+		if setNote, ok := args[9].(bool); !ok || !setNote {
+			t.Fatalf("expected setNote true, got %v", args[9])
+		}
+		if clearNote, ok := args[10].(bool); !ok || !clearNote {
+			t.Fatalf("expected clearNote true, got %v", args[10])
+		}
+		if args[11] != nil {
+			t.Fatalf("expected nil note param, got %v", args[11])
+		}
+		return mockRow{values: []any{"patient-1", "caregiver-1", nil, true, now, nil, nil}}
+	}
+	repo := NewRepoWithPool(pool, nil)
+	started := time.Now()
+	rel := "rel-1"
+	note := ""
+	input := models.CaregiverAssignmentUpdateInput{
+		RelationshipTypeID: &rel,
+		IsPrimary:          nil,
+		StartedAt:          &started,
+		ClearEndedAt:       true,
+		Note:               &note,
+	}
+	if _, err := repo.UpdateCaregiverAssignment(context.Background(), "patient-1", "caregiver-1", input); err != nil {
+		t.Fatalf("UpdateCaregiverAssignment: %v", err)
+	}
+}

--- a/backend/templates/superadmin/care_teams.html
+++ b/backend/templates/superadmin/care_teams.html
@@ -1,0 +1,162 @@
+{{define "superadmin/care_teams.html"}} {{template "layout" .}} {{end}}
+{{define "superadmin/care_teams.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Equipos de cuidado</h1>
+        </div>
+        <div class="hg-card">
+                <h3>Crear nuevo equipo</h3>
+                <form method="post" action="/superadmin/care-teams" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label for="care-team-name">Nombre</label>
+                                <input id="care-team-name" name="name" type="text" required placeholder="Equipo de atención" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="care-team-org">Organización</label>
+                                <select id="care-team-org" name="org_id">
+                                        <option value="">Sin organización</option>
+                                        {{range .Data.Organizations}}
+                                        <option value="{{.ID}}">{{.Name}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Crear equipo</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        {{range .Data.Teams}}
+        {{$team := .}}
+        <div class="hg-card">
+                <div class="hg-flex-between hg-card-header">
+                        <div>
+                                <h3>{{$team.Name}}</h3>
+                                <p class="hg-muted">{{if $team.OrgName}}{{$team.OrgName}}{{else}}Sin organización{{end}}</p>
+                        </div>
+                        <form method="post" action="/superadmin/care-teams/{{$team.ID}}/delete" data-hg-confirm="¿Eliminar equipo?" class="hg-inline-form">
+                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                        </form>
+                </div>
+                <details class="hg-details">
+                        <summary>Editar equipo</summary>
+                        <form method="post" action="/superadmin/care-teams/{{$team.ID}}/update" class="hg-form-grid">
+                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                <div class="hg-form-field">
+                                        <label>Nombre</label>
+                                        <input name="name" type="text" value="{{$team.Name}}" required />
+                                </div>
+                                <div class="hg-form-field">
+                                        <label>Organización</label>
+                                        <select name="org_id">
+                                                <option value="" {{if not $team.OrgID}}selected{{end}}>Sin organización</option>
+                                                {{range $.Data.Organizations}}
+                                                <option value="{{.ID}}" {{if eq .ID (stringValue $team.OrgID)}}selected{{end}}>{{.Name}}</option>
+                                                {{end}}
+                                        </select>
+                                </div>
+                                <div class="hg-form-actions">
+                                        <button type="submit">Guardar cambios</button>
+                                </div>
+                        </form>
+                </details>
+                <div class="hg-split">
+                        <div class="hg-split-column">
+                                <h4>Miembros</h4>
+                                <ul class="hg-list">
+                                        {{with index $.Data.Members $team.ID}}
+                                        {{range .}}
+                                        <li class="hg-list-item">
+                                                <div>
+                                                        <strong>{{.UserName}}</strong>
+                                                        <div class="hg-muted">{{.UserEmail}}</div>
+                                                        <div class="hg-muted">Rol en equipo: {{.RoleInTeam}}</div>
+                                                </div>
+                                                <div class="hg-list-actions">
+                                                        <details>
+                                                                <summary>Editar rol</summary>
+                                                                <form method="post" action="/superadmin/care-teams/{{$team.ID}}/members/{{.UserID}}/update" class="hg-form-inline">
+                                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                        <input name="role_in_team" type="text" value="{{.RoleInTeam}}" required />
+                                                                        <button type="submit">Actualizar</button>
+                                                                </form>
+                                                        </details>
+                                                        <form method="post" action="/superadmin/care-teams/{{$team.ID}}/members/{{.UserID}}/delete" data-hg-confirm="¿Quitar miembro?" class="hg-inline-form">
+                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                <button type="submit" class="hg-link hg-link-danger">Quitar</button>
+                                                        </form>
+                                                </div>
+                                        </li>
+                                        {{end}}
+                                        {{else}}
+                                        <li class="hg-list-item hg-muted">Sin miembros registrados.</li>
+                                        {{end}}
+                                </ul>
+                                <form method="post" action="/superadmin/care-teams/{{$team.ID}}/members" class="hg-form-grid hg-form-inline">
+                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                        <div class="hg-form-field">
+                                                <label>Usuario</label>
+                                                <select name="user_id" required>
+                                                        <option value="">Selecciona usuario</option>
+                                                        {{range $.Data.Users}}
+                                                        <option value="{{.ID}}">{{.Name}} ({{.Email}})</option>
+                                                        {{end}}
+                                                </select>
+                                        </div>
+                                        <div class="hg-form-field">
+                                                <label>Rol en el equipo</label>
+                                                <input name="role_in_team" type="text" placeholder="Coordinador, Especialista..." required />
+                                        </div>
+                                        <div class="hg-form-actions">
+                                                <button type="submit">Agregar miembro</button>
+                                        </div>
+                                </form>
+                        </div>
+                        <div class="hg-split-column">
+                                <h4>Pacientes vinculados</h4>
+                                <ul class="hg-list">
+                                        {{with index $.Data.TeamPatients $team.ID}}
+                                        {{range .}}
+                                        <li class="hg-list-item hg-flex-between">
+                                                <div>
+                                                        <strong>{{.PatientName}}</strong>
+                                                </div>
+                                                <form method="post" action="/superadmin/care-teams/{{$team.ID}}/patients/{{.PatientID}}/delete" data-hg-confirm="¿Desvincular paciente?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Quitar</button>
+                                                </form>
+                                        </li>
+                                        {{end}}
+                                        {{else}}
+                                        <li class="hg-list-item hg-muted">Sin pacientes asociados.</li>
+                                        {{end}}
+                                </ul>
+                                <form method="post" action="/superadmin/care-teams/{{$team.ID}}/patients" class="hg-form-grid hg-form-inline">
+                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                        <div class="hg-form-field">
+                                                <label>Paciente</label>
+                                                <select name="patient_id" required>
+                                                        <option value="">Selecciona paciente</option>
+                                                        {{range $.Data.Patients}}
+                                                        <option value="{{.ID}}">{{.Name}}</option>
+                                                        {{end}}
+                                                </select>
+                                        </div>
+                                        <div class="hg-form-actions">
+                                                <button type="submit">Vincular paciente</button>
+                                        </div>
+                                </form>
+                        </div>
+                </div>
+        </div>
+        {{else}}
+        <div class="hg-card">
+                <p class="hg-empty">Aún no hay equipos registrados.</p>
+        </div>
+        {{end}}
+</section>
+{{end}}

--- a/backend/templates/superadmin/caregivers.html
+++ b/backend/templates/superadmin/caregivers.html
@@ -1,0 +1,198 @@
+{{define "superadmin/caregivers.html"}} {{template "layout" .}} {{end}}
+{{define "superadmin/caregivers.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Cuidadores</h1>
+        </div>
+        <div class="hg-card">
+                <h3>Asignar cuidador a paciente</h3>
+                <form method="post" action="/superadmin/caregivers/assignments" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field">
+                                <label>Paciente</label>
+                                <select name="patient_id" required>
+                                        <option value="">Selecciona paciente</option>
+                                        {{range .Data.Patients}}
+                                        <option value="{{.ID}}">{{.Name}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Cuidador</label>
+                                <select name="caregiver_id" required>
+                                        <option value="">Selecciona usuario</option>
+                                        {{range .Data.Caregivers}}
+                                        <option value="{{.ID}}">{{.Name}} ({{.Email}})</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Relación</label>
+                                <select name="rel_type_id">
+                                        <option value="">Sin relación</option>
+                                        {{range .Data.RelationshipTypes}}
+                                        <option value="{{.ID}}">{{.Label}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Rol principal</label>
+                                <select name="is_primary">
+                                        <option value="">No especificar</option>
+                                        <option value="yes">Sí</option>
+                                        <option value="no">No</option>
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Inicio</label>
+                                <input type="date" name="started_at" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label>Fin</label>
+                                <input type="date" name="ended_at" />
+                        </div>
+                        <div class="hg-form-field hg-form-field-wide">
+                                <label>Nota</label>
+                                <textarea name="note" rows="2" placeholder="Observaciones"></textarea>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Asignar cuidador</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Asignaciones activas</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Paciente</th>
+                                        <th>Cuidador</th>
+                                        <th>Relación</th>
+                                        <th>Principal</th>
+                                        <th>Inicio</th>
+                                        <th>Fin</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Assignments}}
+                                <tr>
+                                        <td>{{.PatientName}}</td>
+                                        <td>{{.CaregiverName}}</td>
+                                        <td>{{if .RelationshipTypeLabel}}{{.RelationshipTypeLabel}}{{else}}—{{end}}</td>
+                                        <td>{{if .IsPrimary}}Sí{{else}}No{{end}}</td>
+                                        <td>{{formatDate .StartedAt}}</td>
+                                        <td>{{if .EndedAt}}{{formatDatePtr .EndedAt}}{{else}}—{{end}}</td>
+                                        <td>
+                                                <details>
+                                                        <summary>Editar</summary>
+                                                        {{$relID := stringValue .RelationshipTypeID}}
+                                                        <form method="post" action="/superadmin/caregivers/assignments/{{.PatientID}}/{{.CaregiverID}}/update" class="hg-form-grid">
+                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                <div class="hg-form-field">
+                                                                        <label>Relación</label>
+                                                                        <select name="rel_type_id">
+                                                                                <option value="">Sin relación</option>
+                                                                                {{range $.Data.RelationshipTypes}}
+                                                                                <option value="{{.ID}}" {{if eq .ID $relID}}selected{{end}}>{{.Label}}</option>
+                                                                                {{end}}
+                                                                        </select>
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Rol principal</label>
+                                                                        <select name="is_primary">
+                                                                                <option value="">Sin cambios</option>
+                                                                                <option value="yes">Sí</option>
+                                                                                <option value="no">No</option>
+                                                                        </select>
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Inicio</label>
+                                                                        <input type="date" name="started_at" value="{{formatDate .StartedAt}}" />
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Fin</label>
+                                                                        <input type="date" name="ended_at" value="{{formatDatePtr .EndedAt}}" />
+                                                                        <label class="hg-checkbox"><input type="checkbox" name="clear_ended_at" /> Limpiar fecha</label>
+                                                                </div>
+                                                                <div class="hg-form-field hg-form-field-wide">
+                                                                        <label>Nota</label>
+                                                                        <textarea name="note" rows="2">{{stringValue .Note}}</textarea>
+                                                                </div>
+                                                                <div class="hg-form-actions">
+                                                                        <button type="submit">Guardar</button>
+                                                                </div>
+                                                        </form>
+                                                </details>
+                                                <form method="post" action="/superadmin/caregivers/assignments/{{.PatientID}}/{{.CaregiverID}}/delete" data-hg-confirm="¿Eliminar asignación?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="7" class="hg-empty-cell">Sin asignaciones registradas.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Tipos de relación</h3>
+                <div class="hg-grid-2">
+                        <div>
+                                <ul class="hg-list">
+                                        {{range .Data.RelationshipTypes}}
+                                        <li class="hg-list-item">
+                                                <form method="post" action="/superadmin/caregivers/relationship-types/{{.ID}}/update" class="hg-form-grid">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <div class="hg-form-field">
+                                                                <label>Código</label>
+                                                                <input name="code" type="text" value="{{.Code}}" required />
+                                                        </div>
+                                                        <div class="hg-form-field">
+                                                                <label>Etiqueta</label>
+                                                                <input name="label" type="text" value="{{.Label}}" required />
+                                                        </div>
+                                                        <div class="hg-form-actions">
+                                                                <button type="submit">Actualizar</button>
+                                                        </div>
+                                                </form>
+                                                <form method="post" action="/superadmin/caregivers/relationship-types/{{.ID}}/delete" data-hg-confirm="¿Eliminar relación?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </li>
+                                        {{else}}
+                                        <li class="hg-list-item hg-muted">Sin tipos de relación registrados.</li>
+                                        {{end}}
+                                </ul>
+                        </div>
+                        <div>
+                                <h4>Crear relación</h4>
+                                <form method="post" action="/superadmin/caregivers/relationship-types" class="hg-form-grid">
+                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                        <div class="hg-form-field">
+                                                <label>Código</label>
+                                                <input name="code" type="text" required placeholder="familia" />
+                                        </div>
+                                        <div class="hg-form-field">
+                                                <label>Etiqueta</label>
+                                                <input name="label" type="text" required placeholder="Familiar" />
+                                        </div>
+                                        <div class="hg-form-actions">
+                                                <button type="submit">Crear relación</button>
+                                        </div>
+                                </form>
+                        </div>
+                </div>
+        </div>
+</section>
+{{end}}


### PR DESCRIPTION
## Summary
- add care team, member, patient-link and caregiver models and repository support
- expose new API endpoints and UI handlers for managing care teams and caregiver assignments
- introduce superadmin templates for care teams and caregivers plus accompanying tests and changelog entry

## Testing
- go test ./... *(fails: module path not configured in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e9f3cf933c832f97752c7d98fbe0bc