### PR TITLE
Add batch export management flows

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -130,6 +130,13 @@ func NewRouter(logger authmw.Logger, cfg *config.Config, repo superadmin.Reposit
 			pr.Post("/{id}/delete", uiHandlers.PushDevicesDelete)
 		})
 
+		s.Route("/batch-exports", func(br chi.Router) {
+			br.Get("/", uiHandlers.BatchExportsIndex)
+			br.Post("/", uiHandlers.BatchExportsCreate)
+			br.Post("/{id}/status", uiHandlers.BatchExportsUpdateStatus)
+			br.Post("/{id}/delete", uiHandlers.BatchExportsDelete)
+		})
+
 		s.Route("/signal-streams", func(sr chi.Router) {
 			sr.Get("/", uiHandlers.SignalStreamsIndex)
 			sr.Post("/", uiHandlers.SignalStreamsCreate)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -879,6 +879,29 @@ type AuditLog struct {
 	IP       *string        `json:"ip,omitempty"`        // inet -> string
 }
 
+type BatchExport struct {
+	ID               string         `json:"id"`
+	Purpose          string         `json:"purpose"`
+	TargetRef        string         `json:"target_ref"`
+	RequestedBy      *string        `json:"requested_by,omitempty"`
+	RequestedByName  *string        `json:"requested_by_name,omitempty"`
+	RequestedByEmail *string        `json:"requested_by_email,omitempty"`
+	RequestedAt      time.Time      `json:"requested_at"`
+	CompletedAt      *time.Time     `json:"completed_at,omitempty"`
+	StatusID         string         `json:"status_id"`
+	StatusCode       string         `json:"status_code"`
+	StatusLabel      string         `json:"status_label"`
+	Details          map[string]any `json:"details,omitempty"`
+}
+
+type BatchExportInput struct {
+	Purpose     string         `json:"purpose"`
+	TargetRef   string         `json:"target_ref"`
+	RequestedBy *string        `json:"requested_by,omitempty"`
+	StatusCode  string         `json:"status_code,omitempty"`
+	Details     map[string]any `json:"details,omitempty"`
+}
+
 type OperationCount struct {
 	Action string `json:"action"`
 	Count  int    `json:"count"`

--- a/backend/internal/superadmin/batch_exports_helpers.go
+++ b/backend/internal/superadmin/batch_exports_helpers.go
@@ -1,0 +1,94 @@
+package superadmin
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/google/uuid"
+)
+
+const batchExportUploadDir = "uploads/batch_exports"
+
+const maxBatchExportUploadSize = 50 << 20 // 50 MiB
+
+var (
+	errBatchExportMissingFile  = errors.New("missing batch export file")
+	errBatchExportFileTooLarge = errors.New("batch export file too large")
+)
+
+func sanitizeBatchExportBase(name string) string {
+	base := strings.TrimSpace(filepath.Base(name))
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return "export"
+	}
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	if base == "" {
+		return "export"
+	}
+	var b strings.Builder
+	for _, r := range base {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(unicode.ToLower(r))
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		case unicode.IsSpace(r):
+			b.WriteRune('-')
+		}
+	}
+	cleaned := strings.Trim(b.String(), "-_")
+	if cleaned == "" {
+		return "export"
+	}
+	if len(cleaned) > 40 {
+		cleaned = cleaned[:40]
+	}
+	return cleaned
+}
+
+func saveBatchExportUpload(header *multipart.FileHeader) (string, error) {
+	if header == nil {
+		return "", errBatchExportMissingFile
+	}
+	src, err := header.Open()
+	if err != nil {
+		return "", err
+	}
+	defer src.Close()
+
+	if err := os.MkdirAll(batchExportUploadDir, 0o755); err != nil {
+		return "", err
+	}
+
+	ext := strings.ToLower(filepath.Ext(header.Filename))
+	base := sanitizeBatchExportBase(header.Filename)
+	filename := fmt.Sprintf("%s_%s%s", base, uuid.NewString(), ext)
+	destPath := filepath.Join(batchExportUploadDir, filename)
+
+	dest, err := os.Create(destPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = dest.Close()
+	}()
+
+	limited := io.LimitReader(src, maxBatchExportUploadSize+1)
+	written, err := io.Copy(dest, limited)
+	if err != nil {
+		_ = os.Remove(destPath)
+		return "", err
+	}
+	if written > maxBatchExportUploadSize {
+		_ = os.Remove(destPath)
+		return "", errBatchExportFileTooLarge
+	}
+
+	return "file://" + filepath.ToSlash(destPath), nil
+}

