### PR TITLE
Add multi-tenant alert service microservice

### DIFF
--- a/microservicios/alert_service/.env.example
+++ b/microservicios/alert_service/.env.example
@@ -1,0 +1,5 @@
+FLASK_ENV=development
+DATABASE_URL=postgresql://user:password@db_host:5432/alert_db
+JWT_SECRET=tu-clave-secreta-compartida
+AUDIT_SERVICE_URL=http://audit_service:5000/v1/log
+ANALYTICS_SERVICE_URL=http://analytics_service:5000/v1/ingest

--- a/microservicios/alert_service/__init__.py
+++ b/microservicios/alert_service/__init__.py
@@ -1,0 +1,3 @@
+"""Alert service package."""
+
+from .app import create_app  # noqa: F401

--- a/microservicios/alert_service/app.py
+++ b/microservicios/alert_service/app.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Optional
+
+from flask import Flask
+
+from .config import Config
+from .db import db
+from .routes import alerts_bp
+
+
+def create_app(config_object: Optional[type] = None) -> Flask:
+    app = Flask(__name__)
+    cfg = config_object or Config
+    app.config.from_object(cfg)
+
+    if not app.config.get("SQLALCHEMY_DATABASE_URI"):
+        raise RuntimeError("DATABASE_URL is not configured")
+
+    logging.basicConfig(level=logging.INFO)
+
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+
+    app.register_blueprint(alerts_bp)
+
+    @app.route("/health", methods=["GET"])
+    def health() -> str:
+        return "OK"
+
+    return app
+
+
+app: Optional[Flask]
+try:
+    app = create_app()
+except RuntimeError:
+    app = None

--- a/microservicios/alert_service/config.py
+++ b/microservicios/alert_service/config.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+BASE_DIR = Path(__file__).resolve().parent
+load_dotenv(BASE_DIR / ".env")
+
+
+class Config:
+    FLASK_ENV = os.getenv("FLASK_ENV", "production")
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    JWT_SECRET = os.getenv("JWT_SECRET", "")
+    AUDIT_SERVICE_URL = os.getenv("AUDIT_SERVICE_URL", "")
+    ANALYTICS_SERVICE_URL = os.getenv("ANALYTICS_SERVICE_URL", "")

--- a/microservicios/alert_service/db.py
+++ b/microservicios/alert_service/db.py
@@ -1,0 +1,4 @@
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()

