### PR TITLE
Add analytics service for metrics reporting and ingest

### DIFF
--- a/microservicios/analytics_service/.env.example
+++ b/microservicios/analytics_service/.env.example
@@ -1,0 +1,13 @@
+# Flask environment
+FLASK_ENV=development
+SERVICE_PORT=5010
+
+# Primary analytics database
+ANALYTICS_DATABASE_URL=postgresql://user:password@localhost:5432/analytics
+
+# Read-only connections to external services
+ANALYTICS_AUDIT_DATABASE_URL=postgresql://user:password@localhost:5432/audit
+ANALYTICS_ORG_DATABASE_URL=postgresql://user:password@localhost:5432/orgs
+
+# Internal authentication
+ANALYTICS_INTERNAL_API_KEY=replace-me

--- a/microservicios/analytics_service/__init__.py
+++ b/microservicios/analytics_service/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics service package."""

--- a/microservicios/analytics_service/app.py
+++ b/microservicios/analytics_service/app.py
@@ -1,0 +1,35 @@
+"""Application factory for the analytics service."""
+
+from __future__ import annotations
+
+from flask import Flask
+
+from config import engine, settings
+from models import Base
+from routes.ingest import bp as ingest_bp
+from routes.reports import bp as reports_bp
+from utils import create_response
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config.update(
+        ENV=settings.FLASK_ENV,
+        JSON_SORT_KEYS=False,
+    )
+
+    # Ensure tables exist when running the service standalone.
+    Base.metadata.create_all(bind=engine)
+
+    @app.get("/health")
+    def healthcheck():
+        return create_response({"service": "analytics_service", "status": "healthy"})
+
+    app.register_blueprint(reports_bp)
+    app.register_blueprint(ingest_bp)
+    return app
+
+
+if __name__ == "__main__":
+    service = create_app()
+    service.run(host="0.0.0.0", port=settings.SERVICE_PORT, debug=settings.FLASK_ENV == "development")

--- a/microservicios/analytics_service/config.py
+++ b/microservicios/analytics_service/config.py
@@ -1,0 +1,101 @@
+"""Configuration and database initialization for the analytics service."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# Load environment variables from the service specific .env file if present
+_SERVICE_DIR = Path(__file__).resolve().parent
+for candidate in (_SERVICE_DIR / ".env", _SERVICE_DIR.parent / ".env"):
+    if candidate.exists():
+        load_dotenv(candidate, override=False)
+
+
+class Settings:
+    """Typed access to configuration options."""
+
+    FLASK_ENV: str = os.getenv("FLASK_ENV", os.getenv("ENV", "production"))
+    SERVICE_PORT: int = int(os.getenv("ANALYTICS_SERVICE_PORT", os.getenv("SERVICE_PORT", "5010")))
+
+    DATABASE_URL: str = os.getenv("ANALYTICS_DATABASE_URL") or os.getenv("DATABASE_URL", "postgresql://heartguard_app:dev_change_me@localhost:5432/heartguard")
+    AUDIT_DATABASE_URL: Optional[str] = os.getenv("ANALYTICS_AUDIT_DATABASE_URL") or os.getenv("AUDIT_DATABASE_URL")
+    ORG_DATABASE_URL: Optional[str] = os.getenv("ANALYTICS_ORG_DATABASE_URL") or os.getenv("ORG_DATABASE_URL")
+
+    INTERNAL_API_KEY: str = os.getenv("ANALYTICS_INTERNAL_API_KEY", os.getenv("INTERNAL_API_KEY", ""))
+
+
+settings = Settings()
+
+
+def _build_engine(url: Optional[str]) -> Optional[Engine]:
+    if not url:
+        return None
+    return create_engine(url, pool_pre_ping=True, future=True)
+
+
+def _build_session_factory(engine: Optional[Engine]) -> Optional[sessionmaker]:
+    if engine is None:
+        return None
+    return sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+
+
+engine: Engine = create_engine(settings.DATABASE_URL, pool_pre_ping=True, future=True)
+SessionLocal: sessionmaker = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+
+audit_engine: Optional[Engine] = _build_engine(settings.AUDIT_DATABASE_URL)
+audit_session_factory: Optional[sessionmaker] = _build_session_factory(audit_engine)
+
+org_engine: Optional[Engine] = _build_engine(settings.ORG_DATABASE_URL)
+org_session_factory: Optional[sessionmaker] = _build_session_factory(org_engine)
+
+
+@contextmanager
+def get_db_session() -> Iterator[Session]:
+    """Context manager that yields a transactional session against the local database."""
+
+    session: Session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+@contextmanager
+def get_audit_session() -> Iterator[Session]:
+    """Yield a read-only session for the audit database if configured."""
+
+    if audit_session_factory is None:
+        raise RuntimeError("AUDIT_DATABASE_URL is not configured")
+
+    session: Session = audit_session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@contextmanager
+def get_org_session() -> Iterator[Session]:
+    """Yield a read-only session for the organization service database if configured."""
+
+    if org_session_factory is None:
+        raise RuntimeError("ORG_DATABASE_URL is not configured")
+
+    session: Session = org_session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+

