### PR TITLE
feat: Normalizar campos a 3FN y actualizar la aplicación

### DIFF
--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -72,24 +72,26 @@ type MetricsOverview struct {
 }
 
 type Patient struct {
-	ID        string     `json:"id"`
-	OrgID     *string    `json:"org_id,omitempty"`
-	OrgName   *string    `json:"org_name,omitempty"`
-	Name      string     `json:"name"`
-	Birthdate *time.Time `json:"birthdate,omitempty"`
+	ID              string     `json:"id"`
+	OrgID           *string    `json:"org_id,omitempty"`
+	OrgName         *string    `json:"org_name,omitempty"`
+	Name            string     `json:"name"`
+	Birthdate       *time.Time `json:"birthdate,omitempty"`
 	SexCode         *string    `json:"sex_code,omitempty"`
 	SexLabel        *string    `json:"sex_label,omitempty"`
-	RiskLevel       *string    `json:"risk_level,omitempty"`
+	RiskLevelID     *string    `json:"risk_level_id,omitempty"`
+	RiskLevelCode   *string    `json:"risk_level_code,omitempty"`
+	RiskLevelLabel  *string    `json:"risk_level_label,omitempty"`
 	ProfilePhotoURL *string    `json:"profile_photo_url,omitempty"`
 	CreatedAt       time.Time  `json:"created_at"`
 }
 
 type PatientInput struct {
-	OrgID     *string    `json:"org_id,omitempty"`
+	OrgID           *string    `json:"org_id,omitempty"`
 	Name            string     `json:"name"`
 	Birthdate       *time.Time `json:"birthdate,omitempty"`
 	SexCode         *string    `json:"sex_code,omitempty"`
-	RiskLevel       *string    `json:"risk_level,omitempty"`
+	RiskLevelID     *string    `json:"risk_level_id,omitempty"`
 	ProfilePhotoURL *string    `json:"profile_photo_url,omitempty"`
 }
 