--- a/microservicios/alert_service/models.py
+++ b/microservicios/alert_service/models.py
@@ -1,0 +1,115 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import relationship
+
+from .db import db
+
+
+class BaseModel(db.Model):
+    __abstract__ = True
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(UUID(as_uuid=True), nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    @declared_attr
+    def __tablename__(cls) -> str:  # type: ignore[misc]
+        return cls.__name__.lower()
+
+
+class AlertType(BaseModel):
+    name = Column(String(120), nullable=False)
+    description = Column(Text, nullable=True)
+
+    alerts = relationship("Alert", back_populates="alert_type")
+
+
+class AlertLevel(BaseModel):
+    name = Column(String(50), nullable=False)
+    description = Column(Text, nullable=True)
+
+    alerts = relationship("Alert", back_populates="alert_level")
+
+
+class AlertStatus(BaseModel):
+    name = Column(String(50), nullable=False)
+    description = Column(Text, nullable=True)
+
+    alerts = relationship("Alert", back_populates="alert_status")
+
+
+class DeliveryStatus(BaseModel):
+    name = Column(String(50), nullable=False)
+    description = Column(Text, nullable=True)
+
+    deliveries = relationship("AlertDelivery", back_populates="delivery_status")
+
+
+class Alert(BaseModel):
+    patient_id = Column(UUID(as_uuid=True), nullable=False)
+    alert_type_id = Column(
+        UUID(as_uuid=True), ForeignKey("alerttype.id", ondelete="RESTRICT"), nullable=False
+    )
+    alert_level_id = Column(
+        UUID(as_uuid=True), ForeignKey("alertlevel.id", ondelete="RESTRICT"), nullable=False
+    )
+    alert_status_id = Column(
+        UUID(as_uuid=True), ForeignKey("alertstatus.id", ondelete="RESTRICT"), nullable=False
+    )
+    message = Column(Text, nullable=False)
+    payload = Column(JSONB, nullable=True)
+    is_active = Column(Boolean, default=True, nullable=False)
+
+    alert_type = relationship("AlertType", back_populates="alerts")
+    alert_level = relationship("AlertLevel", back_populates="alerts")
+    alert_status = relationship("AlertStatus", back_populates="alerts")
+    deliveries = relationship("AlertDelivery", back_populates="alert", cascade="all,delete")
+    ground_truth_labels = relationship(
+        "GroundTruthLabel", back_populates="alert", cascade="all,delete"
+    )
+
+
+class AlertDelivery(BaseModel):
+    alert_id = Column(
+        UUID(as_uuid=True), ForeignKey("alert.id", ondelete="CASCADE"), nullable=False
+    )
+    delivery_status_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("deliverystatus.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    channel = Column(String(50), nullable=False)
+    recipient = Column(String(255), nullable=False)
+    delivered_at = Column(DateTime, nullable=True)
+    payload = Column(JSONB, nullable=True)
+
+    alert = relationship("Alert", back_populates="deliveries")
+    delivery_status = relationship("DeliveryStatus", back_populates="deliveries")
+
+
+class GroundTruthLabel(BaseModel):
+    alert_id = Column(
+        UUID(as_uuid=True), ForeignKey("alert.id", ondelete="CASCADE"), nullable=False
+    )
+    label = Column(String(120), nullable=False)
+    notes = Column(Text, nullable=True)
+
+    alert = relationship("Alert", back_populates="ground_truth_labels")
+
+
+__all__ = [
+    "Alert",
+    "AlertType",
+    "AlertLevel",
+    "AlertStatus",
+    "AlertDelivery",
+    "DeliveryStatus",
+    "GroundTruthLabel",
+]

--- a/microservicios/alert_service/repository.py
+++ b/microservicios/alert_service/repository.py
@@ -1,0 +1,156 @@
+import uuid
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.exc import NoResultFound
+
+from .db import db
+from .models import (
+    Alert,
+    AlertDelivery,
+    AlertLevel,
+    AlertStatus,
+    AlertType,
+    DeliveryStatus,
+    GroundTruthLabel,
+)
+
+
+def _as_uuid(value: Any) -> uuid.UUID:
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))
+
+
+class AlertRepository:
+    def __init__(self, session=None) -> None:
+        self.session = session or db.session
+
+    def _filter_by_org(self, model, org_id: Any):
+        normalized_org_id = _as_uuid(org_id)
+        return self.session.query(model).filter(model.org_id == normalized_org_id)
+
+    def _get_alert(self, alert_id: str, org_id: str) -> Alert:
+        alert_uuid = _as_uuid(alert_id)
+        query = self._filter_by_org(Alert, org_id).filter(Alert.id == alert_uuid)
+        alert = query.one_or_none()
+        if not alert:
+            raise NoResultFound("Alert not found")
+        return alert
+
+    def get_alerts(self, org_id: str, filters: Optional[Dict[str, Any]] = None) -> List[Alert]:
+        query = self._filter_by_org(Alert, org_id)
+        filters = filters or {}
+
+        if "patient_id" in filters:
+            query = query.filter(Alert.patient_id == _as_uuid(filters["patient_id"]))
+        if "status_id" in filters:
+            query = query.filter(Alert.alert_status_id == _as_uuid(filters["status_id"]))
+        if "type_id" in filters:
+            query = query.filter(Alert.alert_type_id == _as_uuid(filters["type_id"]))
+        if "level_id" in filters:
+            query = query.filter(Alert.alert_level_id == _as_uuid(filters["level_id"]))
+
+        return query.order_by(Alert.created_at.desc()).all()
+
+    def get_active_alerts_by_patient(self, org_id: str, patient_id: str) -> List[Alert]:
+        return (
+            self._filter_by_org(Alert, org_id)
+            .filter(Alert.patient_id == _as_uuid(patient_id), Alert.is_active.is_(True))
+            .order_by(Alert.created_at.desc())
+            .all()
+        )
+
+    def create_alert(self, org_id: str, data: Dict[str, Any]) -> Alert:
+        alert = Alert(org_id=_as_uuid(org_id), **data)
+        self.session.add(alert)
+        self.session.commit()
+        return alert
+
+    def update_alert(self, alert_id: str, org_id: str, data: Dict[str, Any]) -> Alert:
+        alert = self._get_alert(alert_id, org_id)
+        for key, value in data.items():
+            setattr(alert, key, value)
+        self.session.commit()
+        return alert
+
+    def delete_alert(self, alert_id: str, org_id: str) -> None:
+        alert = self._get_alert(alert_id, org_id)
+        self.session.delete(alert)
+        self.session.commit()
+
+    def create_delivery(self, alert_id: str, org_id: str, data: Dict[str, Any]) -> AlertDelivery:
+        self._get_alert(alert_id, org_id)
+        delivery = AlertDelivery(org_id=_as_uuid(org_id), alert_id=_as_uuid(alert_id), **data)
+        self.session.add(delivery)
+        self.session.commit()
+        return delivery
+
+    def create_ground_truth_label(
+        self, alert_id: str, org_id: str, data: Dict[str, Any]
+    ) -> GroundTruthLabel:
+        self._get_alert(alert_id, org_id)
+        label = GroundTruthLabel(org_id=_as_uuid(org_id), alert_id=_as_uuid(alert_id), **data)
+        self.session.add(label)
+        self.session.commit()
+        return label
+
+    def list_alert_types(self, org_id: str) -> List[AlertType]:
+        return self._filter_by_org(AlertType, org_id).all()
+
+    def list_alert_levels(self, org_id: str) -> List[AlertLevel]:
+        return self._filter_by_org(AlertLevel, org_id).all()
+
+    def list_alert_statuses(self, org_id: str) -> List[AlertStatus]:
+        return self._filter_by_org(AlertStatus, org_id).all()
+
+    def list_delivery_statuses(self, org_id: str) -> List[DeliveryStatus]:
+        return self._filter_by_org(DeliveryStatus, org_id).all()
+
+
+def serialize_alert(alert: Alert) -> Dict[str, Any]:
+    return {
+        "id": str(alert.id),
+        "org_id": str(alert.org_id),
+        "patient_id": str(alert.patient_id),
+        "alert_type_id": str(alert.alert_type_id),
+        "alert_level_id": str(alert.alert_level_id),
+        "alert_status_id": str(alert.alert_status_id),
+        "message": alert.message,
+        "payload": alert.payload or {},
+        "is_active": alert.is_active,
+        "created_at": alert.created_at.isoformat(),
+        "updated_at": alert.updated_at.isoformat(),
+    }
+
+
+def serialize_delivery(delivery: AlertDelivery) -> Dict[str, Any]:
+    return {
+        "id": str(delivery.id),
+        "alert_id": str(delivery.alert_id),
+        "org_id": str(delivery.org_id),
+        "delivery_status_id": str(delivery.delivery_status_id),
+        "channel": delivery.channel,
+        "recipient": delivery.recipient,
+        "delivered_at": delivery.delivered_at.isoformat() if delivery.delivered_at else None,
+        "payload": delivery.payload or {},
+        "created_at": delivery.created_at.isoformat(),
+    }
+
+
+def serialize_label(label: GroundTruthLabel) -> Dict[str, Any]:
+    return {
+        "id": str(label.id),
+        "alert_id": str(label.alert_id),
+        "org_id": str(label.org_id),
+        "label": label.label,
+        "notes": label.notes,
+        "created_at": label.created_at.isoformat(),
+    }
+
+
+__all__ = [
+    "AlertRepository",
+    "serialize_alert",
+    "serialize_delivery",
+    "serialize_label",
+]