--- a/microservicios/analytics_service/models.py
+++ b/microservicios/analytics_service/models.py
@@ -1,0 +1,52 @@
+"""Database models for the analytics service."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from config import engine
+
+
+class Base(DeclarativeBase):
+    """Declarative base used by all SQLAlchemy models in the service."""
+
+
+class ServiceHealth(Base):
+    """Store the last heartbeat and status for each internal service."""
+
+    __tablename__ = "service_health"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    service_name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="ok")
+    last_heartbeat: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+    payload: Mapped[Dict[str, Any]] = mapped_column("details", JSONB, nullable=False, default=dict)
+
+    def touch(self, status: str, metadata: Dict[str, Any]) -> None:
+        """Update this record with the latest status and metadata payload."""
+
+        self.status = status
+        self.last_heartbeat = datetime.now(timezone.utc)
+        self.payload = metadata
+
+
+# Create the tables on module import to simplify local development environments.
+Base.metadata.create_all(bind=engine)
+
+# Additional cross-service engines can be registered in :mod:`config` by creating
+# read-only engine factories, for example::
+#
+#     audit_db_engine = create_engine(settings.AUDIT_DATABASE_URL, future=True)
+#
+# Session factories exposed in :mod:`config` (``audit_session_factory`` and
+# ``org_session_factory``) provide dedicated connections for running analytical
+# queries against the audit and organization services without mutating their
+# state.

--- a/microservicios/analytics_service/repository.py
+++ b/microservicios/analytics_service/repository.py
@@ -40,17 +40,18 @@ def log_heartbeat(service_name: str, status: str, metadata: Optional[Dict[str, A
             ServiceHealth.service_name,
             ServiceHealth.status,
             ServiceHealth.last_heartbeat,
-            ServiceHealth.payload,
+            ServiceHealth.payload.label("metadata"),
         )
 
         result = session.execute(stmt)
         row = result.mappings().one()
         last_seen = row["last_heartbeat"]
+        metadata = row.get("metadata") or {}
         return {
             "service_name": row["service_name"],
             "status": row["status"],
             "last_heartbeat": last_seen.isoformat() if last_seen else None,
-            "metadata": row["payload"],
+            "metadata": metadata,
         }
 
 

--- a/microservicios/analytics_service/repository.py
+++ b/microservicios/analytics_service/repository.py
@@ -1,0 +1,89 @@
+"""Data access layer for the analytics service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from sqlalchemy import func, text
+from sqlalchemy.dialects.postgresql import insert
+
+from config import get_audit_session, get_db_session
+from models import ServiceHealth
+
+
+class RepositoryError(RuntimeError):
+    """Raised when repository operations fail."""
+
+
+def log_heartbeat(service_name: str, status: str, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Insert or update the heartbeat entry for a given service."""
+
+    metadata = metadata or {}
+    payload = {
+        "service_name": service_name,
+        "status": status,
+        "details": metadata,
+        "last_heartbeat": datetime.now(timezone.utc),
+    }
+
+    with get_db_session() as session:
+        insert_stmt = insert(ServiceHealth).values(payload)
+        stmt = insert_stmt.on_conflict_do_update(
+            index_elements=[ServiceHealth.service_name],
+            set_={
+                "status": insert_stmt.excluded.status,
+                "details": insert_stmt.excluded.details,
+                "last_heartbeat": func.now(),
+            },
+        ).returning(
+            ServiceHealth.service_name,
+            ServiceHealth.status,
+            ServiceHealth.last_heartbeat,
+            ServiceHealth.payload,
+        )
+
+        result = session.execute(stmt)
+        row = result.mappings().one()
+        last_seen = row["last_heartbeat"]
+        return {
+            "service_name": row["service_name"],
+            "status": row["status"],
+            "last_heartbeat": last_seen.isoformat() if last_seen else None,
+            "metadata": row["payload"],
+        }
+
+
+def get_overview_metrics(org_id: Optional[str], is_superadmin: bool) -> Dict[str, Any]:
+    """Fetch summary metrics from the audit service respecting org scoping."""
+
+    query = [
+        "SELECT",
+        "    COUNT(*) FILTER (WHERE action = 'login') AS login_events",
+        "  , COUNT(*) FILTER (WHERE action = 'data_export') AS data_exports",
+        "  , COUNT(DISTINCT user_id) AS active_users",
+        "  , MAX(created_at) AS last_event_at",
+        "FROM audit_logs",
+    ]
+
+    params: Dict[str, Any] = {}
+    if not is_superadmin:
+        if not org_id:
+            raise RepositoryError("Organization context is required for non super-admin users")
+        query.append("WHERE org_id = :org_id")
+        params["org_id"] = org_id
+
+    sql = text("\n".join(query))
+
+    with get_audit_session() as session:
+        row = session.execute(sql, params).mappings().one()
+
+    last_event_at = row["last_event_at"].isoformat() if row["last_event_at"] else None
+    return {
+        "login_events": int(row["login_events"] or 0),
+        "data_exports": int(row["data_exports"] or 0),
+        "active_users": int(row["active_users"] or 0),
+        "last_event_at": last_event_at,
+        "scope": "all" if is_superadmin and not org_id else org_id,
+    }
+

--- a/microservicios/analytics_service/requirements.txt
+++ b/microservicios/analytics_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3.0,<3.0.0
+SQLAlchemy>=2.0.0,<3.0.0
+psycopg2-binary>=2.9.0
+requests>=2.31.0
+dicttoxml>=1.7.16
+python-dotenv>=1.0.0

--- a/microservicios/analytics_service/routes/__init__.py
+++ b/microservicios/analytics_service/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Route blueprints for the analytics service."""

--- a/microservicios/analytics_service/routes/ingest.py
+++ b/microservicios/analytics_service/routes/ingest.py
@@ -1,0 +1,45 @@
+"""Endpoints for ingesting analytics signals."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from flask import Blueprint, request
+
+from repository import log_heartbeat
+from utils import create_response, require_internal_api_key
+
+bp = Blueprint("analytics_ingest", __name__, url_prefix="/v1/metrics")
+
+
+def _validate_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    service_name = (payload.get("service_name") or "").strip()
+    if not service_name:
+        raise ValueError("'service_name' is required")
+
+    status = (payload.get("status") or "ok").strip() or "ok"
+    metadata = payload.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise ValueError("'metadata' must be an object if provided")
+
+    return {
+        "service_name": service_name,
+        "status": status,
+        "metadata": metadata or {},
+    }
+
+
+@bp.post("/heartbeat")
+@require_internal_api_key
+def heartbeat():
+    """Register a heartbeat event emitted by an internal service."""
+
+    payload = request.get_json(silent=True) or {}
+    try:
+        data = _validate_payload(payload)
+    except ValueError as exc:
+        return create_response(message=str(exc), status_code=400)
+
+    record = log_heartbeat(**data)
+    return create_response(data=record, status_code=202)
+

--- a/microservicios/analytics_service/routes/ingest.py
+++ b/microservicios/analytics_service/routes/ingest.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from flask import Blueprint, request
 
-from repository import log_heartbeat
+from repository import RepositoryError, log_heartbeat
 from utils import create_response, require_internal_api_key
 
 bp = Blueprint("analytics_ingest", __name__, url_prefix="/v1/metrics")
@@ -40,6 +40,10 @@ def heartbeat():
     except ValueError as exc:
         return create_response(message=str(exc), status_code=400)
 
-    record = log_heartbeat(**data)
+    try:
+        record = log_heartbeat(**data)
+    except RepositoryError as exc:
+        return create_response(message=str(exc), status_code=500)
+
     return create_response(data=record, status_code=202)
 

--- a/microservicios/analytics_service/routes/reports.py
+++ b/microservicios/analytics_service/routes/reports.py
@@ -1,0 +1,29 @@
+"""Read-only reporting endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, g, request
+
+from repository import RepositoryError, get_overview_metrics
+from utils import create_response, require_auth
+
+bp = Blueprint("analytics_reports", __name__, url_prefix="/v1/metrics")
+
+
+@bp.get("/overview")
+@require_auth
+def overview_metrics():
+    """Return aggregated activity metrics for admins and superadmins."""
+
+    if g.role not in {"admin", "superadmin"}:
+        return create_response(message="Forbidden", status_code=403)
+
+    requested_org = request.args.get("org_id") if g.role == "superadmin" else g.org_id
+
+    try:
+        metrics = get_overview_metrics(requested_org, is_superadmin=(g.role == "superadmin"))
+    except RepositoryError as exc:
+        return create_response(message=str(exc), status_code=400)
+
+    return create_response(data=metrics)
+

--- a/microservicios/analytics_service/utils.py
+++ b/microservicios/analytics_service/utils.py
@@ -1,0 +1,73 @@
+"""HTTP helpers and decorators shared across the analytics service."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Dict, Optional
+
+from flask import Response, g, jsonify, request
+
+from config import settings
+
+
+def create_response(
+    data: Optional[Dict[str, Any]] = None,
+    *,
+    message: Optional[str] = None,
+    meta: Optional[Dict[str, Any]] = None,
+    status_code: int = 200,
+    errors: Optional[Dict[str, Any]] = None,
+) -> tuple[Response, int]:
+    """Return a standardized JSON response."""
+
+    payload: Dict[str, Any] = {"status": "ok" if status_code < 400 else "error"}
+    if message:
+        payload["message"] = message
+    if data is not None:
+        payload["data"] = data
+    if meta is not None:
+        payload["meta"] = meta
+    if errors:
+        payload["errors"] = errors
+    return jsonify(payload), status_code
+
+
+def require_auth(fn: Callable) -> Callable:
+    """Decorator ensuring the request carries the user context headers."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        user_id = request.headers.get("X-User-Id")
+        role = (request.headers.get("X-User-Role") or "").strip().lower()
+        org_id = request.headers.get("X-Org-Id")
+
+        if not user_id:
+            return create_response(message="Missing authentication context", status_code=401)
+        if not org_id and role != "superadmin":
+            return create_response(message="Organization context required", status_code=400)
+
+        g.user_id = user_id
+        g.role = role
+        g.org_id = org_id
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def require_internal_api_key(fn: Callable) -> Callable:
+    """Protect endpoints with the configured internal API key."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        expected_key = settings.INTERNAL_API_KEY
+        provided_key = request.headers.get("X-Internal-API-Key")
+
+        if not expected_key:
+            return create_response(message="Internal API key is not configured", status_code=500)
+        if not provided_key or provided_key != expected_key:
+            return create_response(message="Forbidden", status_code=403)
+
+        return fn(*args, **kwargs)
+
+    return wrapper
+


### PR DESCRIPTION
## Summary
- add the analytics_service package with configuration, models, repository helpers, and an app factory
- implement metrics overview and heartbeat ingest blueprints protected by shared utilities
- provide example environment variables and service-specific requirements

## Testing
- python -m compileall microservicios/analytics_service

------
https://chatgpt.com/codex/tasks/task_e_6902612dd8348323b0cb29a81479c45e