### PR TITLE
Handle duplicate caregiver assignments gracefully

### DIFF
--- a/backend/internal/superadmin/handlers.go
+++ b/backend/internal/superadmin/handlers.go
@@ -2757,6 +2757,10 @@ func (h *Handlers) CreateCaregiverAssignment(w http.ResponseWriter, r *http.Requ
 	defer cancel()
 	assignment, err := h.repo.CreateCaregiverAssignment(ctx, input)
 	if err != nil {
+		if errors.Is(err, ErrDuplicateCaregiverAssignment) {
+			writeProblem(w, 409, "duplicate_assignment", "caregiver already assigned to patient", nil)
+			return
+		}
 		writeProblem(w, 400, "db_error", err.Error(), nil)
 		return
 	}

--- a/backend/internal/superadmin/handlers_ui.go
+++ b/backend/internal/superadmin/handlers_ui.go
@@ -4063,7 +4063,11 @@ func (h *Handlers) CaregiversAssignmentsCreate(w http.ResponseWriter, r *http.Re
 		Note:               notePtr,
 	})
 	if err != nil {
-		h.sessions.PushFlash(r.Context(), middleware.SessionJTIFromContext(r.Context()), session.Flash{Type: "error", Message: "No se pudo asignar el cuidador"})
+		message := "No se pudo asignar el cuidador"
+		if errors.Is(err, ErrDuplicateCaregiverAssignment) {
+			message = "Este cuidador ya está asignado a este paciente"
+		}
+		h.sessions.PushFlash(r.Context(), middleware.SessionJTIFromContext(r.Context()), session.Flash{Type: "error", Message: message})
 		http.Redirect(w, r, "/superadmin/caregivers", http.StatusSeeOther)
 		return
 	}


### PR DESCRIPTION
## Summary
- return a sentinel error when caregiver assignment inserts hit a unique violation
- surface clearer duplicate-assignment messaging in both the UI flow and REST API
- add regression coverage that expects the sentinel error on duplicate caregiver assignments

## Testing
- `go test ./internal/superadmin -run TestRepoCreateCaregiverAssignmentDuplicate -count=1` *(hangs in container, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ea0b765d10832f8ce16cb61613611c