--- a/microservicios/alert_service/requirements.txt
+++ b/microservicios/alert_service/requirements.txt
@@ -1,0 +1,8 @@
+Flask
+Flask-SQLAlchemy
+psycopg2-binary
+python-dotenv
+requests
+PyJWT
+dicttoxml
+gunicorn

--- a/microservicios/alert_service/routes/__init__.py
+++ b/microservicios/alert_service/routes/__init__.py
@@ -1,0 +1,6 @@
+from flask import Blueprint
+
+
+alerts_bp = Blueprint("alerts", __name__, url_prefix="/v1")
+
+from . import alerts  # noqa: E402,F401

--- a/microservicios/alert_service/routes/alerts.py
+++ b/microservicios/alert_service/routes/alerts.py
@@ -1,0 +1,206 @@
+from datetime import datetime
+from typing import Any, Dict
+
+from flask import abort, g, request
+from sqlalchemy.exc import NoResultFound
+
+from ..repository import (
+    AlertRepository,
+    serialize_alert,
+    serialize_delivery,
+    serialize_label,
+)
+from ..utils import (
+    AuthError,
+    auto_response,
+    send_analytics_event,
+    send_audit_event,
+    token_required,
+)
+from . import alerts_bp
+
+
+repository = AlertRepository()
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("Invalid datetime format. Use ISO 8601.") from exc
+
+
+def _parse_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    return bool(value)
+
+
+@alerts_bp.errorhandler(AuthError)
+def handle_auth_error(error: AuthError):
+    return auto_response({"error": str(error)}, 401)
+
+
+@alerts_bp.errorhandler(NoResultFound)
+def handle_not_found(error: NoResultFound):
+    return auto_response({"error": str(error)}, 404)
+
+
+@alerts_bp.errorhandler(ValueError)
+def handle_value_error(error: ValueError):
+    return auto_response({"error": str(error)}, 400)
+
+
+@alerts_bp.route("/alerts", methods=["GET"])
+@token_required
+def list_alerts():
+    filters = {}
+    for key in ("patient_id", "status_id", "type_id", "level_id"):
+        value = request.args.get(key)
+        if value:
+            filters[key] = value
+
+    alerts = repository.get_alerts(g.org_id, filters)
+    send_analytics_event("alerts.list", {"filters": filters})
+    return auto_response({"alerts": [serialize_alert(alert) for alert in alerts]})
+
+
+@alerts_bp.route("/alerts", methods=["POST"])
+@token_required
+def create_alert():
+    payload = request.get_json() or {}
+    required_fields = [
+        "patient_id",
+        "alert_type_id",
+        "alert_level_id",
+        "alert_status_id",
+        "message",
+    ]
+    missing = [field for field in required_fields if field not in payload]
+    if missing:
+        abort(400, description=f"Missing fields: {', '.join(missing)}")
+
+    data: Dict[str, Any] = {
+        "patient_id": payload["patient_id"],
+        "alert_type_id": payload["alert_type_id"],
+        "alert_level_id": payload["alert_level_id"],
+        "alert_status_id": payload["alert_status_id"],
+        "message": payload["message"],
+    }
+    if "payload" in payload:
+        data["payload"] = payload["payload"]
+    if "is_active" in payload:
+        data["is_active"] = _parse_bool(payload["is_active"])
+
+    alert = repository.create_alert(g.org_id, data)
+    send_audit_event("CREATE_ALERT", {"alert_id": str(alert.id)})
+    send_analytics_event("alerts.created", {"alert_id": str(alert.id)})
+    return auto_response({"alert": serialize_alert(alert)}, 201)
+
+
+@alerts_bp.route("/alerts/<alert_id>", methods=["PATCH"])
+@token_required
+def update_alert(alert_id: str):
+    payload = request.get_json() or {}
+    allowed = {
+        "alert_type_id",
+        "alert_level_id",
+        "alert_status_id",
+        "message",
+        "payload",
+        "is_active",
+    }
+
+    update_data: Dict[str, Any] = {}
+    for key in allowed:
+        if key in payload:
+            update_data[key] = (
+                _parse_bool(payload[key]) if key == "is_active" else payload[key]
+            )
+
+    if not update_data:
+        abort(400, description="No valid fields to update")
+
+    alert = repository.update_alert(alert_id, g.org_id, update_data)
+    send_audit_event("UPDATE_ALERT", {"alert_id": str(alert.id)})
+    send_analytics_event("alerts.updated", {"alert_id": str(alert.id)})
+    return auto_response({"alert": serialize_alert(alert)})
+
+
+@alerts_bp.route("/alerts/<alert_id>", methods=["DELETE"])
+@token_required
+def delete_alert(alert_id: str):
+    repository.delete_alert(alert_id, g.org_id)
+    send_audit_event("DELETE_ALERT", {"alert_id": alert_id})
+    send_analytics_event("alerts.deleted", {"alert_id": alert_id})
+    return auto_response({"deleted": True})
+
+
+@alerts_bp.route("/alerts/active-by-patient", methods=["GET"])
+@token_required
+def active_alerts_by_patient():
+    patient_id = request.args.get("patient_id")
+    if not patient_id:
+        abort(400, description="patient_id query parameter is required")
+
+    alerts = repository.get_active_alerts_by_patient(g.org_id, patient_id)
+    send_analytics_event(
+        "alerts.active_by_patient", {"patient_id": patient_id, "count": len(alerts)}
+    )
+    return auto_response({"alerts": [serialize_alert(alert) for alert in alerts]})
+
+
+@alerts_bp.route("/alerts/<alert_id>/deliveries", methods=["POST"])
+@token_required
+def create_delivery(alert_id: str):
+    payload = request.get_json() or {}
+    required_fields = ["delivery_status_id", "channel", "recipient"]
+    missing = [field for field in required_fields if field not in payload]
+    if missing:
+        abort(400, description=f"Missing fields: {', '.join(missing)}")
+
+    data: Dict[str, Any] = {
+        "delivery_status_id": payload["delivery_status_id"],
+        "channel": payload["channel"],
+        "recipient": payload["recipient"],
+    }
+    if "delivered_at" in payload and payload["delivered_at"]:
+        data["delivered_at"] = _parse_iso_datetime(payload["delivered_at"])
+    if "payload" in payload:
+        data["payload"] = payload["payload"]
+
+    delivery = repository.create_delivery(alert_id, g.org_id, data)
+    send_audit_event(
+        "CREATE_ALERT_DELIVERY", {"alert_id": alert_id, "delivery_id": str(delivery.id)}
+    )
+    send_analytics_event(
+        "alerts.delivery_created", {"alert_id": alert_id, "delivery_id": str(delivery.id)}
+    )
+    return auto_response({"delivery": serialize_delivery(delivery)}, 201)
+
+
+@alerts_bp.route("/labels", methods=["POST"])
+@token_required
+def create_label():
+    payload = request.get_json() or {}
+    required_fields = ["alert_id", "label"]
+    missing = [field for field in required_fields if field not in payload]
+    if missing:
+        abort(400, description=f"Missing fields: {', '.join(missing)}")
+
+    data: Dict[str, Any] = {"label": payload["label"]}
+    if "notes" in payload:
+        data["notes"] = payload["notes"]
+
+    label = repository.create_ground_truth_label(payload["alert_id"], g.org_id, data)
+    send_audit_event(
+        "CREATE_GROUND_TRUTH_LABEL",
+        {"alert_id": payload["alert_id"], "label_id": str(label.id)},
+    )
+    send_analytics_event(
+        "alerts.label_created",
+        {"alert_id": payload["alert_id"], "label_id": str(label.id)},
+    )
+    return auto_response({"label": serialize_label(label)}, 201)

