### PR TITLE
Add superadmin patient and user location management

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -74,6 +74,19 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 			pr.Post("/{id}/delete", uiHandlers.PatientsDelete)
 		})
 
+		s.Route("/locations", func(lr chi.Router) {
+			lr.Route("/patients", func(pr chi.Router) {
+				pr.Get("/", uiHandlers.PatientLocationsIndex)
+				pr.Post("/", uiHandlers.PatientLocationsCreate)
+				pr.Post("/{id}/delete", uiHandlers.PatientLocationsDelete)
+			})
+			lr.Route("/users", func(ur chi.Router) {
+				ur.Get("/", uiHandlers.UserLocationsIndex)
+				ur.Post("/", uiHandlers.UserLocationsCreate)
+				ur.Post("/{id}/delete", uiHandlers.UserLocationsDelete)
+			})
+		})
+
 		s.Route("/care-teams", func(ct chi.Router) {
 			ct.Get("/", uiHandlers.CareTeamsIndex)
 			ct.Post("/", uiHandlers.CareTeamsCreate)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -167,6 +167,59 @@ type PatientCareTeamLink struct {
 	PatientName  string `json:"patient_name"`
 }
 
+type PatientLocation struct {
+	ID          string    `json:"id"`
+	PatientID   string    `json:"patient_id"`
+	PatientName *string   `json:"patient_name,omitempty"`
+	RecordedAt  time.Time `json:"recorded_at"`
+	Latitude    float64   `json:"latitude"`
+	Longitude   float64   `json:"longitude"`
+	Source      *string   `json:"source,omitempty"`
+	AccuracyM   *float64  `json:"accuracy_m,omitempty"`
+}
+
+type PatientLocationInput struct {
+	PatientID  string     `json:"patient_id"`
+	RecordedAt *time.Time `json:"recorded_at,omitempty"`
+	Latitude   float64    `json:"latitude"`
+	Longitude  float64    `json:"longitude"`
+	Source     *string    `json:"source,omitempty"`
+	AccuracyM  *float64   `json:"accuracy_m,omitempty"`
+}
+
+type PatientLocationFilters struct {
+	PatientID *string    `json:"patient_id,omitempty"`
+	From      *time.Time `json:"from,omitempty"`
+	To        *time.Time `json:"to,omitempty"`
+}
+
+type UserLocation struct {
+	ID         string    `json:"id"`
+	UserID     string    `json:"user_id"`
+	UserName   *string   `json:"user_name,omitempty"`
+	UserEmail  *string   `json:"user_email,omitempty"`
+	RecordedAt time.Time `json:"recorded_at"`
+	Latitude   float64   `json:"latitude"`
+	Longitude  float64   `json:"longitude"`
+	Source     *string   `json:"source,omitempty"`
+	AccuracyM  *float64  `json:"accuracy_m,omitempty"`
+}
+
+type UserLocationInput struct {
+	UserID     string     `json:"user_id"`
+	RecordedAt *time.Time `json:"recorded_at,omitempty"`
+	Latitude   float64    `json:"latitude"`
+	Longitude  float64    `json:"longitude"`
+	Source     *string    `json:"source,omitempty"`
+	AccuracyM  *float64   `json:"accuracy_m,omitempty"`
+}
+
+type UserLocationFilters struct {
+	UserID *string    `json:"user_id,omitempty"`
+	From   *time.Time `json:"from,omitempty"`
+	To     *time.Time `json:"to,omitempty"`
+}
+
 type CaregiverRelationshipType struct {
 	ID    string `json:"id"`
 	Code  string `json:"code"`

--- a/backend/internal/ui/renderer.go
+++ b/backend/internal/ui/renderer.go
@@ -81,6 +81,15 @@ func NewRenderer() (*Renderer, error) {
 			}
 			return strconv.FormatFloat(float64(*v), 'f', 4, 32)
 		},
+		"formatFloat64": func(v *float64, prec int) string {
+			if v == nil {
+				return ""
+			}
+			if prec < 0 {
+				prec = 2
+			}
+			return strconv.FormatFloat(*v, 'f', prec, 64)
+		},
 		"stringValue": func(ptr *string) string {
 			if ptr == nil {
 				return ""

--- a/backend/templates/layout.html
+++ b/backend/templates/layout.html
@@ -35,6 +35,8 @@
           <li><a href="/superadmin/content">Contenido</a></li>
           <li><a href="/superadmin/content-block-types">Tipos de bloque</a></li>
           <li><a href="/superadmin/patients">Pacientes</a></li>
+          <li><a href="/superadmin/locations/patients">Ubicaciones de pacientes</a></li>
+          <li><a href="/superadmin/locations/users">Ubicaciones de usuarios</a></li>
           <li><a href="/superadmin/ground-truth">Ground Truth</a></li>
           <li><a href="/superadmin/devices">Dispositivos</a></li>
           <li><a href="/superadmin/push-devices">Dispositivos push</a></li>

--- a/backend/templates/superadmin/patient_locations.html
+++ b/backend/templates/superadmin/patient_locations.html
@@ -1,0 +1,180 @@
+{{define "superadmin/patient_locations.html"}} {{template "layout" .}} {{end}} {{define "superadmin/patient_locations.html:content"}}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Ubicaciones de pacientes</h1>
+        </div>
+        <div class="hg-card">
+                <form method="get" action="/superadmin/locations/patients" class="hg-form-grid">
+                        <div class="hg-form-field">
+                                <label for="patient-filter">Paciente</label>
+                                <select id="patient-filter" name="patient_id">
+                                        <option value="">Todos</option>
+                                        {{range .Data.Patients}}
+                                        <option value="{{.ID}}" {{if eq $.Data.SelectedPatientID .ID}}selected{{end}}>{{.Name}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="from-date">Desde</label>
+                                <input id="from-date" name="from" type="date" value="{{.Data.From}}" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="to-date">Hasta</label>
+                                <input id="to-date" name="to" type="date" value="{{.Data.To}}" />
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Filtrar</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Mapa</h3>
+                <div id="patientLocationsMap" class="hg-map"></div>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Registrar ubicación manual</h3>
+                <form method="post" action="/superadmin/locations/patients" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <input type="hidden" name="from" value="{{.Data.From}}" />
+                        <input type="hidden" name="to" value="{{.Data.To}}" />
+                        <div class="hg-form-field">
+                                <label for="patient-select">Paciente</label>
+                                <select id="patient-select" name="patient_id" required>
+                                        <option value="">Seleccione un paciente</option>
+                                        {{range .Data.Patients}}
+                                        <option value="{{.ID}}" {{if eq $.Data.SelectedPatientID .ID}}selected{{end}}>{{.Name}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="recorded-at">Fecha y hora</label>
+                                <input id="recorded-at" name="recorded_at" type="datetime-local" />
+                                <span class="hg-field-hint">Opcional. Si se omite se usará la hora actual.</span>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="latitude">Latitud</label>
+                                <input id="latitude" name="latitude" type="number" step="any" min="-90" max="90" required />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="longitude">Longitud</label>
+                                <input id="longitude" name="longitude" type="number" step="any" min="-180" max="180" required />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="accuracy">Precisión (m)</label>
+                                <input id="accuracy" name="accuracy_m" type="number" step="any" min="0" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="source">Fuente</label>
+                                <input id="source" name="source" type="text" maxlength="40" placeholder="GPS, manual, etc." />
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Guardar ubicación</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Historial de ubicaciones</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Paciente</th>
+                                        <th>Registrada</th>
+                                        <th>Latitud</th>
+                                        <th>Longitud</th>
+                                        <th>Fuente</th>
+                                        <th>Precisión (m)</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Items}}
+                                <tr>
+                                        <td>{{if .PatientName}}{{.PatientName}}{{else}}—{{end}}</td>
+                                        <td>{{formatTime .RecordedAt}}</td>
+                                        <td>{{printf "%.6f" .Latitude}}</td>
+                                        <td>{{printf "%.6f" .Longitude}}</td>
+                                        <td>{{if .Source}}{{.Source}}{{else}}—{{end}}</td>
+                                        <td>{{if .AccuracyM}}{{formatFloat64 .AccuracyM 2}}{{else}}—{{end}}</td>
+                                        <td class="hg-actions">
+                                                <form method="post" action="/superadmin/locations/patients/{{.ID}}/delete" data-hg-confirm="¿Eliminar ubicación?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <input type="hidden" name="patient_id" value="{{$.Data.SelectedPatientID}}" />
+                                                        <input type="hidden" name="from" value="{{$.Data.From}}" />
+                                                        <input type="hidden" name="to" value="{{$.Data.To}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="7" class="hg-empty-cell">Sin ubicaciones registradas.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+
+<script type="application/json" id="patientLocationsData">{{toJSON .Data.Items}}</script>
+<script>
+        document.addEventListener("DOMContentLoaded", function () {
+                var container = document.getElementById("patientLocationsMap");
+                if (!container || !window.L) {
+                        return;
+                }
+                var raw = document.getElementById("patientLocationsData");
+                var dataset = [];
+                if (raw) {
+                        try {
+                                dataset = JSON.parse(raw.textContent || "[]");
+                        } catch (err) {
+                                console.error("locations parse", err);
+                        }
+                }
+                var map = L.map(container).setView([19.4326, -99.1332], 5);
+                L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+                        attribution: "&copy; OpenStreetMap colaboradores",
+                        maxZoom: 18,
+                }).addTo(map);
+                if (Array.isArray(dataset) && dataset.length > 0) {
+                        var bounds = [];
+                        dataset.forEach(function (entry) {
+                                if (!entry || typeof entry.latitude !== "number" || typeof entry.longitude !== "number") {
+                                        return;
+                                }
+                                var marker = L.marker([entry.latitude, entry.longitude]).addTo(map);
+                                var content = "";
+                                if (entry.patient_name) {
+                                        content += "<strong>" + entry.patient_name + "</strong><br />";
+                                }
+                                if (entry.recorded_at) {
+                                        content += new Date(entry.recorded_at).toLocaleString("es-MX") + "<br />";
+                                }
+                                content += "Lat: " + entry.latitude.toFixed(6) + "<br />Lng: " + entry.longitude.toFixed(6);
+                                if (entry.accuracy_m) {
+                                        content += "<br />±" + Number(entry.accuracy_m).toFixed(2) + " m";
+                                }
+                                if (entry.source) {
+                                        content += "<br />Fuente: " + entry.source;
+                                }
+                                marker.bindPopup(content);
+                                bounds.push([entry.latitude, entry.longitude]);
+                        });
+                        if (bounds.length > 0) {
+                                map.fitBounds(bounds, { padding: [24, 24] });
+                        }
+                }
+        });
+</script>
+{{end}}

--- a/backend/templates/superadmin/user_locations.html
+++ b/backend/templates/superadmin/user_locations.html
@@ -1,0 +1,184 @@
+{{define "superadmin/user_locations.html"}} {{template "layout" .}} {{end}} {{define "superadmin/user_locations.html:content"}}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Ubicaciones de usuarios</h1>
+        </div>
+        <div class="hg-card">
+                <form method="get" action="/superadmin/locations/users" class="hg-form-grid">
+                        <div class="hg-form-field">
+                                <label for="user-filter">Usuario</label>
+                                <select id="user-filter" name="user_id">
+                                        <option value="">Todos</option>
+                                        {{range .Data.Users}}
+                                        <option value="{{.ID}}" {{if eq $.Data.SelectedUserID .ID}}selected{{end}}>{{.Name}} {{if .Email}}({{.Email}}){{end}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-from">Desde</label>
+                                <input id="user-from" name="from" type="date" value="{{.Data.From}}" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-to">Hasta</label>
+                                <input id="user-to" name="to" type="date" value="{{.Data.To}}" />
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Filtrar</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Mapa</h3>
+                <div id="userLocationsMap" class="hg-map"></div>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Registrar ubicación manual</h3>
+                <form method="post" action="/superadmin/locations/users" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <input type="hidden" name="from" value="{{.Data.From}}" />
+                        <input type="hidden" name="to" value="{{.Data.To}}" />
+                        <div class="hg-form-field">
+                                <label for="user-select">Usuario</label>
+                                <select id="user-select" name="user_id" required>
+                                        <option value="">Seleccione un usuario</option>
+                                        {{range .Data.Users}}
+                                        <option value="{{.ID}}" {{if eq $.Data.SelectedUserID .ID}}selected{{end}}>{{.Name}} {{if .Email}}({{.Email}}){{end}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-recorded">Fecha y hora</label>
+                                <input id="user-recorded" name="recorded_at" type="datetime-local" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-latitude">Latitud</label>
+                                <input id="user-latitude" name="latitude" type="number" step="any" min="-90" max="90" required />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-longitude">Longitud</label>
+                                <input id="user-longitude" name="longitude" type="number" step="any" min="-180" max="180" required />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-accuracy">Precisión (m)</label>
+                                <input id="user-accuracy" name="accuracy_m" type="number" step="any" min="0" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="user-source">Fuente</label>
+                                <input id="user-source" name="source" type="text" maxlength="40" placeholder="GPS, manual, etc." />
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Guardar ubicación</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Historial de ubicaciones</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Usuario</th>
+                                        <th>Correo</th>
+                                        <th>Registrada</th>
+                                        <th>Latitud</th>
+                                        <th>Longitud</th>
+                                        <th>Fuente</th>
+                                        <th>Precisión (m)</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Items}}
+                                <tr>
+                                        <td>{{if .UserName}}{{.UserName}}{{else}}—{{end}}</td>
+                                        <td>{{if .UserEmail}}{{.UserEmail}}{{else}}—{{end}}</td>
+                                        <td>{{formatTime .RecordedAt}}</td>
+                                        <td>{{printf "%.6f" .Latitude}}</td>
+                                        <td>{{printf "%.6f" .Longitude}}</td>
+                                        <td>{{if .Source}}{{.Source}}{{else}}—{{end}}</td>
+                                        <td>{{if .AccuracyM}}{{formatFloat64 .AccuracyM 2}}{{else}}—{{end}}</td>
+                                        <td class="hg-actions">
+                                                <form method="post" action="/superadmin/locations/users/{{.ID}}/delete" data-hg-confirm="¿Eliminar ubicación?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <input type="hidden" name="user_id" value="{{$.Data.SelectedUserID}}" />
+                                                        <input type="hidden" name="from" value="{{$.Data.From}}" />
+                                                        <input type="hidden" name="to" value="{{$.Data.To}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="8" class="hg-empty-cell">Sin ubicaciones registradas.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+
+<script type="application/json" id="userLocationsData">{{toJSON .Data.Items}}</script>
+<script>
+        document.addEventListener("DOMContentLoaded", function () {
+                var container = document.getElementById("userLocationsMap");
+                if (!container || !window.L) {
+                        return;
+                }
+                var raw = document.getElementById("userLocationsData");
+                var dataset = [];
+                if (raw) {
+                        try {
+                                dataset = JSON.parse(raw.textContent || "[]");
+                        } catch (err) {
+                                console.error("locations parse", err);
+                        }
+                }
+                var map = L.map(container).setView([19.4326, -99.1332], 5);
+                L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+                        attribution: "&copy; OpenStreetMap colaboradores",
+                        maxZoom: 18,
+                }).addTo(map);
+                if (Array.isArray(dataset) && dataset.length > 0) {
+                        var bounds = [];
+                        dataset.forEach(function (entry) {
+                                if (!entry || typeof entry.latitude !== "number" || typeof entry.longitude !== "number") {
+                                        return;
+                                }
+                                var marker = L.marker([entry.latitude, entry.longitude]).addTo(map);
+                                var content = "";
+                                if (entry.user_name) {
+                                        content += "<strong>" + entry.user_name + "</strong><br />";
+                                }
+                                if (entry.user_email) {
+                                        content += entry.user_email + "<br />";
+                                }
+                                if (entry.recorded_at) {
+                                        content += new Date(entry.recorded_at).toLocaleString("es-MX") + "<br />";
+                                }
+                                content += "Lat: " + entry.latitude.toFixed(6) + "<br />Lng: " + entry.longitude.toFixed(6);
+                                if (entry.accuracy_m) {
+                                        content += "<br />±" + Number(entry.accuracy_m).toFixed(2) + " m";
+                                }
+                                if (entry.source) {
+                                        content += "<br />Fuente: " + entry.source;
+                                }
+                                marker.bindPopup(content);
+                                bounds.push([entry.latitude, entry.longitude]);
+                        });
+                        if (bounds.length > 0) {
+                                map.fitBounds(bounds, { padding: [24, 24] });
+                        }
+                }
+        });
+</script>
+{{end}}

--- a/backend/ui/assets/css/app.css
+++ b/backend/ui/assets/css/app.css
@@ -1174,6 +1174,15 @@ label .hg-required {
 	gap: 18px;
 }
 
+.hg-map {
+	width: 100%;
+	height: 360px;
+	border-radius: var(--hg-radius-md);
+	overflow: hidden;
+	background: rgba(15, 23, 42, 0.35);
+	border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
 .hg-toolbar {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add patient and user location models plus repository methods for listing, creating, and deleting records with validation
- expose REST and UI handlers with new routes for managing location history, including map/table views and manual entry forms
- extend templates, navigation, and styling to surface the location pages with Leaflet-based visualizations

## Testing
- `timeout 120s go test ./...` *(fails: stubPool redeclared in repo_push_devices_test.go and related compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e9f9283e78832f93a4a92b99d62ccb