--- a/backend/templates/superadmin/batch_exports.html
+++ b/backend/templates/superadmin/batch_exports.html
@@ -1,0 +1,149 @@
+{{define "superadmin/batch_exports.html"}} {{template "layout" .}} {{end}} {{define "superadmin/batch_exports.html:content"}}
+<section class="hg-section">
+        <div class="hg-flex-between">
+                <h1>Exportaciones por lotes</h1>
+        </div>
+        <div class="hg-card">
+                <h3>Nuevo lote</h3>
+                <form method="post" action="/superadmin/batch-exports" enctype="multipart/form-data" class="hg-form-grid">
+                        <input type="hidden" name="_csrf" value="{{.CSRFToken}}" />
+                        <div class="hg-form-field hg-form-field-span2">
+                                <label for="batch-purpose">Propósito</label>
+                                <input type="text" id="batch-purpose" name="purpose" required placeholder="Descripción del lote" />
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="batch-status">Estado inicial</label>
+                                <select id="batch-status" name="status_code">
+                                        <option value="">Automático</option>
+                                        {{range .Data.Statuses}}
+                                        <option value="{{.Code}}" {{if eq .Code "queued"}}selected{{end}}>{{.Label}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field hg-form-field-span2">
+                                <label for="batch-file">Archivo (opcional)</label>
+                                <input type="file" id="batch-file" name="target_file" />
+                                <small class="hg-field-help">Si cargas un archivo se almacenará localmente.</small>
+                        </div>
+                        <div class="hg-form-field hg-form-field-span2">
+                                <label for="batch-url">Enlace (opcional)</label>
+                                <input type="url" id="batch-url" name="target_url" placeholder="https://..." />
+                                <small class="hg-field-help">Se usará únicamente cuando no se adjunte archivo.</small>
+                        </div>
+                        <div class="hg-form-field hg-form-field-span2">
+                                <label for="batch-details">Detalles (JSON)</label>
+                                <textarea id="batch-details" name="details_json" rows="2" placeholder='{"nota":"opcional"}'></textarea>
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Crear lote</button>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Filtros</h3>
+                <form method="get" action="/superadmin/batch-exports" class="hg-form-grid">
+                        <div class="hg-form-field">
+                                <label for="filter-status">Estado</label>
+                                <select id="filter-status" name="status">
+                                        <option value="">Todos</option>
+                                        {{range .Data.Statuses}}
+                                        <option value="{{.Code}}" {{if eq $.Data.FilterStatus .Code}}selected{{end}}>{{.Label}}</option>
+                                        {{end}}
+                                </select>
+                        </div>
+                        <div class="hg-form-field">
+                                <label for="filter-q">Buscar</label>
+                                <input type="text" id="filter-q" name="q" value="{{.Data.Search}}" placeholder="Propósito o destino" />
+                        </div>
+                        <div class="hg-form-actions">
+                                <button type="submit">Aplicar filtros</button>
+                                <a class="hg-link" href="/superadmin/batch-exports">Limpiar</a>
+                        </div>
+                </form>
+        </div>
+</section>
+
+<section class="hg-section">
+        <div class="hg-card">
+                <h3>Lotes registrados</h3>
+                <table class="hg-table">
+                        <thead>
+                                <tr>
+                                        <th>Propósito</th>
+                                        <th>Destino</th>
+                                        <th>Estado</th>
+                                        <th>Solicitado por</th>
+                                        <th>Solicitado</th>
+                                        <th>Completado</th>
+                                        <th>Detalles</th>
+                                        <th></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                {{range .Data.Items}}
+                                {{$item := .}}
+                                <tr>
+                                        <td>{{$item.Purpose}}</td>
+                                        <td>
+                                                {{if $item.TargetURL}}
+                                                <a href="{{stringValue $item.TargetURL}}" target="_blank" rel="noopener">{{$item.TargetDisplay}}</a>
+                                                {{else}}
+                                                <span class="hg-mono">{{$item.TargetDisplay}}</span>
+                                                {{end}}
+                                        </td>
+                                        <td>{{$item.StatusLabel}}</td>
+                                        <td>{{if $item.RequestedByName}}{{$item.RequestedByName}}{{else}}—{{end}}{{if $item.RequestedByEmail}}<br /><small>{{$item.RequestedByEmail}}</small>{{end}}</td>
+                                        <td>{{formatTime $item.RequestedAt}}</td>
+                                        <td>{{formatTimePtr $item.CompletedAt}}</td>
+                                        <td>
+                                                {{if $item.Details}}
+                                                <pre class="hg-pre">{{toJSON $item.Details}}</pre>
+                                                {{else}}
+                                                —
+                                                {{end}}
+                                        </td>
+                                        <td class="hg-flex">
+                                                <details>
+                                                        <summary>Actualizar</summary>
+                                                        <form method="post" action="/superadmin/batch-exports/{{$item.ID}}/status" class="hg-form-grid">
+                                                                <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                                <div class="hg-form-field">
+                                                                        <label>Estado</label>
+                                                                        <select name="status_code" required>
+                                                                                {{range $.Data.Statuses}}
+                                                                                <option value="{{.Code}}" {{if eq .Code $item.StatusCode}}selected{{end}}>{{.Label}}</option>
+                                                                                {{end}}
+                                                                        </select>
+                                                                </div>
+                                                                <div class="hg-form-field">
+                                                                        <label>Completado</label>
+                                                                        <input type="datetime-local" name="completed_at" value="{{formatTimeLocalPtr $item.CompletedAt}}" />
+                                                                </div>
+                                                                <div class="hg-form-field hg-form-field-span2">
+                                                                        <label>Detalles (JSON)</label>
+                                                                        <textarea name="details_json" rows="3">{{if $item.Details}}{{toJSON $item.Details}}{{end}}</textarea>
+                                                                </div>
+                                                                <div class="hg-form-actions">
+                                                                        <button type="submit">Guardar</button>
+                                                                </div>
+                                                        </form>
+                                                </details>
+                                                <form method="post" action="/superadmin/batch-exports/{{$item.ID}}/delete" data-hg-confirm="¿Eliminar lote?" class="hg-inline-form">
+                                                        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
+                                                        <button type="submit" class="hg-link hg-link-danger">Eliminar</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                                {{else}}
+                                <tr>
+                                        <td colspan="8" class="hg-empty-cell">Sin registros.</td>
+                                </tr>
+                                {{end}}
+                        </tbody>
+                </table>
+        </div>
+</section>
+{{end}}


### PR DESCRIPTION
## Summary
- introduce BatchExport data models and repository helpers for listing, creating, updating and deleting exports
- add REST and UI handlers plus template to manage batch export batches, including optional file uploads and status updates
- register the new superadmin routes and audit labels for batch export operations

## Testing
- ⚠️ `go test ./...` *(hangs waiting for external services in this environment; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68e9fef66828832fa45b90e9a2bc7381