--- a/microservicios/alert_service/test_alert_service.bat
+++ b/microservicios/alert_service/test_alert_service.bat
@@ -36,7 +36,13 @@ if errorlevel 1 goto :fail
 "%PYTHON_EXE%" -m pip install pytest >nul
 if errorlevel 1 goto :fail
 
-set "PYTHONPATH=%SERVICE_DIR%;%PYTHONPATH%"
+for %%I in ("%SERVICE_DIR%\..") do set "MICROSERVICES_DIR=%%~fI"
+for %%I in ("%MICROSERVICES_DIR%\..") do set "REPO_DIR=%%~fI"
+if defined PYTHONPATH (
+    set "PYTHONPATH=%REPO_DIR%;%MICROSERVICES_DIR%;%SERVICE_DIR%;%PYTHONPATH%"
+) else (
+    set "PYTHONPATH=%REPO_DIR%;%MICROSERVICES_DIR%;%SERVICE_DIR%"
+)
 set "FLASK_ENV=testing"
 set "DATABASE_URL=sqlite+pysqlite:///:memory:"
 set "JWT_SECRET=test-secret"
@@ -50,7 +56,7 @@ echo [alert] Ejecutando pruebas unitarias...
 "%PYTHON_EXE%" -m pytest "%SERVICE_DIR%\tests" %PYTEST_ARGS%
 set "TEST_EXIT=%ERRORLEVEL%"
 