@@ -117,17 +119,19 @@ type CareTeamMember struct {
 	UserID       string    `json:"user_id"`
 	UserName     string    `json:"user_name"`
 	UserEmail    string    `json:"user_email"`
-	RoleInTeam   string    `json:"role_in_team"`
+	RoleID       string    `json:"role_id"`
+	RoleCode     string    `json:"role_code"`
+	RoleLabel    string    `json:"role_label"`
 	JoinedAt     time.Time `json:"joined_at"`
 }
 
 type CareTeamMemberInput struct {
-	UserID     string `json:"user_id"`
-	RoleInTeam string `json:"role_in_team"`
+	UserID string `json:"user_id"`
+	RoleID string `json:"role_id"`
 }
 
 type CareTeamMemberUpdateInput struct {
-	RoleInTeam *string `json:"role_in_team,omitempty"`
+	RoleID *string `json:"role_id,omitempty"`
 }
 
 type PatientCareTeamLink struct {
@@ -707,4 +711,17 @@ type SystemSettingsInput struct {
 	DefaultTimezone    string  `json:"default_timezone"`
 	MaintenanceMode    bool    `json:"maintenance_mode"`
 	MaintenanceMessage *string `json:"maintenance_message,omitempty"`
+}
+
+type RiskLevel struct {
+	ID     string  `json:"id"`
+	Code   string  `json:"code"`
+	Label  string  `json:"label"`
+	Weight *int    `json:"weight,omitempty"`
+}
+
+type TeamMemberRole struct {
+	ID    string `json:"id"`
+	Code  string `json:"code"`
+	Label string `json:"label"`
 }

--- a/backend/internal/superadmin/handlers.go
+++ b/backend/internal/superadmin/handlers.go
@@ -41,6 +41,8 @@ type Repository interface {
 	ListOrganizationCareTeams(ctx context.Context, orgID string, limit int) ([]models.CareTeam, error)
 	UpdateOrganization(ctx context.Context, id string, code, name *string) (*models.Organization, error)
 	DeleteOrganization(ctx context.Context, id string) error
+	ListRiskLevels(ctx context.Context) ([]models.RiskLevel, error)
+	ListTeamMemberRoles(ctx context.Context) ([]models.TeamMemberRole, error)
 
 	CreateInvitation(ctx context.Context, orgID, orgRoleID string, email *string, ttlHours int, createdBy *string) (*models.OrgInvitation, error)
 	ListInvitations(ctx context.Context, orgID *string, limit, offset int) ([]models.OrgInvitation, error)

--- a/backend/templates/superadmin/care_teams.html
+++ b/backend/templates/superadmin/care_teams.html
@@ -74,14 +74,19 @@
                                                 <div>
                                                         <strong>{{.UserName}}</strong>
                                                         <div class="hg-muted">{{.UserEmail}}</div>
-                                                        <div class="hg-muted">Rol en equipo: {{.RoleInTeam}}</div>
+                                                        <div class="hg-muted">Rol en equipo: {{.RoleLabel}}</div>
                                                 </div>
                                                 <div class="hg-list-actions">
                                                         <details>
                                                                 <summary>Editar rol</summary>
                                                                 <form method="post" action="/superadmin/care-teams/{{$team.ID}}/members/{{.UserID}}/update" class="hg-form-inline">
                                                                         <input type="hidden" name="_csrf" value="{{$.CSRFToken}}" />
-                                                                        <input name="role_in_team" type="text" value="{{.RoleInTeam}}" required />
+                                                                        {{$currentRoleID := .RoleID}}
+                                                                        <select name="role_id" required>
+                                                                                {{range $.Data.Roles}}
+                                                                                <option value="{{.ID}}" {{if eq .ID $currentRoleID}}selected{{end}}>{{.Label}}</option>
+                                                                                {{end}}
+                                                                        </select>
                                                                         <button type="submit">Actualizar</button>
                                                                 </form>
                                                         </details>
@@ -109,7 +114,12 @@
                                         </div>
                                         <div class="hg-form-field">
                                                 <label>Rol en el equipo</label>
-                                                <input name="role_in_team" type="text" placeholder="Coordinador, Especialista..." required />
+                                                <select name="role_id" required>
+                                                        <option value="">Selecciona rol</option>
+                                                        {{range $.Data.Roles}}
+                                                        <option value="{{.ID}}">{{.Label}}</option>
+                                                        {{end}}
+                                                </select>
                                         </div>
                                         <div class="hg-form-actions">
                                                 <button type="submit">Agregar miembro</button>

--- a/backend/templates/superadmin/patient_detail.html
+++ b/backend/templates/superadmin/patient_detail.html
@@ -8,8 +8,8 @@
 		</div>
 		<div class="hg-detail-meta">
 			{{if .Data.Patient.OrgName}}<span class="hg-detail-pill">{{.Data.Patient.OrgName}}</span>{{end}}
-			{{with .Data.RiskLevel}}
-			<span class="hg-status-chip {{if eq . "alto"}}is-danger{{else if eq . "medio"}}is-warn{{else if eq . "bajo"}}is-success{{end}}">Riesgo: {{.}}</span>
+			{{with .Data.Patient.RiskLevelCode}}
+			<span class="hg-status-chip {{if eq . "high"}}is-danger{{else if eq . "medium"}}is-warn{{else if eq . "low"}}is-success{{end}}">Riesgo: {{$.Data.Patient.RiskLevelLabel}}</span>
 			{{end}}
 		</div>
 	</div>
@@ -20,7 +20,7 @@
 		</article>
 		<article class="hg-summary-card">
 			<span class="hg-summary-label">Nivel de riesgo</span>
-			<span class="hg-summary-value">{{if .Data.RiskLevel}}{{.Data.RiskLevel}}{{else}}—{{end}}</span>
+			<span class="hg-summary-value">{{if .Data.Patient.RiskLevelLabel}}{{stringValue .Data.Patient.RiskLevelLabel}}{{else}}—{{end}}</span>
 		</article>
 		<article class="hg-summary-card">
 			<span class="hg-summary-label">Sexo</span>

--- a/backend/templates/superadmin/patient_detail.html
+++ b/backend/templates/superadmin/patient_detail.html
@@ -8,8 +8,8 @@
 		</div>
 		<div class="hg-detail-meta">
 			{{if .Data.Patient.OrgName}}<span class="hg-detail-pill">{{.Data.Patient.OrgName}}</span>{{end}}
-			{{with .Data.Patient.RiskLevelCode}}
-			<span class="hg-status-chip {{if eq . "high"}}is-danger{{else if eq . "medium"}}is-warn{{else if eq . "low"}}is-success{{end}}">Riesgo: {{$.Data.Patient.RiskLevelLabel}}</span>
+			{{if .Data.Patient.RiskLevelCode}}
+			<span class="hg-status-chip {{if eq (stringValue .Data.Patient.RiskLevelCode) "high"}}is-danger{{else if eq (stringValue .Data.Patient.RiskLevelCode) "medium"}}is-warn{{else if eq (stringValue .Data.Patient.RiskLevelCode) "low"}}is-success{{end}}">Riesgo: {{if .Data.Patient.RiskLevelLabel}}{{stringValue .Data.Patient.RiskLevelLabel}}{{else}}—{{end}}</span>
 			{{end}}
 		</div>
 	</div>

--- a/backend/templates/superadmin/patients.html
+++ b/backend/templates/superadmin/patients.html
@@ -35,7 +35,12 @@
 			</div>
 			<div class="hg-form-field">
 				<label for="patient-risk">Nivel de riesgo</label>
-				<input id="patient-risk" name="risk_level" type="text" placeholder="Por ejemplo: alto" />
+				<select id="patient-risk" name="risk_level_id">
+					<option value="">No asignado</option>
+					{{range .Data.RiskLevels}}
+					<option value="{{.ID}}">{{.Label}}</option>
+					{{end}}
+				</select>
 			</div>
 			<div class="hg-form-field">
 				<label for="patient-photo">URL de la foto</label>
@@ -76,7 +81,7 @@
 					<td><a href="/superadmin/patients/{{$patient.ID}}">{{$patient.Name}}</a></td>
 					<td>{{if $patient.OrgName}}{{$patient.OrgName}}{{else}}—{{end}}</td>
 					<td>{{if $patient.SexLabel}}{{$patient.SexLabel}}{{else}}—{{end}}</td>
-					<td>{{if ne (stringValue $patient.RiskLevel) ""}}{{stringValue $patient.RiskLevel}}{{else}}—{{end}}</td>
+					<td>{{if $patient.RiskLevelLabel}}{{stringValue $patient.RiskLevelLabel}}{{else}}—{{end}}</td>
 					<td>{{formatDatePtr $patient.Birthdate}}</td>
 					<td>{{formatTime $patient.CreatedAt}}</td>
 					<td class="hg-flex">
@@ -112,7 +117,12 @@
 								</div>
 								<div class="hg-form-field">
 									<label>Riesgo</label>
-									<input name="risk_level" type="text" value="{{stringValue $patient.RiskLevel}}" />
+									<select name="risk_level_id">
+										<option value="">No asignado</option>
+										{{range $.Data.RiskLevels}}
+										<option value="{{.ID}}" {{if eq .ID (stringValue $patient.RiskLevelID)}}selected{{end}}>{{.Label}}</option>
+										{{end}}
+									</select>
 								</div>
 								<div class="hg-form-field">
 									<label>URL de la foto</label>

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -47,6 +47,19 @@ INSERT INTO delivery_statuses(code,label) VALUES
   ('SENT','Enviado'),('DELIVERED','Entregado'),('FAILED','Fallido')
 ON CONFLICT (code) DO NOTHING;
 
+INSERT INTO risk_levels(code, label, weight) VALUES
+  ('low', 'Bajo', 1),
+  ('medium', 'Medio', 2),
+  ('high', 'Alto', 3)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO team_member_roles(code, label) VALUES
+  ('doctor', 'Doctor/a'),
+  ('nurse', 'Enfermero/a'),
+  ('admin', 'Administrador/a de Equipo'),
+  ('specialist', 'Especialista')
+ON CONFLICT (code) DO NOTHING;
+
 -- Roles globales y permisos
 INSERT INTO roles(name, description) VALUES
   ('superadmin','Full system access'),
@@ -352,7 +365,7 @@ ON CONFLICT (id) DO NOTHING;
 -- Datos demo clínicos y operativos
 -- =========================================================
 
-INSERT INTO patients (id, org_id, person_name, birthdate, sex_id, risk_level, created_at)
+INSERT INTO patients (id, org_id, person_name, birthdate, sex_id, risk_level_id, created_at)
 VALUES
   (
     '8c9436b4-f085-405f-a3d2-87cb1d1cf097'::uuid,
@@ -360,7 +373,7 @@ VALUES
     'María Delgado',
     '1978-03-22',
     (SELECT id FROM sexes WHERE code='F'),
-    'high',
+    (SELECT id FROM risk_levels WHERE code='high'),
     NOW() - INTERVAL '120 days'
   ),
   (
@@ -369,7 +382,7 @@ VALUES
     'José Hernández',
     '1965-11-04',
     (SELECT id FROM sexes WHERE code='M'),
-    'medium',
+    (SELECT id FROM risk_levels WHERE code='medium'),
     NOW() - INTERVAL '180 days'
   ),
   (
@@ -378,7 +391,7 @@ VALUES
     'Valeria Ortiz',
     '1992-07-15',
     (SELECT id FROM sexes WHERE code='F'),
-    'low',
+    (SELECT id FROM risk_levels WHERE code='low'),
     NOW() - INTERVAL '45 days'
   )
 ON CONFLICT (id) DO NOTHING;
@@ -399,20 +412,20 @@ VALUES
   )
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO care_team_member (care_team_id, user_id, role_in_team, joined_at)
-SELECT '1ad17404-323c-4469-86eb-aef83336d1c9'::uuid, u.id, 'Cardióloga tratante', NOW() - INTERVAL '120 days'
+INSERT INTO care_team_member (care_team_id, user_id, role_id, joined_at)
+SELECT '1ad17404-323c-4469-86eb-aef83336d1c9'::uuid, u.id, (SELECT id FROM team_member_roles WHERE code='specialist'), NOW() - INTERVAL '120 days'
 FROM users u
 WHERE u.email='ana.ruiz@heartguard.com'
 ON CONFLICT DO NOTHING;
 
-INSERT INTO care_team_member (care_team_id, user_id, role_in_team, joined_at)
-SELECT '1ad17404-323c-4469-86eb-aef83336d1c9'::uuid, u.id, 'Analista de monitoreo', NOW() - INTERVAL '100 days'
+INSERT INTO care_team_member (care_team_id, user_id, role_id, joined_at)
+SELECT '1ad17404-323c-4469-86eb-aef83336d1c9'::uuid, u.id, (SELECT id FROM team_member_roles WHERE code='admin'), NOW() - INTERVAL '100 days'
 FROM users u
 WHERE u.email='martin.ops@heartguard.com'
 ON CONFLICT DO NOTHING;
 
-INSERT INTO care_team_member (care_team_id, user_id, role_in_team, joined_at)
-SELECT 'a9c83e54-30e5-4487-abb5-1f97a10cca17'::uuid, u.id, 'Supervisor clínico', NOW() - INTERVAL '150 days'
+INSERT INTO care_team_member (care_team_id, user_id, role_id, joined_at)
+SELECT 'a9c83e54-30e5-4487-abb5-1f97a10cca17'::uuid, u.id, (SELECT id FROM team_member_roles WHERE code='doctor'), NOW() - INTERVAL '150 days'
 FROM users u
 WHERE u.email='admin@heartguard.com'
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Normaliza los campos `risk_level` en la tabla `patients` y `role_in_team` en la tabla `care_team_member` a la Tercera Forma Normal (3FN).

- Crea nuevas tablas de catálogo `risk_levels` y `team_member_roles`.
- Modifica las tablas `patients` y `care_team_member` para usar claves foráneas que referencian a las nuevas tablas.
- Añade índices a todas las claves foráneas del esquema que no los tenían, incluyendo las nuevas, para mejorar el rendimiento de las consultas.
- Actualiza los datos de prueba (`seed.sql`) para que sean consistentes con el nuevo esquema.
- Actualiza los modelos de Go, el repositorio y los manejadores para reflejar los cambios en la base de datos, incluyendo la adición de `JOINs` en las consultas.
- Modifica las plantillas HTML para reemplazar campos de texto por menús desplegables (`<select>`) para los campos normalizados.
- Añade los nuevos catálogos al sistema de gestión de catálogos de la interfaz de superadministrador.