### PR TITLE
Add catalog service microservice scaffold

### DIFF
--- a/microservicios/catalog_service/.env.example
+++ b/microservicios/catalog_service/.env.example
@@ -1,0 +1,5 @@
+FLASK_ENV=development
+DATABASE_URL=sqlite:///catalog.db
+JWT_SECRET=change-me
+AUDIT_SERVICE_URL=http://localhost:5001/audit
+ANALYTICS_SERVICE_URL=http://localhost:5002/events

--- a/microservicios/catalog_service/app.py
+++ b/microservicios/catalog_service/app.py
@@ -1,0 +1,28 @@
+"""Catalog service Flask application factory."""
+from __future__ import annotations
+
+from flask import Flask
+
+from .config import CONFIG
+from .db import db
+from .routes.catalog import catalog_bp
+
+
+def create_app() -> Flask:
+    """Application factory for the catalog service."""
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = CONFIG.DATABASE_URL
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["ENV"] = CONFIG.FLASK_ENV
+    app.config["JWT_SECRET"] = CONFIG.JWT_SECRET
+
+    db.init_app(app)
+
+    app.register_blueprint(catalog_bp)
+
+    @app.shell_context_processor
+    def _shell_context():
+        return {"db": db}
+
+    return app

--- a/microservicios/catalog_service/config.py
+++ b/microservicios/catalog_service/config.py
@@ -1,0 +1,32 @@
+"""Application configuration for the catalog service."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:
+    value = os.getenv(name, default)
+    if value is None:
+        return default
+    return value
+
+
+@dataclass
+class Config:
+    """Base configuration loaded from environment variables."""
+
+    FLASK_ENV: str = _get_env("FLASK_ENV", "production")
+    DATABASE_URL: str = _get_env("DATABASE_URL", "sqlite:///catalog.db")
+    JWT_SECRET: str = _get_env("JWT_SECRET", "change-me")
+    AUDIT_SERVICE_URL: Optional[str] = _get_env("AUDIT_SERVICE_URL")
+    ANALYTICS_SERVICE_URL: Optional[str] = _get_env("ANALYTICS_SERVICE_URL")
+
+
+CONFIG = Config()

--- a/microservicios/catalog_service/db.py
+++ b/microservicios/catalog_service/db.py
@@ -1,0 +1,5 @@
+"""Database utilities for the catalog service."""
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()

--- a/microservicios/catalog_service/models.py
+++ b/microservicios/catalog_service/models.py
@@ -1,0 +1,65 @@
+"""SQLAlchemy models for catalog entries."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, String, Text, func
+
+from .db import db
+
+
+class CatalogBase(db.Model):
+    """Base mixin providing shared columns for catalog tables."""
+
+    __abstract__ = True
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    org_id = Column(String(36), nullable=True, index=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=func.now())
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<{self.__class__.__name__} id={self.id!r} name={self.name!r}>"
+
+
+class CareSpecialty(CatalogBase):
+    __tablename__ = "care_specialties"
+
+
+class MedicalDevice(CatalogBase):
+    __tablename__ = "medical_devices"
+
+
+class MedicationClass(CatalogBase):
+    __tablename__ = "medication_classes"
+
+
+class InsuranceProvider(CatalogBase):
+    __tablename__ = "insurance_providers"
+
+
+class ServiceCode(CatalogBase):
+    __tablename__ = "service_codes"
+
+
+class DiagnosisCategory(CatalogBase):
+    __tablename__ = "diagnosis_categories"
+
+
+class ClinicalProgram(CatalogBase):
+    __tablename__ = "clinical_programs"
+
+
+class CareLocation(CatalogBase):
+    __tablename__ = "care_locations"
+
+
+class AppointmentType(CatalogBase):
+    __tablename__ = "appointment_types"
+
+
+class CommunicationTemplate(CatalogBase):
+    __tablename__ = "communication_templates"

