### PR TITLE
Fix gateway token identity handling and auth org fallback

### DIFF
--- a/microservicios/auth_service/repository.py
+++ b/microservicios/auth_service/repository.py
@@ -1,4 +1,5 @@
 from typing import Optional, Dict, Any, List
+
 from db import get_conn, put_conn
 
 def fetch_user_by_email(email: str) -> Optional[Dict[str, Any]]:
@@ -22,6 +23,24 @@ def fetch_user_by_email(email: str) -> Optional[Dict[str, Any]]:
                 "password_hash": row[3],
                 "user_status_id": str(row[4]) if row[4] else None
             }
+    finally:
+        put_conn(conn)
+
+
+def fetch_primary_org_for_user(user_id: str) -> Optional[str]:
+    sql = """
+        SELECT org_id
+          FROM user_org_membership
+         WHERE user_id = %s
+         ORDER BY joined_at ASC
+         LIMIT 1;
+    """
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, (user_id,))
+            row = cur.fetchone()
+            return str(row[0]) if row else None
     finally:
         put_conn(conn)
 

--- a/microservicios/auth_service/routes/auth.py
+++ b/microservicios/auth_service/routes/auth.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request
 from flask_jwt_extended import jwt_required, get_jwt, get_jwt_identity
 from responses import ok, err
 from repository import (
+    fetch_primary_org_for_user,
     fetch_user_by_email,
     insert_refresh_token,
     revoke_refresh_token,
@@ -39,6 +40,9 @@ def login():
     user = fetch_user_by_email(email)
     if not user or not verify_password(password, user["password_hash"]):
         return err("Credenciales inválidas", code="invalid_credentials", status=401)
+
+    if not org_id:
+        org_id = fetch_primary_org_for_user(user["id"]) or ""
 
     identity = {
         "user_id": user["id"],

--- a/microservicios/gateway/middleware/auth.py
+++ b/microservicios/gateway/middleware/auth.py
@@ -1,45 +1,66 @@
-import jwt
+"""Helpers related to authentication for the gateway service."""
+
 from functools import wraps
-from flask import request, jsonify, g
+
+import jwt
+from flask import g, jsonify, request
+
 from config import Config
 
-def token_required(f):
-    @wraps(f)
+
+def _extract_bearer_token() -> str | None:
+    """Return the bearer token sent in the Authorization header, if any."""
+
+    header_value = request.headers.get("Authorization", "").strip()
+    if not header_value:
+        return None
+
+    parts = header_value.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise ValueError("Formato de token inválido")
+    return parts[1]
+
+
+def token_required(fn):
+    """Ensure the request includes a valid JWT before proxying it."""
+
+    @wraps(fn)
     def decorated(*args, **kwargs):
-        token = None
-        if 'Authorization' in request.headers:
-            try:
-                # Espera un token "Bearer <token>"
-                token_parts = request.headers['Authorization'].split()
-                if token_parts[0].lower() != 'bearer' or len(token_parts) != 2:
-                    raise ValueError("Formato de token inválido")
-                token = token_parts[1]
-            except Exception:
-                 return jsonify({"message": "Formato de token inválido"}), 401
+        try:
+            token = _extract_bearer_token()
+        except ValueError as exc:
+            return jsonify({"message": str(exc)}), 401
 
         if not token:
             return jsonify({"message": "Token es requerido"}), 401
 
         try:
-            # Decodificar el token usando la clave y algoritmo de la config
-            data = jwt.decode(
-                token, 
-                Config.JWT_SECRET_KEY, 
-                algorithms=[Config.JWT_ALGORITHM]
+            claims = jwt.decode(
+                token,
+                Config.JWT_SECRET_KEY,
+                algorithms=[Config.JWT_ALGORITHM],
             )
-            
-            # Almacenar datos del token en el contexto global de Flask (g)
-            # para que la ruta del proxy pueda implementar la Tenancy (x-org-ID)
-            g.user_id = data.get('user_id')
-            g.org_id = data.get('org_id')
-
         except jwt.ExpiredSignatureError:
             return jsonify({"message": "Token ha expirado"}), 401
         except jwt.InvalidTokenError:
             return jsonify({"message": "Token inválido"}), 401
-        except Exception as e:
-            return jsonify({"message": "Error al procesar el token", "error": str(e)}), 401
+        except Exception as exc:  # pragma: no cover - caso inesperado
+            return (
+                jsonify({"message": "Error al procesar el token", "error": str(exc)}),
+                401,
+            )
 
-        return f(*args, **kwargs)
+        identity = claims.get("identity") or {}
+        if not isinstance(identity, dict):
+            identity = {}
+
+        g.token_claims = claims
+        g.user_id = identity.get("user_id")
+
+        org_id = identity.get("org_id") or request.headers.get("X-Org-ID")
+        g.org_id = org_id
+
+        return fn(*args, **kwargs)
 
     return decorated
+


### PR DESCRIPTION
## Summary
- ensure the gateway decodes identity claims correctly and forwards x-org-id headers consistently
- add a repository helper so auth/login falls back to the user's first organization when none is provided

## Testing
- python -m compileall microservicios

------
https://chatgpt.com/codex/tasks/task_e_69012e0762848322a04f3ddcc0a9540d