-if %TEST_EXIT% EQU 0 (
+if "%TEST_EXIT%"=="0" (
     echo [alert] Todas las pruebas pasaron correctamente.
     goto :success
 ) else (

--- a/microservicios/alert_service/test_alert_service.bat
+++ b/microservicios/alert_service/test_alert_service.bat
@@ -1,0 +1,78 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+rem --------------------------------------------------------------
+rem  Script de validacion para el microservicio alert_service
+rem --------------------------------------------------------------
+
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+set "SERVICE_DIR=%cd%"
+set "VENV_DIR=%SERVICE_DIR%\.venv"
+set "PYTHON_EXE=%VENV_DIR%\Scripts\python.exe"
+set "PYTEST_ARGS=-q"
+
+call :find_python
+if errorlevel 1 goto :fail
+
+if not exist "%VENV_DIR%" (
+    echo [alert] Creando entorno virtual...
+    "%PYTHON_BOOTSTRAP%" -m venv "%VENV_DIR%"
+    if errorlevel 1 goto :fail
+) else (
+    echo [alert] Entorno virtual existente.
+)
+
+if not exist "%PYTHON_EXE%" (
+    echo [alert] No se encontro el interprete en el entorno virtual.
+    goto :fail
+)
+
+echo [alert] Instalando dependencias del servicio...
+"%PYTHON_EXE%" -m pip install --upgrade pip >nul
+if errorlevel 1 goto :fail
+"%PYTHON_EXE%" -m pip install -r "%SERVICE_DIR%\requirements.txt" >nul
+if errorlevel 1 goto :fail
+"%PYTHON_EXE%" -m pip install pytest >nul
+if errorlevel 1 goto :fail
+
+set "PYTHONPATH=%SERVICE_DIR%;%PYTHONPATH%"
+set "FLASK_ENV=testing"
+set "DATABASE_URL=sqlite+pysqlite:///:memory:"
+set "JWT_SECRET=test-secret"
+set "AUDIT_SERVICE_URL=http://localhost:5000/v1/log"
+set "ANALYTICS_SERVICE_URL=http://localhost:5001/v1/ingest"
+
+rem Se utiliza sqlite en memoria para las pruebas unitarias
+set "SQLALCHEMY_SILENCE_UBER_WARNING=1"
+
+echo [alert] Ejecutando pruebas unitarias...
+"%PYTHON_EXE%" -m pytest "%SERVICE_DIR%\tests" %PYTEST_ARGS%
+set "TEST_EXIT=%ERRORLEVEL%"
+
+if %TEST_EXIT% EQU 0 (
+    echo [alert] Todas las pruebas pasaron correctamente.
+    goto :success
+) else (
+    echo [alert] Fallo durante la ejecucion de pruebas (codigo %TEST_EXIT%).
+    goto :fail
+)
+
+:find_python
+for %%P in (py python python3) do (
+    where %%P >nul 2>nul
+    if not errorlevel 1 (
+        set "PYTHON_BOOTSTRAP=%%P"
+        exit /b 0
+    )
+)
+echo [alert] No se encontro un interprete de Python en el PATH.
+exit /b 1
+
+:success
+endlocal & exit /b 0
+
+:fail
+set "EXIT_CODE=%ERRORLEVEL%"
+if not defined EXIT_CODE set "EXIT_CODE=1"
+endlocal & exit /b %EXIT_CODE%

--- a/microservicios/alert_service/tests/__init__.py
+++ b/microservicios/alert_service/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package initializer

--- a/microservicios/alert_service/tests/test_alerts.py
+++ b/microservicios/alert_service/tests/test_alerts.py
@@ -1,0 +1,101 @@
+import uuid
+from typing import Dict
+
+import jwt
+import pytest
+
+from microservicios.alert_service.app import create_app
+from microservicios.alert_service.config import Config
+from microservicios.alert_service.db import db
+from microservicios.alert_service.models import Alert, AlertLevel, AlertStatus, AlertType
+
+
+class TestConfig(Config):
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    TESTING = True
+    JWT_SECRET = "test-secret"
+
+
+@pytest.fixture
+def app():
+    app = create_app(TestConfig)
+    with app.app_context():
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def auth_context(app):
+    org_id = uuid.uuid4()
+    token = jwt.encode({"user_id": "user-1", "org_id": str(org_id)}, app.config["JWT_SECRET"], algorithm="HS256")
+    headers = {"Authorization": f"Bearer {token}"}
+    return headers, org_id
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _seed_dependencies(org_id: uuid.UUID) -> Dict[str, uuid.UUID]:
+    alert_type = AlertType(org_id=org_id, name="Vital", description="Vital alert")
+    alert_level = AlertLevel(org_id=org_id, name="High", description="High risk")
+    alert_status = AlertStatus(org_id=org_id, name="Open", description="Open alert")
+    db.session.add_all([alert_type, alert_level, alert_status])
+    db.session.commit()
+    return {
+        "alert_type_id": alert_type.id,
+        "alert_level_id": alert_level.id,
+        "alert_status_id": alert_status.id,
+    }
+
+
+def test_list_alerts_returns_empty(client, auth_context):
+    headers, _ = auth_context
+    response = client.get("/v1/alerts", headers=headers)
+    assert response.status_code == 200
+    assert response.get_json() == {"alerts": []}
+
+
+def test_list_alerts_filters_by_org(client, auth_context):
+    headers, org_id = auth_context
+    other_org_id = uuid.uuid4()
+
+    with client.application.app_context():
+        ids = _seed_dependencies(org_id)
+        other_ids = _seed_dependencies(other_org_id)
+
+        alert = Alert(
+            org_id=org_id,
+            patient_id=uuid.uuid4(),
+            alert_type_id=ids["alert_type_id"],
+            alert_level_id=ids["alert_level_id"],
+            alert_status_id=ids["alert_status_id"],
+            message="Test alert",
+        )
+        db.session.add(alert)
+        other_alert = Alert(
+            org_id=other_org_id,
+            patient_id=uuid.uuid4(),
+            alert_type_id=other_ids["alert_type_id"],
+            alert_level_id=other_ids["alert_level_id"],
+            alert_status_id=other_ids["alert_status_id"],
+            message="Should not appear",
+        )
+        db.session.add(other_alert)
+        db.session.commit()
+
+    response = client.get("/v1/alerts", headers=headers)
+    data = response.get_json()
+    assert response.status_code == 200
+    assert len(data["alerts"]) == 1
+    assert data["alerts"][0]["message"] == "Test alert"
+
+
+def test_list_alerts_returns_xml(client, auth_context):
+    headers, _ = auth_context
+    headers = {**headers, "Accept": "application/xml"}
+    response = client.get("/v1/alerts", headers=headers)
+    assert response.status_code == 200
+    assert response.mimetype == "application/xml"

--- a/microservicios/alert_service/utils/__init__.py
+++ b/microservicios/alert_service/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the alert service."""
+
+from .auth import token_required  # noqa: F401
+from .helpers import send_audit_event, send_analytics_event  # noqa: F401
+from .responses import auto_response  # noqa: F401

--- a/microservicios/alert_service/utils/__init__.py
+++ b/microservicios/alert_service/utils/__init__.py
@@ -1,5 +1,13 @@
 """Utility helpers for the alert service."""
 
-from .auth import token_required  # noqa: F401
+from .auth import AuthError, token_required  # noqa: F401
 from .helpers import send_audit_event, send_analytics_event  # noqa: F401
 from .responses import auto_response  # noqa: F401
+
+__all__ = [
+    "AuthError",
+    "token_required",
+    "send_audit_event",
+    "send_analytics_event",
+    "auto_response",
+]

--- a/microservicios/alert_service/utils/__init__.py
+++ b/microservicios/alert_service/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers for the alert service."""
 
-from .auth import token_required  # noqa: F401
+from .auth import AuthError, token_required  # noqa: F401
 from .helpers import send_audit_event, send_analytics_event  # noqa: F401
 from .responses import auto_response  # noqa: F401

--- a/microservicios/alert_service/utils/auth.py
+++ b/microservicios/alert_service/utils/auth.py
@@ -1,0 +1,56 @@
+import os
+from functools import wraps
+from typing import Any, Callable
+
+import jwt
+from flask import abort, current_app, g, request
+
+
+class AuthError(Exception):
+    """Custom exception for authentication failures."""
+
+
+def _get_jwt_secret() -> str:
+    secret = current_app.config.get("JWT_SECRET") if current_app else None
+    return secret or os.getenv("JWT_SECRET", "")
+
+
+def token_required(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator that ensures the requester presents a valid JWT token."""
+
+    @wraps(f)
+    def decorated(*args: Any, **kwargs: Any):
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            abort(401, description="Missing or invalid authorization header")
+
+        token = auth_header.split(" ", 1)[1].strip()
+        secret = _get_jwt_secret()
+        if not secret:
+            abort(500, description="JWT secret is not configured")
+
+        try:
+            payload = jwt.decode(token, secret, algorithms=["HS256"])
+        except jwt.ExpiredSignatureError as exc:
+            raise AuthError("Token expired") from exc
+        except jwt.InvalidTokenError as exc:
+            raise AuthError("Invalid token") from exc
+
+        user_id = payload.get("user_id")
+        org_id = payload.get("org_id")
+
+        if not org_id:
+            org_id = request.headers.get("x-org-id") or request.headers.get("X-Org-ID")
+
+        if not org_id:
+            abort(403, description="Organization context is required")
+
+        g.user_id = user_id
+        g.org_id = org_id
+
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+__all__ = ["token_required", "AuthError"]

--- a/microservicios/alert_service/utils/helpers.py
+++ b/microservicios/alert_service/utils/helpers.py
@@ -1,0 +1,54 @@
+import logging
+import os
+from typing import Any, Dict
+
+import requests
+from flask import current_app, g
+
+logger = logging.getLogger(__name__)
+
+
+def _get_service_url(config_key: str, env_key: str) -> str:
+    if current_app:
+        url = current_app.config.get(config_key)
+    else:
+        url = None
+    return url or os.getenv(env_key, "")
+
+
+def _post_with_timeout(url: str, payload: Dict[str, Any], timeout: float = 2.0) -> None:
+    if not url:
+        logger.warning("Target URL not configured for payload: %s", payload)
+        return
+
+    try:
+        requests.post(url, json=payload, timeout=timeout)
+    except requests.RequestException as exc:
+        logger.error("Failed to send payload to %s: %s", url, exc)
+
+
+def send_audit_event(action: str, details: Dict[str, Any]) -> None:
+    payload = {
+        "service": "alert_service",
+        "action": action,
+        "user_id": getattr(g, "user_id", None),
+        "org_id": getattr(g, "org_id", None),
+        "details": details,
+    }
+    url = _get_service_url("AUDIT_SERVICE_URL", "AUDIT_SERVICE_URL")
+    _post_with_timeout(url, payload)
+
+
+def send_analytics_event(event_type: str, payload: Dict[str, Any]) -> None:
+    body = {
+        "service": "alert_service",
+        "event_type": event_type,
+        "user_id": getattr(g, "user_id", None),
+        "org_id": getattr(g, "org_id", None),
+        "payload": payload,
+    }
+    url = _get_service_url("ANALYTICS_SERVICE_URL", "ANALYTICS_SERVICE_URL")
+    _post_with_timeout(url, body)
+
+
+__all__ = ["send_audit_event", "send_analytics_event"]

--- a/microservicios/alert_service/utils/responses.py
+++ b/microservicios/alert_service/utils/responses.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict
+
+from dicttoxml import dicttoxml
+from flask import Response, jsonify, request
+
+
+def auto_response(data: Dict[str, Any], status_code: int = 200) -> Response:
+    """Return a Flask response based on the Accept header."""
+    accept_header = request.headers.get("Accept", "application/json")
+
+    if "application/xml" in accept_header:
+        xml = dicttoxml(data, custom_root="response", attr_type=False)
+        return Response(xml, status=status_code, mimetype="application/xml")
+
+    response = jsonify(data)
+    response.status_code = status_code
+    return response
+
+
+__all__ = ["auto_response"]


### PR DESCRIPTION
## Summary
- add a Flask-based alert service with database models, repository layer, and application factory
- implement JWT auth, automatic JSON/XML responses, and integrations with audit and analytics services
- expose alert management routes and seed configuration, requirements, and basic tests

## Testing
- pytest microservicios/alert_service/tests/test_alerts.py *(fails: missing Flask-SQLAlchemy dependency in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690281fa3c28832398e21a4804bcd429