--- a/microservicios/catalog_service/repository.py
+++ b/microservicios/catalog_service/repository.py
@@ -1,0 +1,155 @@
+"""Repository layer for catalog tables."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Type
+
+from flask import g
+from sqlalchemy import or_
+
+from .db import db
+from .models import (
+    AppointmentType,
+    CareLocation,
+    CareSpecialty,
+    ClinicalProgram,
+    CommunicationTemplate,
+    DiagnosisCategory,
+    InsuranceProvider,
+    MedicalDevice,
+    MedicationClass,
+    ServiceCode,
+)
+
+CatalogModel = Type[CareSpecialty]
+
+
+class PermissionDenied(Exception):
+    """Raised when the caller does not have enough privileges."""
+
+
+class CatalogNotFound(Exception):
+    """Raised when a catalog or entry is not found."""
+
+
+class CatalogRepository:
+    """Repository handling catalog CRUD operations."""
+
+    _catalog_map: Dict[str, CatalogModel] = {
+        "care_specialties": CareSpecialty,
+        "medical_devices": MedicalDevice,
+        "medication_classes": MedicationClass,
+        "insurance_providers": InsuranceProvider,
+        "service_codes": ServiceCode,
+        "diagnosis_categories": DiagnosisCategory,
+        "clinical_programs": ClinicalProgram,
+        "care_locations": CareLocation,
+        "appointment_types": AppointmentType,
+        "communication_templates": CommunicationTemplate,
+    }
+
+    def __init__(self, session=None):
+        self.session = session or db.session
+
+    def _get_model(self, catalog_name: str) -> CatalogModel:
+        try:
+            return self._catalog_map[catalog_name]
+        except KeyError as exc:
+            raise CatalogNotFound(f"Unknown catalog '{catalog_name}'") from exc
+
+    def list_entries(self, catalog_name: str, org_id: str) -> List[Dict[str, Any]]:
+        model = self._get_model(catalog_name)
+        rows = (
+            self.session.query(model)
+            .filter(or_(model.org_id.is_(None), model.org_id == org_id))
+            .order_by(model.name.asc())
+            .all()
+        )
+        return [self._serialize(row) for row in rows]
+
+    def get_entry(self, catalog_name: str, entry_id: str, org_id: str) -> Dict[str, Any]:
+        model = self._get_model(catalog_name)
+        entry = (
+            self.session.query(model)
+            .filter(model.id == entry_id)
+            .filter(or_(model.org_id.is_(None), model.org_id == org_id))
+            .one_or_none()
+        )
+        if not entry:
+            raise CatalogNotFound("Catalog entry not found")
+        return self._serialize(entry)
+
+    def create_entry(self, catalog_name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self._ensure_admin()
+        model = self._get_model(catalog_name)
+        entry = model(
+            name=payload["name"],
+            description=payload.get("description"),
+            org_id=payload.get("org_id", g.org_id),
+        )
+        self.session.add(entry)
+        self.session.commit()
+        return self._serialize(entry)
+
+    def update_entry(self, catalog_name: str, entry_id: str, payload: Dict[str, Any], org_id: str) -> Dict[str, Any]:
+        self._ensure_admin()
+        model = self._get_model(catalog_name)
+        entry = (
+            self.session.query(model)
+            .filter(model.id == entry_id)
+            .filter(or_(model.org_id.is_(None), model.org_id == org_id))
+            .one_or_none()
+        )
+        if not entry:
+            raise CatalogNotFound("Catalog entry not found")
+
+        if "name" in payload:
+            entry.name = payload["name"]
+        if "description" in payload:
+            entry.description = payload["description"]
+        if "org_id" in payload:
+            entry.org_id = payload["org_id"]
+
+        self.session.commit()
+        return self._serialize(entry)
+
+    def delete_entry(self, catalog_name: str, entry_id: str, org_id: str) -> None:
+        self._ensure_admin()
+        model = self._get_model(catalog_name)
+        entry = (
+            self.session.query(model)
+            .filter(model.id == entry_id)
+            .filter(or_(model.org_id.is_(None), model.org_id == org_id))
+            .one_or_none()
+        )
+        if not entry:
+            raise CatalogNotFound("Catalog entry not found")
+
+        self.session.delete(entry)
+        self.session.commit()
+
+    @staticmethod
+    def _ensure_admin() -> None:
+        payload = getattr(g, "token_payload", {}) or {}
+        roles = payload.get("roles")
+        if isinstance(roles, str):
+            roles = [roles]
+        if not roles:
+            roles = []
+        role = payload.get("role")
+        if role and role not in roles:
+            roles.append(role)
+
+        allowed = {"admin", "superadmin"}
+        if not any(r in allowed for r in roles):
+            raise PermissionDenied("Administrator privileges required")
+
+    @staticmethod
+    def _serialize(entry: Any) -> Dict[str, Any]:
+        return {
+            "id": entry.id,
+            "name": entry.name,
+            "description": entry.description,
+            "org_id": entry.org_id,
+            "created_at": entry.created_at.isoformat() if entry.created_at else None,
+            "updated_at": entry.updated_at.isoformat() if entry.updated_at else None,
+        }

--- a/microservicios/catalog_service/requirements.txt
+++ b/microservicios/catalog_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask==2.3.3
+Flask-SQLAlchemy==3.0.5
+python-dotenv==1.0.0
+PyJWT==2.8.0
+dicttoxml==1.7.4
+requests==2.31.0

--- a/microservicios/catalog_service/routes/__init__.py
+++ b/microservicios/catalog_service/routes/__init__.py
@@ -1,0 +1,4 @@
+"""Route blueprints for catalog service."""
+from .catalog import catalog_bp
+
+__all__ = ["catalog_bp"]

--- a/microservicios/catalog_service/routes/catalog.py
+++ b/microservicios/catalog_service/routes/catalog.py
@@ -1,0 +1,75 @@
+"""Catalog service routes."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from flask import Blueprint, g, jsonify, request
+
+from ..repository import CatalogNotFound, CatalogRepository, PermissionDenied
+from ..utils.auth import AuthenticationError, token_required
+from ..utils.helpers import log_analytics_event, log_audit_event
+from ..utils.responses import auto_response
+
+catalog_bp = Blueprint("catalog", __name__)
+repository = CatalogRepository()
+
+
+@catalog_bp.errorhandler(AuthenticationError)
+def _handle_auth_error(exc: AuthenticationError):
+    return jsonify({"error": str(exc)}), 401
+
+
+@catalog_bp.errorhandler(PermissionDenied)
+def _handle_permission_error(exc: PermissionDenied):
+    return jsonify({"error": str(exc)}), 403
+
+
+@catalog_bp.errorhandler(CatalogNotFound)
+def _handle_not_found(exc: CatalogNotFound):
+    return jsonify({"error": str(exc)}), 404
+
+
+@catalog_bp.route("/v1/catalog/<string:catalog_name>", methods=["GET"])
+@token_required
+def list_catalog(catalog_name: str):
+    entries = repository.list_entries(catalog_name, g.org_id)
+    log_analytics_event(
+        "catalog_list",
+        {"catalog": catalog_name, "org_id": g.org_id, "count": len(entries)},
+    )
+    return auto_response({"items": entries}, 200)
+
+
+@catalog_bp.route("/v1/catalog/<string:catalog_name>", methods=["POST"])
+@token_required
+def create_catalog_entry(catalog_name: str):
+    payload = request.get_json(force=True) or {}
+    if "name" not in payload:
+        return jsonify({"error": "Field 'name' is required"}), 400
+
+    entry = repository.create_entry(catalog_name, payload)
+    log_audit_event("create", catalog_name, entry)
+    log_analytics_event("catalog_create", {"catalog": catalog_name, "entry_id": entry["id"]})
+    return auto_response(entry, 201)
+
+
+@catalog_bp.route("/v1/catalog/<string:catalog_name>/<uuid:entry_id>", methods=["PATCH"])
+@token_required
+def update_catalog_entry(catalog_name: str, entry_id: UUID):
+    payload = request.get_json(force=True) or {}
+    if not payload:
+        return jsonify({"error": "No fields to update"}), 400
+
+    entry = repository.update_entry(catalog_name, str(entry_id), payload, g.org_id)
+    log_audit_event("update", catalog_name, entry)
+    log_analytics_event("catalog_update", {"catalog": catalog_name, "entry_id": entry["id"]})
+    return auto_response(entry, 200)
+
+
+@catalog_bp.route("/v1/catalog/<string:catalog_name>/<uuid:entry_id>", methods=["DELETE"])
+@token_required
+def delete_catalog_entry(catalog_name: str, entry_id: UUID):
+    repository.delete_entry(catalog_name, str(entry_id), g.org_id)
+    log_audit_event("delete", catalog_name, {"id": str(entry_id)})
+    log_analytics_event("catalog_delete", {"catalog": catalog_name, "entry_id": str(entry_id)})
+    return auto_response(None, 204)

--- a/microservicios/catalog_service/test_service.bat
+++ b/microservicios/catalog_service/test_service.bat
@@ -1,0 +1,29 @@
+@echo off
+set BASE_URL=http://localhost:8000
+set TOKEN=REPLACE_WITH_JWT_TOKEN
+
+echo Listing catalog entries (JSON)...
+curl -H "Authorization: Bearer %TOKEN%" ^
+     -H "Accept: application/json" ^
+     %BASE_URL%/v1/catalog/care_specialties
+
+echo Listing catalog entries (XML)...
+curl -H "Authorization: Bearer %TOKEN%" ^
+     -H "Accept: application/xml" ^
+     %BASE_URL%/v1/catalog/care_specialties
+
+echo Creating catalog entry...
+curl -X POST -H "Authorization: Bearer %TOKEN%" ^
+     -H "Content-Type: application/json" ^
+     -d "{\"name\":\"New Specialty\",\"description\":\"Example\"}" ^
+     %BASE_URL%/v1/catalog/care_specialties
+
+echo Updating catalog entry...
+curl -X PATCH -H "Authorization: Bearer %TOKEN%" ^
+     -H "Content-Type: application/json" ^
+     -d "{\"description\":\"Updated description\"}" ^
+     %BASE_URL%/v1/catalog/care_specialties/00000000-0000-0000-0000-000000000000
+
+echo Deleting catalog entry...
+curl -X DELETE -H "Authorization: Bearer %TOKEN%" ^
+     %BASE_URL%/v1/catalog/care_specialties/00000000-0000-0000-0000-000000000000

--- a/microservicios/catalog_service/utils/__init__.py
+++ b/microservicios/catalog_service/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for catalog service."""
+
+__all__ = []

--- a/microservicios/catalog_service/utils/auth.py
+++ b/microservicios/catalog_service/utils/auth.py
@@ -1,0 +1,54 @@
+"""Authentication helpers for catalog service."""
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Dict
+
+import jwt
+from flask import current_app, g, request
+
+
+class AuthenticationError(Exception):
+    """Raised when token validation fails."""
+
+
+def _extract_token() -> str:
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        return auth_header.split(" ", 1)[1]
+    return auth_header
+
+
+def token_required(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator to validate JWT tokens and expose user/org identifiers."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any):
+        token = _extract_token()
+        if not token:
+            raise AuthenticationError("Authorization token missing")
+
+        try:
+            payload: Dict[str, Any] = jwt.decode(
+                token,
+                current_app.config.get("JWT_SECRET", ""),
+                algorithms=["HS256"],
+                options={"verify_aud": False},
+            )
+        except jwt.PyJWTError as exc:  # pragma: no cover - runtime safety
+            raise AuthenticationError("Invalid token") from exc
+
+        user_id = payload.get("sub") or payload.get("user_id")
+        org_id = payload.get("org_id")
+        if not user_id:
+            raise AuthenticationError("User identifier missing in token")
+        if org_id is None:
+            raise AuthenticationError("Organization identifier missing in token")
+
+        g.user_id = user_id
+        g.org_id = org_id
+        g.token_payload = payload
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/microservicios/catalog_service/utils/helpers.py
+++ b/microservicios/catalog_service/utils/helpers.py
@@ -1,0 +1,54 @@
+"""Helper utilities for integrations."""
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, Optional
+
+import requests
+from flask import current_app, g
+
+
+def _post_async(url: str, payload: Dict[str, Any]) -> None:
+    def _worker():
+        try:
+            requests.post(url, json=payload, timeout=5)
+        except requests.RequestException:
+            # Fire-and-forget: intentionally swallow exceptions to avoid
+            # blocking the main request flow.
+            pass
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+
+
+def log_audit_event(action: str, catalog_name: str, data: Dict[str, Any]) -> None:
+    """Send audit events to the external audit service."""
+
+    url: Optional[str] = current_app.config.get("AUDIT_SERVICE_URL")
+    if not url:
+        return
+
+    payload = {
+        "action": action,
+        "catalog": catalog_name,
+        "data": data,
+        "user_id": getattr(g, "user_id", None),
+        "org_id": getattr(g, "org_id", None),
+    }
+    _post_async(url, payload)
+
+
+def log_analytics_event(event_name: str, payload: Dict[str, Any]) -> None:
+    """Stub for analytics logging to the analytics service."""
+
+    url: Optional[str] = current_app.config.get("ANALYTICS_SERVICE_URL")
+    if not url:
+        return
+
+    body = {
+        "event": event_name,
+        "payload": payload,
+        "user_id": getattr(g, "user_id", None),
+        "org_id": getattr(g, "org_id", None),
+    }
+    _post_async(url, body)

--- a/microservicios/catalog_service/utils/responses.py
+++ b/microservicios/catalog_service/utils/responses.py
@@ -1,0 +1,22 @@
+"""Response utilities for the catalog service."""
+from __future__ import annotations
+
+from typing import Any
+
+from dicttoxml import dicttoxml
+from flask import Response, jsonify, request
+
+
+def auto_response(data: Any, status_code: int = 200) -> Response:
+    """Return JSON or XML depending on the request's Accept header."""
+
+    if status_code == 204:
+        return Response(status=status_code)
+
+    accept_header = request.headers.get("Accept", "application/json")
+    if "xml" in accept_header.lower():
+        payload = data if isinstance(data, dict) else {"data": data}
+        xml_body = dicttoxml(payload, custom_root="response", attr_type=False)
+        return Response(xml_body, status=status_code, mimetype="application/xml")
+
+    return jsonify(data), status_code


### PR DESCRIPTION
## Summary
- add catalog service Flask application with environment-driven configuration and SQLAlchemy models
- implement authentication, response helpers, repository permissions, and RESTful routes for catalog management
- provide integration utilities, environment defaults, dependencies, and sample curl scripts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690294425ccc8323a186b9400ec368fa