### PR TITLE
Add Flask service stubs for HeartGuard microservices

### DIFF
--- a/Microservicios/.env.example
+++ b/Microservicios/.env.example
@@ -1,0 +1,160 @@
+# =============================
+# HeartGuard Microservices ENV
+# =============================
+# Copiar este archivo a .env y ajustar valores reales antes del despliegue.
+
+# ---- Configuración global ----
+GATEWAY_URL=http://34.70.7.33:5000
+AUTH_URL=http://34.70.7.33:5001
+ORGANIZATION_URL=http://34.70.7.33:5002
+USER_URL=http://34.70.7.33:5003
+PATIENT_URL=http://34.70.7.33:5004
+DEVICE_URL=http://34.70.7.33:5005
+INFLUX_SERVICE_URL=http://34.70.7.33:5006
+INFERENCE_URL=http://34.70.7.33:5007
+ALERT_URL=http://34.70.7.33:5008
+NOTIFICATION_URL=http://34.70.7.33:5009
+MEDIA_URL=http://34.70.7.33:5010
+AUDIT_URL=http://34.70.7.33:5011
+RABBITMQ_URL=amqp://heartguard:change_me@rabbitmq:5672/heartguard
+REDIS_URL=redis://redis:6379/0
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_SUPERUSER=postgres
+POSTGRES_SUPERPASS=postgres
+INFLUX_URL=http://influxdb:8086
+INFLUX_TOKEN=replace-with-influx-token
+INFLUX_ORG=heartguard
+INFLUX_BUCKET=heartguard_signals
+GCS_BUCKET=heartguard-system
+SERVICE_ACCOUNT_EMAIL=751259101579-compute@developer.gserviceaccount.com
+GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp-sa.json
+OTEL_EXPORTER_OTLP_ENDPOINT=
+
+# ---- Gateway Service (port 5000) ----
+GATEWAY_PORT=5000
+GATEWAY_JWT_SECRET=change-me-gateway
+GATEWAY_JWT_EXPIRES_IN=900
+GATEWAY_REFRESH_TOKEN_TTL=604800
+GATEWAY_ALLOWED_ORIGINS=https://app.heartguard.com,https://admin.heartguard.com
+GATEWAY_RATE_LIMIT=200/minute
+GATEWAY_LOG_LEVEL=INFO
+
+# ---- Auth Service (port 5001) ----
+AUTH_PORT=5001
+AUTH_DB_SCHEMA=auth
+POSTGRES_URL_AUTH=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${AUTH_DB_SCHEMA}
+AUTH_JWT_SECRET=change-me-auth
+AUTH_JWT_EXPIRES_IN=900
+AUTH_REFRESH_TOKEN_TTL=604800
+AUTH_ALLOWED_ORIGINS=https://app.heartguard.com
+AUTH_RATE_LIMIT=100/minute
+AUTH_LOG_LEVEL=INFO
+AUTH_ACCESS_TOKEN_AUD=heartguard-clients
+AUTH_REFRESH_TOKEN_AUD=heartguard-refresh
+
+# ---- Organization Service (port 5002) ----
+ORGANIZATION_PORT=5002
+ORGANIZATION_DB_SCHEMA=organization
+POSTGRES_URL_ORGANIZATION=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${ORGANIZATION_DB_SCHEMA}
+ORGANIZATION_JWT_SECRET=${AUTH_JWT_SECRET}
+ORGANIZATION_ALLOWED_ORIGINS=https://admin.heartguard.com
+ORGANIZATION_RATE_LIMIT=80/minute
+ORGANIZATION_LOG_LEVEL=INFO
+
+# ---- User Service (port 5003) ----
+USER_PORT=5003
+USER_DB_SCHEMA=user_ctx
+POSTGRES_URL_USER=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${USER_DB_SCHEMA}
+USER_JWT_SECRET=${AUTH_JWT_SECRET}
+USER_ALLOWED_ORIGINS=https://app.heartguard.com
+USER_RATE_LIMIT=150/minute
+USER_LOG_LEVEL=INFO
+
+# ---- Patient Service (port 5004) ----
+PATIENT_PORT=5004
+PATIENT_DB_SCHEMA=patient
+POSTGRES_URL_PATIENT=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${PATIENT_DB_SCHEMA}
+PATIENT_JWT_SECRET=${AUTH_JWT_SECRET}
+PATIENT_ALLOWED_ORIGINS=https://admin.heartguard.com
+PATIENT_RATE_LIMIT=120/minute
+PATIENT_LOG_LEVEL=INFO
+
+# ---- Device Service (port 5005) ----
+DEVICE_PORT=5005
+DEVICE_DB_SCHEMA=device
+POSTGRES_URL_DEVICE=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${DEVICE_DB_SCHEMA}
+DEVICE_JWT_SECRET=${AUTH_JWT_SECRET}
+DEVICE_ALLOWED_ORIGINS=https://admin.heartguard.com
+DEVICE_RATE_LIMIT=120/minute
+DEVICE_LOG_LEVEL=INFO
+
+# ---- Influx Service (port 5006) ----
+INFLUX_SERVICE_PORT=5006
+INFLUX_SERVICE_JWT_SECRET=${AUTH_JWT_SECRET}
+INFLUX_SERVICE_ALLOWED_ORIGINS=https://app.heartguard.com
+INFLUX_SERVICE_RATE_LIMIT=180/minute
+INFLUX_SERVICE_LOG_LEVEL=INFO
+INFLUX_SERVICE_PAGE_SIZE_DEFAULT=200
+INFLUX_SERVICE_PAGE_SIZE_MAX=1000
+
+# ---- Inference Service (port 5007) ----
+INFERENCE_PORT=5007
+INFERENCE_DB_SCHEMA=inference
+POSTGRES_URL_INFERENCE=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${INFERENCE_DB_SCHEMA}
+INFERENCE_JWT_SECRET=${AUTH_JWT_SECRET}
+INFERENCE_ALLOWED_ORIGINS=https://admin.heartguard.com
+INFERENCE_RATE_LIMIT=120/minute
+INFERENCE_LOG_LEVEL=INFO
+INFERENCE_MODEL_STORAGE_PATH=/models
+
+# ---- Alert Service (port 5008) ----
+ALERT_PORT=5008
+ALERT_DB_SCHEMA=alert
+POSTGRES_URL_ALERT=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${ALERT_DB_SCHEMA}
+ALERT_JWT_SECRET=${AUTH_JWT_SECRET}
+ALERT_ALLOWED_ORIGINS=https://admin.heartguard.com
+ALERT_RATE_LIMIT=120/minute
+ALERT_LOG_LEVEL=INFO
+
+# ---- Notification Service (port 5009) ----
+NOTIFICATION_PORT=5009
+NOTIFICATION_DB_SCHEMA=notification
+POSTGRES_URL_NOTIFICATION=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${NOTIFICATION_DB_SCHEMA}
+NOTIFICATION_JWT_SECRET=${AUTH_JWT_SECRET}
+NOTIFICATION_ALLOWED_ORIGINS=https://admin.heartguard.com
+NOTIFICATION_RATE_LIMIT=120/minute
+NOTIFICATION_LOG_LEVEL=INFO
+NOTIFICATION_PUSH_TTL_SECONDS=3600
+
+# ---- Media Service (port 5010) ----
+MEDIA_PORT=5010
+MEDIA_DB_SCHEMA=media
+POSTGRES_URL_MEDIA=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${MEDIA_DB_SCHEMA}
+MEDIA_JWT_SECRET=${AUTH_JWT_SECRET}
+MEDIA_ALLOWED_ORIGINS=https://app.heartguard.com
+MEDIA_RATE_LIMIT=60/minute
+MEDIA_LOG_LEVEL=INFO
+MEDIA_MAX_FILE_SIZE_MB=50
+MEDIA_ALLOWED_MIME=image/png,image/jpeg,application/pdf
+MEDIA_SIGNED_URL_TTL=3600
+
+# ---- Audit Service (port 5011) ----
+AUDIT_PORT=5011
+AUDIT_DB_SCHEMA=audit
+POSTGRES_URL_AUDIT=postgresql://heartguard:change_me@${POSTGRES_HOST}:${POSTGRES_PORT}/heartguard?options=-csearch_path%3D${AUDIT_DB_SCHEMA}
+AUDIT_JWT_SECRET=${AUTH_JWT_SECRET}
+AUDIT_ALLOWED_ORIGINS=https://admin.heartguard.com
+AUDIT_RATE_LIMIT=60/minute
+AUDIT_LOG_LEVEL=INFO
+
+# ---- RabbitMQ exchanges ----
+RABBITMQ_INFERENCE_EXCHANGE=inference.fanout
+RABBITMQ_ALERT_EXCHANGE=alert.direct
+RABBITMQ_NOTIFICATION_EXCHANGE=notification.topic
+RABBITMQ_AUDIT_EXCHANGE=audit.fanout
+
+# ---- Feature flags / opcionales ----
+ENABLE_XML_LOGGING=true
+ENABLE_PROMETHEUS_METRICS=true
+

--- a/Microservicios/PLAN.md
+++ b/Microservicios/PLAN.md
@@ -1,0 +1,231 @@
+# HeartGuard Microservices Architecture Plan
+
+## 1. Visión general
+El dominio médico descrito en `db/init.sql` se segmenta en contextos delimitados (bounded contexts) que alinean responsabilidades de negocio con servicios Flask independientes. Cada servicio expone APIs REST bilingües (JSON/XML) y participa en flujos síncronos vía HTTP y asíncronos mediante RabbitMQ, operando sobre su propia base de datos ("database per service") dentro de una instancia PostgreSQL multi‐schema. El despliegue está orientado a la VM pública `34.70.7.33`, con puertos consecutivos a partir del 5000.
+
+## 2. Diagrama de arquitectura
+```
+                   Internet / VPN
+                   +--------------+
+  Web (XML) ------>|              |
+  Mobile (JSON) -->|   Gateway    |<---------------------------+
+                   |   :5000      |                            |
+                   +-------+------+                            |
+                           |                                   |
+            -------------------------------                     |
+            |        |       |       |    |                    |
+            v        v       v       v    v                    |
+         Auth     Organization  User  Patient  Device          |
+         :5001       :5002     :5003   :5004   :5005           |
+            |           |        |        |        |           |
+            |           |        |        |        |           |
+            |           |        |        |        |           |
+            v           v        v        v        v           |
+          Postgres schemas: auth, organization, user, patient, device
+
+            +-------------------+       +-------------------+
+            | Inference :5007   |<----->| Alert :5008       |
+            +---------+---------+       +-----+-------------+
+                      |                         |
+                      v                         v
+                RabbitMQ (async bus) <----- Notification :5009
+                      |
+                      v
+                 Audit :5011
+
+            +---------------------------+
+            | Media :5010 (GCS bucket)  |
+            +-------------+-------------+
+                          |
+                          v
+                 Google Cloud Storage
+
+            +---------------------------+
+            | Influx Service :5006      |
+            +-------------+-------------+
+                          |
+                          v
+                       InfluxDB
+
+Otros componentes compartidos: Redis (rate limiting, tokens), Postgres (multischema), RabbitMQ, stack de métricas (Prometheus scraping `/metrics`).
+```
+
+## 3. Bounded contexts y responsabilidades
+| Servicio | Tablas / entidades núcleo (desde `db/init.sql`) | Responsabilidades clave |
+|----------|--------------------------------------------------|-------------------------|
+| **Gateway (5000)** | N/A (solo configuración) | Validación JWT y RBAC central, CORS, rate limiting, routing hacia servicios backend, agregación de métricas, `/gateway/health`. |
+| **Auth (5001)** | `users`, `roles`, `permissions`, `role_permission`, `user_roles`, `refresh_tokens`, `user_statuses`, `platforms`, `service_statuses` | Registro, autenticación, emisión/renovación de tokens, administración de roles y permisos globales. |
+| **Organization (5002)** | `organizations`, `org_roles`, `org_invitations`, `org_contacts`, `org_settings`, `org_brands` | Gestión de la organización propietaria del sistema, invitaciones internas, branding y políticas. |
+| **User (5003)** | `user_profiles`, `user_preferences`, `user_org_membership`, `user_devices` | Perfil del usuario de la aplicación, preferencias, asociación con la organización. |
+| **Patient (5004)** | `patients`, `care_teams`, `care_team_member`, `caregiver_patient`, `patient_metrics`, `patient_goals` | Gestión del sujeto clínico, equipos de cuidado y cuidadores. |
+| **Device (5005)** | `device_types`, `devices`, `signal_streams`, `timeseries_binding`, `device_assignments`, `device_health` | Inventario y configuración de dispositivos y su vinculación a series de tiempo. |
+| **Influx Service (5006)** | Integración con InfluxDB (sin tablas SQL) | Abstracción de ingestión y consultas sobre series temporales, gestión de buckets y políticas de retención. |
+| **Inference (5007)** | `models`, `model_versions`, `event_types`, `inferences` | Registro de modelos y resultados de inferencia; consumo de streams/eventos. |
+| **Alert (5008)** | `alerts`, `alert_status`, `alert_assignment`, `alert_ack`, `alert_resolution`, `alert_channels`, `alert_levels`, `risk_levels` | Orquestación completa del ciclo de vida de alertas clínicas. |
+| **Notification (5009)** | `push_devices`, `alert_delivery`, `delivery_statuses` | Entrega de notificaciones multicanal y seguimiento de estado. |
+| **Media (5010)** | `media_assets`, `media_tags` | Gestión de archivos en GCS, URLs firmadas, metadatos. |
+| **Audit (5011)** | `audit_logs` | Recepción de eventos auditables desde cola, persistencia y consulta. |
+
+## 4. Estructura de carpetas
+```
+Microservicios/
+├── PLAN.md
+├── docker-compose.yml
+├── .env.example
+├── start_services.sh
+├── stop_services.sh
+├── validate_endpoints.sh
+├── common/
+│   ├── __init__.py
+│   ├── config.py          # carga .env, utilidades comunes
+│   ├── auth.py            # JWT utilities, RBAC helpers
+│   ├── middleware.py      # logging, request_id, error handling
+│   ├── serialization.py   # negociación JSON/XML
+│   ├── errors.py          # excepciones y manejador uniforme
+│   ├── responses.py       # plantillas estándar
+│   └── observability.py   # métricas y trazas
+├── gateway/
+│   ├── app.py
+│   ├── routes.py
+│   ├── config.py
+│   ├── requirements.txt
+│   └── Dockerfile
+├── auth_service/
+│   └── ...
+├── organization_service/
+│   └── ...
+├── user_service/
+│   └── ...
+├── patient_service/
+│   └── ...
+├── device_service/
+│   └── ...
+├── influx_service/
+│   └── ...
+├── inference_service/
+│   └── ...
+├── alert_service/
+│   └── ...
+├── notification_service/
+│   └── ...
+├── media_service/
+│   └── ...
+├── audit_service/
+│   └── ...
+└── schemas/
+    ├── json/
+    │   ├── user.json
+    │   ├── organization.json
+    │   ├── patient.json
+    │   ├── device.json
+    │   ├── alert.json
+    │   ├── inference.json
+    │   ├── media_item.json
+    │   └── timeseries_point.json
+    └── xsd/
+        └── (mismos nombres .xsd)
+```
+
+## 5. Flujos de interacción
+### 5.1 Flujos síncronos (HTTP)
+1. **Autenticación**: cliente → Gateway → Auth (login/refresh). El Gateway recibe tokens y los guarda en encabezados para posteriores solicitudes.
+2. **Gestión de organización**: admin web (XML) → Gateway → Organization (CRUD de configuración).
+3. **Perfil de usuario**: app móvil (JSON) → Gateway → User.
+4. **Gestión de pacientes y dispositivos**: clínico/admin → Gateway → Patient/Device Services.
+5. **Consultas de series temporales**: servicio Device / cliente → Gateway → Influx Service (`/write`, `/query`).
+6. **Descarga de media**: cliente → Gateway → Media (genera URL firmada, redirige).
+
+### 5.2 Flujos asíncronos (RabbitMQ)
+1. **Inferencia**: Device Service emite evento `signal_stream.bound` con metadata de `timeseries_binding`. Inference Service consume, ejecuta modelo y publica `inference.generated`.
+2. **Alertas**: Inference Service publica `inference.alert_candidate`. Alert Service consume, crea alertas y envía `alert.created`.
+3. **Notificaciones**: Alert Service publica `alert.notify`. Notification Service envía push/SMS/email según `alert_channels`, confirma `alert.delivery_update`.
+4. **Auditoría**: Todos los servicios publican eventos `audit.log` en fanout exchange; Audit Service consume, valida y persiste en `audit_logs`.
+
+## 6. Manejo uniforme de errores
+- `common.errors` define excepciones (`ValidationError`, `AuthError`, `NotFoundError`, `ConflictError`, `RateLimitError`, `ServiceUnavailableError`).
+- Middleware global registra errores con `request_id`, `user_id` y detalles, devolviendo respuesta homogénea:
+```json
+{
+  "status": "error",
+  "code": 400,
+  "error": {
+    "id": "HG-VAL-001",
+    "message": "Datos inválidos",
+    "details": [{"field": "email", "issue": "formato"}]
+  }
+}
+```
+XML equivalente mediante `dicttoxml`. Códigos HTTP alineados con RFC 7807 (a futuro se puede usar `application/problem+json`).
+
+## 7. Seguridad
+- **JWT**: HS256, `exp` (15 min) y refresh token (7 días). Claims incluyen `sub`, `roles`, `permissions`, `org_id`, `aud`.
+- **Refresh tokens**: almacenados con hash en tabla `refresh_tokens` (Auth) y cacheados en Redis para revocación inmediata.
+- **RBAC**: Gateway valida `roles`/`permissions` antes de enrutar; servicios aplican reglas de negocio específicas (p.ej. Patient Service exige `patient:write`).
+- **CORS**: configurado con listas blancas por servicio (`ALLOWED_ORIGINS`). Gateway verifica `Origin` y añade encabezados `Access-Control-Allow-*`.
+- **Rate limiting**: `flask-limiter` con backend Redis; límites por IP y por `user_id`.
+- **Input sanitization**: validaciones con `marshmallow`, escapes y normalización; longitud máxima de payload (`MAX_CONTENT_LENGTH`).
+- **TLS**: gestionado fuera de Docker (balanceador / ingress). Servicios escuchan en `0.0.0.0` solo dentro de red Docker.
+
+## 8. Observabilidad
+- **Logging estructurado**: `structlog` con `service`, `request_id`, `user_id`, `path`, `status`, `latency_ms`.
+- **Request ID**: middleware genera UUID si el cliente no envía `X-Request-ID`.
+- **Métricas**: `prometheus_flask_exporter` exponiendo `/metrics` (solo accesible dentro de red interna). Métricas clave: latencia por endpoint, tasa de errores, tamaño de payload, uso de cache.
+- **Health Checks**: cada servicio tiene `/health` (liveness) y `/ready` (readiness). Gateway expone `/gateway/health`. Influx Service verifica conexión real (`client.ping()`).
+- **Tracing (opcional)**: hooks para integrar OpenTelemetry (`OTEL_EXPORTER_OTLP_ENDPOINT`).
+
+## 9. Gestión de configuración y credenciales
+- `.env` carga variables específicas por servicio (puertos, secretos, URLs). Servicios leen mediante `python-dotenv` o inyección en contenedor.
+- Credenciales sensibles (p.ej. `GOOGLE_APPLICATION_CREDENTIALS`) montadas como `docker secret` o volumen de solo lectura.
+
+## 10. Pasos de despliegue en VM 34.70.7.33
+1. Instalar Docker Engine y Docker Compose v2.
+2. Clonar repositorio `HeartGuard` y copiar carpeta `Microservicios/` completa.
+3. Crear archivo `.env` desde `.env.example` con valores reales.
+4. Colocar credencial GCP (`service-account.json`) en `/etc/heartguard/gcp/sa.json` y ajustar permisos (600). El `docker-compose.yml` montará el archivo como secreto para `media_service`.
+5. Abrir puertos 5000-5011 en firewall GCP (restringir por IP cuando sea posible).
+6. Ejecutar `./start_services.sh` para construir e iniciar contenedores (`docker compose up -d --build`).
+7. Verificar estado con `docker compose ps` y health checks (`curl http://34.70.7.33:5000/gateway/health`).
+8. Configurar supervisión (systemd unit opcional) para reiniciar servicios.
+9. Desde entorno local ejecutar `./validate_endpoints.sh --host 34.70.7.33` para validar disponibilidad JSON/XML.
+10. Configurar backups: snapshots de Postgres (`pg_dump` por esquema), exportaciones de InfluxDB, versionado GCS.
+
+## 11. Estrategia de datos y migraciones
+- Cada servicio tiene esquema PostgreSQL independiente (`auth`, `organization`, `user`, `patient`, `device`, `inference`, `alert`, `notification`, `media`, `audit`). Docker compose incluye scripts de inicialización para crear esquemas y aplicar migraciones usando Alembic por servicio.
+- Influx Service administra buckets (`heartguard_signals`, `heartguard_predictions`) mediante API.
+- Migraciones versionadas en cada servicio (`migrations/` con Alembic).
+
+## 12. Endpoints representativos y negociación de contenido
+Cada servicio expone endpoints REST que aceptan/retornan JSON o XML según encabezado `Accept`. Ejemplo general:
+```
+GET /patients/{id}
+Accept: application/json
+Authorization: Bearer <token>
+```
+Respuesta JSON: `{"status":"success","data":{...}}`
+
+Si `Accept: application/xml`, respuesta: `
+<response>
+  <status>success</status>
+  <data>...</data>
+</response>
+`
+
+Para escrituras (`POST/PUT/PATCH`) se valida `Content-Type` (JSON/XML) y se transforma internamente a diccionario normalizado previo a validación.
+
+## 13. Operación del bus de eventos
+- Exchanges por dominio: `inference.fanout`, `alert.direct`, `notification.topic`, `audit.fanout`.
+- Mensajes en JSON estándar, incluyen cabeceras `content_type` y `x-request-id`.
+- Retries gestionados mediante colas `retry` con TTL + DLX; errores definitivos van a cola `dead-letter`.
+
+## 14. Estrategia de pruebas
+- Tests unitarios: Pytest + coverage por servicio.
+- Contract tests: JSON Schema/XSD validados contra respuestas.
+- Smoke tests: script `validate_endpoints.sh`.
+- Integración: pipelines CI ejecutan `docker compose run --rm <service> pytest`.
+
+## 15. Consideraciones futuras
+- Incorporar API Gateway dedicado (Kong/Traefik) si se requiere características avanzadas.
+- Añadir OpenAPI generado (Swagger) con ejemplos JSON/XML.
+- Integrar sistema de feature flags (p.ej. Unleash) si se amplía dominio.
+- Hardening: limitar tamaño de archivos en Media, cifrado at rest (KMS) y rotación de secretos.
+

--- a/Microservicios/alert_service/__init__.py
+++ b/Microservicios/alert_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/alert_service/app.py
+++ b/Microservicios/alert_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "alerts"
+DEFAULT_PORT = 5008
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/alert_service/requirements.txt
+++ b/Microservicios/alert_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/alert_service/routes.py
+++ b/Microservicios/alert_service/routes.py
@@ -1,0 +1,116 @@
+"""Alert service handling alert lifecycle operations."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Dict, List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("alerts", __name__)
+
+ALERTS: Dict[str, Dict] = {
+    "alert-1": {
+        "id": "alert-1",
+        "patient_id": "pat-1",
+        "status": "new",
+        "severity": "high",
+        "event_type": "tachycardia",
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+}
+
+ALERT_ASSIGNMENTS: List[Dict] = []
+ALERT_ACKS: List[Dict] = []
+ALERT_RESOLUTIONS: List[Dict] = []
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "alerts", "status": "healthy", "alerts": len(ALERTS)})
+
+
+@bp.route("", methods=["GET"])
+@require_auth(optional=True)
+def list_alerts() -> "Response":
+    return render_response({"alerts": list(ALERTS.values())}, meta={"total": len(ALERTS)})
+
+
+@bp.route("", methods=["POST"])
+@require_auth(optional=True)
+def create_alert() -> "Response":
+    payload, _ = parse_request_data(request)
+    patient_id = payload.get("patient_id")
+    if not patient_id:
+        raise APIError("patient_id is required", status_code=400, error_id="HG-ALERT-VALIDATION")
+    alert_id = f"alert-{len(ALERTS) + 1}"
+    alert = {
+        "id": alert_id,
+        "patient_id": patient_id,
+        "status": "new",
+        "severity": payload.get("severity", "medium"),
+        "event_type": payload.get("event_type"),
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    ALERTS[alert_id] = alert
+    return render_response({"alert": alert}, status_code=201)
+
+
+@bp.route("/<alert_id>/assign", methods=["POST"])
+@require_auth(required_roles=["clinician", "admin"])
+def assign_alert(alert_id: str) -> "Response":
+    payload, _ = parse_request_data(request)
+    assignee = payload.get("assignee_id")
+    if alert_id not in ALERTS:
+        raise APIError("Alert not found", status_code=404, error_id="HG-ALERT-NOT-FOUND")
+    if not assignee:
+        raise APIError("assignee_id is required", status_code=400, error_id="HG-ALERT-ASSIGN")
+    assignment = {
+        "alert_id": alert_id,
+        "assignee_id": assignee,
+        "assigned_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    ALERT_ASSIGNMENTS.append(assignment)
+    ALERTS[alert_id]["status"] = "assigned"
+    return render_response({"assignment": assignment, "alert": ALERTS[alert_id]})
+
+
+@bp.route("/<alert_id>/ack", methods=["POST"])
+@require_auth(optional=True)
+def acknowledge_alert(alert_id: str) -> "Response":
+    if alert_id not in ALERTS:
+        raise APIError("Alert not found", status_code=404, error_id="HG-ALERT-NOT-FOUND")
+    payload, _ = parse_request_data(request)
+    ack = {
+        "alert_id": alert_id,
+        "acknowledged_by": payload.get("acknowledged_by"),
+        "acknowledged_at": dt.datetime.utcnow().isoformat() + "Z",
+        "notes": payload.get("notes"),
+    }
+    ALERT_ACKS.append(ack)
+    ALERTS[alert_id]["status"] = "acknowledged"
+    return render_response({"ack": ack, "alert": ALERTS[alert_id]})
+
+
+@bp.route("/<alert_id>/resolve", methods=["POST"])
+@require_auth(optional=True)
+def resolve_alert(alert_id: str) -> "Response":
+    if alert_id not in ALERTS:
+        raise APIError("Alert not found", status_code=404, error_id="HG-ALERT-NOT-FOUND")
+    payload, _ = parse_request_data(request)
+    resolution = {
+        "alert_id": alert_id,
+        "resolved_by": payload.get("resolved_by"),
+        "resolution_reason": payload.get("reason", "resolved"),
+        "resolved_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    ALERT_RESOLUTIONS.append(resolution)
+    ALERTS[alert_id]["status"] = "resolved"
+    return render_response({"resolution": resolution, "alert": ALERTS[alert_id]})
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/alerts")

--- a/Microservicios/audit_service/__init__.py
+++ b/Microservicios/audit_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/audit_service/app.py
+++ b/Microservicios/audit_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "audit"
+DEFAULT_PORT = 5011
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/audit_service/requirements.txt
+++ b/Microservicios/audit_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/audit_service/routes.py
+++ b/Microservicios/audit_service/routes.py
@@ -1,0 +1,51 @@
+"""Audit service ingesting audit log events."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("audit", __name__)
+
+AUDIT_LOGS: List[dict] = []
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "audit", "status": "healthy", "events": len(AUDIT_LOGS)})
+
+
+@bp.route("/logs", methods=["GET"])
+@require_auth(optional=True)
+def list_logs() -> "Response":
+    limit = int(request.args.get("limit", 20))
+    return render_response({"logs": AUDIT_LOGS[-limit:]}, meta={"returned": min(limit, len(AUDIT_LOGS))})
+
+
+@bp.route("/logs", methods=["POST"])
+@require_auth(optional=True)
+def create_log() -> "Response":
+    payload, _ = parse_request_data(request)
+    actor = payload.get("actor_id")
+    action = payload.get("action")
+    if not actor or not action:
+        raise APIError("actor_id and action are required", status_code=400, error_id="HG-AUDIT-VALIDATION")
+    entry = {
+        "id": f"audit-{len(AUDIT_LOGS) + 1}",
+        "actor_id": actor,
+        "action": action,
+        "resource": payload.get("resource"),
+        "metadata": payload.get("metadata", {}),
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    AUDIT_LOGS.append(entry)
+    return render_response({"log": entry}, status_code=201)
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/audit")

--- a/Microservicios/auth_service/__init__.py
+++ b/Microservicios/auth_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/auth_service/app.py
+++ b/Microservicios/auth_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "auth"
+DEFAULT_PORT = 5001
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/auth_service/requirements.txt
+++ b/Microservicios/auth_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/auth_service/routes.py
+++ b/Microservicios/auth_service/routes.py
@@ -1,0 +1,121 @@
+"""Auth service routes implementing JWT issuance and RBAC scaffolding."""
+from __future__ import annotations
+
+import uuid
+from typing import Dict
+
+from flask import Blueprint, request
+
+from common.auth import get_jwt_manager, issue_tokens, require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("auth", __name__)
+
+USERS: Dict[str, Dict] = {
+    "admin@example.com": {
+        "id": "usr-1",
+        "email": "admin@example.com",
+        "password": "Admin123!",
+        "roles": ["admin"],
+    },
+    "clinician@example.com": {
+        "id": "usr-2",
+        "email": "clinician@example.com",
+        "password": "Clinician123!",
+        "roles": ["clinician"],
+    },
+}
+
+REFRESH_STORE: Dict[str, str] = {}
+AVAILABLE_ROLES = ["admin", "clinician", "org_admin", "user", "caregiver"]
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "auth", "status": "healthy", "users": len(USERS)})
+
+
+@bp.route("/register", methods=["POST"])
+def register() -> "Response":
+    payload, _ = parse_request_data(request)
+    email = payload.get("email")
+    password = payload.get("password")
+    roles = payload.get("roles", ["user"])
+    if not email or not password:
+        raise APIError("Email and password are required", status_code=400, error_id="HG-AUTH-VALIDATION")
+    if email in USERS:
+        raise APIError("User already exists", status_code=409, error_id="HG-AUTH-CONFLICT")
+    user_id = f"usr-{uuid.uuid4()}"
+    USERS[email] = {"id": user_id, "email": email, "password": password, "roles": roles}
+    tokens = issue_tokens(user_id, roles)
+    REFRESH_STORE[tokens["refresh_token"]] = email
+    return render_response({"user": {"id": user_id, "email": email, "roles": roles}, "tokens": tokens}, status_code=201)
+
+
+@bp.route("/login", methods=["POST"])
+def login() -> "Response":
+    payload, _ = parse_request_data(request)
+    email = payload.get("email")
+    password = payload.get("password")
+    if not email or not password:
+        raise APIError("Email and password are required", status_code=400, error_id="HG-AUTH-VALIDATION")
+    user = USERS.get(email)
+    if not user or user["password"] != password:
+        raise APIError("Invalid credentials", status_code=401, error_id="HG-AUTH-CREDENTIALS")
+    tokens = issue_tokens(user["id"], user["roles"])
+    REFRESH_STORE[tokens["refresh_token"]] = email
+    return render_response({"tokens": tokens, "user": {"id": user["id"], "roles": user["roles"]}})
+
+
+@bp.route("/refresh", methods=["POST"])
+def refresh() -> "Response":
+    payload, _ = parse_request_data(request)
+    refresh_token = payload.get("refresh_token")
+    if not refresh_token:
+        raise APIError("refresh_token is required", status_code=400, error_id="HG-AUTH-VALIDATION")
+    if refresh_token not in REFRESH_STORE:
+        raise APIError("Refresh token is not recognized", status_code=401, error_id="HG-AUTH-REFRESH")
+    manager = get_jwt_manager()
+    decoded = manager.decode(refresh_token)
+    if decoded.get("type") != "refresh":
+        raise APIError("Provided token is not a refresh token", status_code=401, error_id="HG-AUTH-REFRESH-TYPE")
+    email = REFRESH_STORE[refresh_token]
+    user = USERS[email]
+    tokens = issue_tokens(user["id"], user["roles"])
+    REFRESH_STORE[tokens["refresh_token"]] = email
+    return render_response({"tokens": tokens})
+
+
+@bp.route("/logout", methods=["POST"])
+def logout() -> "Response":
+    payload, _ = parse_request_data(request)
+    refresh_token = payload.get("refresh_token")
+    if refresh_token and refresh_token in REFRESH_STORE:
+        REFRESH_STORE.pop(refresh_token, None)
+    return render_response({"message": "Logged out"}, status_code=200)
+
+
+@bp.route("/roles", methods=["GET"])
+@require_auth(optional=True)
+def list_roles() -> "Response":
+    return render_response({"roles": AVAILABLE_ROLES}, meta={"total": len(AVAILABLE_ROLES)})
+
+
+@bp.route("/permissions", methods=["GET"])
+@require_auth(optional=True)
+def list_permissions() -> "Response":
+    permissions = [
+        "auth:login",
+        "auth:refresh",
+        "user:read",
+        "user:update",
+        "organization:manage",
+        "alert:ack",
+        "media:upload",
+    ]
+    return render_response({"permissions": permissions}, meta={"total": len(permissions)})
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/auth")

--- a/Microservicios/common/__init__.py
+++ b/Microservicios/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities for HeartGuard microservices."""

--- a/Microservicios/common/app_factory.py
+++ b/Microservicios/common/app_factory.py
@@ -1,0 +1,62 @@
+"""Application factory utilities for microservices."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Callable
+
+from flask import Flask, Response, g, request
+from flask_cors import CORS
+
+from .errors import register_error_handlers
+from .serialization import render_response
+
+
+def _configure_logging(service_name: str) -> logging.Logger:
+    logger = logging.getLogger(service_name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            fmt="%(asctime)s %(name)s %(levelname)s %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    logger.setLevel(getattr(logging, log_level, logging.INFO))
+    logger.propagate = False
+    return logger
+
+
+def create_app(service_name: str, register_blueprint: Callable[[Flask], None]) -> Flask:
+    app = Flask(service_name)
+    logger = _configure_logging(service_name)
+
+    allowed_origins = os.getenv("ALLOWED_ORIGINS")
+    if allowed_origins:
+        origins = [origin.strip() for origin in allowed_origins.split(",") if origin.strip()]
+    else:
+        origins = "*"
+    CORS(app, resources={r"/*": {"origins": origins}})
+
+    @app.before_request
+    def _before_request():
+        g.start_time = time.time()
+        g.request_id = request.headers.get("X-Request-ID") or os.urandom(8).hex()
+        g.logger = logger
+
+    @app.after_request
+    def _after_request(response: Response):
+        duration = time.time() - g.get("start_time", time.time())
+        logger.info("request_completed request_id=%s method=%s path=%s status=%s duration_ms=%s",
+                    g.get("request_id"), request.method, request.path, response.status_code, int(duration * 1000))
+        response.headers["X-Request-ID"] = g.get("request_id")
+        return response
+
+    @app.route("/health")
+    def health_check():
+        return render_response({"service": service_name, "status": "healthy"})
+
+    register_blueprint(app)
+    register_error_handlers(app)
+    return app

--- a/Microservicios/common/auth.py
+++ b/Microservicios/common/auth.py
@@ -1,0 +1,93 @@
+"""JWT helpers and decorators for microservices."""
+from __future__ import annotations
+
+import datetime as dt
+import os
+from functools import wraps
+from typing import Any, Callable, Dict
+
+import jwt
+from flask import g, request
+
+from .errors import APIError
+
+DEFAULT_ALGORITHM = "HS256"
+
+
+class JWTManager:
+    """Simple JWT manager based on shared secrets."""
+
+    def __init__(self, secret: str | None = None, algorithm: str = DEFAULT_ALGORITHM):
+        self.secret = secret or os.getenv("JWT_SECRET", "change-me")
+        self.algorithm = algorithm
+
+    def encode(self, payload: Dict[str, Any], expires_in: int = 900) -> str:
+        claims = payload.copy()
+        now = dt.datetime.utcnow()
+        claims.setdefault("iat", now)
+        claims.setdefault("exp", now + dt.timedelta(seconds=expires_in))
+        return jwt.encode(claims, self.secret, algorithm=self.algorithm)
+
+    def decode(self, token: str) -> Dict[str, Any]:
+        return jwt.decode(token, self.secret, algorithms=[self.algorithm])
+
+
+_jwt_manager: JWTManager | None = None
+
+
+def get_jwt_manager() -> JWTManager:
+    global _jwt_manager
+    if _jwt_manager is None:
+        _jwt_manager = JWTManager()
+    return _jwt_manager
+
+
+def require_auth(optional: bool = False, required_roles: list[str] | None = None):
+    required_roles = required_roles or []
+
+    def decorator(func: Callable):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            auth_header = request.headers.get("Authorization", "")
+            if not auth_header:
+                if optional:
+                    return func(*args, **kwargs)
+                raise APIError("Missing Authorization header", status_code=401, error_id="HG-AUTH-MISSING")
+            try:
+                scheme, token = auth_header.split(" ", 1)
+            except ValueError as exc:
+                raise APIError("Invalid Authorization header", status_code=401, error_id="HG-AUTH-BAD") from exc
+            if scheme.lower() != "bearer":
+                raise APIError("Invalid auth scheme", status_code=401, error_id="HG-AUTH-SCHEME")
+            try:
+                payload = get_jwt_manager().decode(token)
+            except jwt.ExpiredSignatureError as exc:
+                raise APIError("Token expired", status_code=401, error_id="HG-AUTH-EXPIRED") from exc
+            except jwt.InvalidTokenError as exc:
+                raise APIError("Invalid token", status_code=401, error_id="HG-AUTH-INVALID") from exc
+
+            roles = payload.get("roles", [])
+            if required_roles and not any(role in roles for role in required_roles):
+                raise APIError("Insufficient permissions", status_code=403, error_id="HG-AUTH-FORBIDDEN")
+
+            g.current_user = payload
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def issue_tokens(user_id: str, roles: list[str] | None = None, expires_in: int = 900) -> Dict[str, Any]:
+    roles = roles or ["user"]
+    manager = get_jwt_manager()
+    access_token = manager.encode({"sub": user_id, "roles": roles}, expires_in=expires_in)
+    refresh_ttl = int(os.getenv("REFRESH_TOKEN_TTL", "604800"))
+    refresh_token = manager.encode({"sub": user_id, "type": "refresh"}, expires_in=refresh_ttl)
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_in": expires_in,
+        "token_type": "Bearer",
+        "roles": roles,
+    }

--- a/Microservicios/common/errors.py
+++ b/Microservicios/common/errors.py
@@ -1,0 +1,53 @@
+"""Shared error classes and registration helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from flask import Flask
+
+
+@dataclass
+class APIError(Exception):
+    """Uniform API error that integrates with the response envelope."""
+
+    message: str
+    status_code: int = 400
+    error_id: str = "HG-GENERIC-ERROR"
+    details: Any | None = None
+    meta: Optional[dict[str, Any]] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "message": self.message,
+            "status_code": self.status_code,
+            "error_id": self.error_id,
+            "details": self.details,
+            "meta": self.meta,
+        }
+
+
+def register_error_handlers(app: Flask) -> None:
+    from .serialization import render_error
+
+    @app.errorhandler(APIError)
+    def _handle_api_error(error: APIError):
+        app.logger.warning("api_error error_id=%s status_code=%s", error.error_id, error.status_code)
+        return render_error(error)
+
+    @app.errorhandler(404)
+    def _handle_not_found(_):
+        return render_error(APIError("Resource not found", status_code=404, error_id="HG-NOT-FOUND"))
+
+    @app.errorhandler(405)
+    def _handle_method_not_allowed(_):
+        return render_error(
+            APIError("Method not allowed", status_code=405, error_id="HG-METHOD-NOT-ALLOWED")
+        )
+
+    @app.errorhandler(Exception)
+    def _handle_unexpected(error: Exception):
+        app.logger.exception("unexpected_error", exc_info=error)
+        return render_error(
+            APIError("Internal server error", status_code=500, error_id="HG-INTERNAL-ERROR")
+        )

--- a/Microservicios/common/serialization.py
+++ b/Microservicios/common/serialization.py
@@ -1,0 +1,109 @@
+"""Utilities for parsing requests and rendering responses in JSON/XML."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Tuple
+
+from flask import Request, Response, current_app, jsonify, make_response, request
+import dicttoxml
+import xmltodict
+
+from .errors import APIError
+
+SUPPORTED_CONTENT_TYPES = {"application/json", "application/xml", "text/xml"}
+
+
+def negotiate_content_type(req: Request) -> str:
+    """Return the preferred response content type based on the Accept header."""
+    accept_header = req.headers.get("Accept", "application/json")
+    if "application/xml" in accept_header.lower():
+        return "application/xml"
+    return "application/json"
+
+
+def _prepare_envelope(status: str, code: int, data: Any = None, meta: Dict[str, Any] | None = None,
+                      error: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    envelope: Dict[str, Any] = {
+        "status": status,
+        "code": code,
+    }
+    if meta:
+        envelope["meta"] = meta
+    if error is not None:
+        envelope["error"] = error
+    if data is not None:
+        envelope["data"] = data
+    return envelope
+
+
+def render_response(data: Any, status_code: int = 200, meta: Dict[str, Any] | None = None) -> Response:
+    """Render a Flask response honoring the Accept header for JSON or XML."""
+    envelope = _prepare_envelope("success", status_code, data=data, meta=meta)
+    content_type = negotiate_content_type(request)
+
+    if content_type == "application/xml":
+        xml_body = dicttoxml.dicttoxml(envelope, custom_root="response", attr_type=False)
+        response = make_response(xml_body, status_code)
+        response.headers["Content-Type"] = "application/xml"
+        return response
+
+    response = jsonify(envelope)
+    response.status_code = status_code
+    return response
+
+
+def render_error(error: APIError) -> Response:
+    """Render an error response using the negotiation rules."""
+    payload = _prepare_envelope(
+        status="error",
+        code=error.status_code,
+        error={
+            "id": error.error_id,
+            "message": error.message,
+            "details": error.details,
+        },
+        meta=error.meta,
+    )
+    content_type = negotiate_content_type(request)
+    if content_type == "application/xml":
+        xml_body = dicttoxml.dicttoxml(payload, custom_root="response", attr_type=False)
+        response = make_response(xml_body, error.status_code)
+        response.headers["Content-Type"] = "application/xml"
+        return response
+
+    response = jsonify(payload)
+    response.status_code = error.status_code
+    return response
+
+
+def parse_request_data(req: Request) -> Tuple[Dict[str, Any], str]:
+    """Parse JSON or XML payloads from the incoming request."""
+    if req.method in {"GET", "DELETE"}:
+        return {}, "application/json"
+
+    content_type = req.headers.get("Content-Type", "").split(";")[0].strip().lower()
+    if not content_type:
+        raise APIError("Missing Content-Type header", status_code=415, error_id="HG-UNSUPPORTED-TYPE")
+
+    if content_type not in SUPPORTED_CONTENT_TYPES:
+        raise APIError(
+            f"Unsupported Content-Type '{content_type}'",
+            status_code=415,
+            error_id="HG-UNSUPPORTED-TYPE",
+        )
+
+    if not req.data:
+        raise APIError("Request body is empty", status_code=400, error_id="HG-EMPTY-BODY")
+
+    try:
+        if content_type == "application/json":
+            return json.loads(req.data.decode("utf-8")), content_type
+        # XML branch
+        parsed = xmltodict.parse(req.data)
+        # normalize to dict by removing possible root wrappers
+        if isinstance(parsed, dict) and len(parsed) == 1:
+            parsed = next(iter(parsed.values()))
+        return json.loads(json.dumps(parsed)), content_type
+    except Exception as exc:  # pragma: no cover - defensive
+        current_app.logger.exception("Failed to parse request payload", exc_info=exc)
+        raise APIError("Invalid request payload", status_code=400, error_id="HG-BAD-PAYLOAD") from exc

--- a/Microservicios/device_service/__init__.py
+++ b/Microservicios/device_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/device_service/app.py
+++ b/Microservicios/device_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "device"
+DEFAULT_PORT = 5005
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/device_service/requirements.txt
+++ b/Microservicios/device_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/device_service/routes.py
+++ b/Microservicios/device_service/routes.py
@@ -1,0 +1,109 @@
+"""Device service managing hardware assets and stream bindings."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Dict, List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("devices", __name__)
+
+DEVICE_TYPES = {
+    "dev-type-1": {"id": "dev-type-1", "name": "HeartGuard Watch", "manufacturer": "HeartGuard"},
+}
+
+DEVICES: Dict[str, Dict] = {
+    "dev-1": {
+        "id": "dev-1",
+        "device_type_id": "dev-type-1",
+        "serial_number": "HGW-0001",
+        "assigned_patient_id": "pat-1",
+        "status": "active",
+    }
+}
+
+SIGNAL_STREAMS: Dict[str, Dict] = {
+    "stream-1": {
+        "id": "stream-1",
+        "device_id": "dev-1",
+        "signal_type": "heart_rate",
+        "sampling_rate": 1,
+    }
+}
+
+TIMESERIES_BINDINGS: List[Dict] = [
+    {
+        "id": "binding-1",
+        "stream_id": "stream-1",
+        "influx_measurement": "heart_rate",
+        "bucket": "heartguard-timeseries",
+        "org": "heartguard",
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+]
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "device", "status": "healthy", "devices": len(DEVICES)})
+
+
+@bp.route("", methods=["GET"])
+@require_auth(optional=True)
+def list_devices() -> "Response":
+    return render_response({"devices": list(DEVICES.values())}, meta={"total": len(DEVICES)})
+
+
+@bp.route("", methods=["POST"])
+@require_auth(required_roles=["admin", "clinician"])
+def register_device() -> "Response":
+    payload, _ = parse_request_data(request)
+    serial = payload.get("serial_number")
+    if not serial:
+        raise APIError("serial_number is required", status_code=400, error_id="HG-DEVICE-VALIDATION")
+    device_id = f"dev-{len(DEVICES) + 1}"
+    device = {
+        "id": device_id,
+        "device_type_id": payload.get("device_type_id", "dev-type-1"),
+        "serial_number": serial,
+        "assigned_patient_id": payload.get("assigned_patient_id"),
+        "status": payload.get("status", "inventory"),
+    }
+    DEVICES[device_id] = device
+    return render_response({"device": device}, status_code=201)
+
+
+@bp.route("/<device_id>/streams", methods=["GET"])
+@require_auth(optional=True)
+def list_streams(device_id: str) -> "Response":
+    streams = [stream for stream in SIGNAL_STREAMS.values() if stream["device_id"] == device_id]
+    bindings = [binding for binding in TIMESERIES_BINDINGS if binding["stream_id"] in {s["id"] for s in streams}]
+    return render_response({"streams": streams, "bindings": bindings}, meta={"streams": len(streams)})
+
+
+@bp.route("/streams/bind", methods=["POST"])
+@require_auth(required_roles=["admin", "clinician"])
+def create_binding() -> "Response":
+    payload, _ = parse_request_data(request)
+    stream_id = payload.get("stream_id")
+    measurement = payload.get("influx_measurement")
+    if not stream_id or not measurement:
+        raise APIError("stream_id and influx_measurement are required", status_code=400, error_id="HG-DEVICE-BINDING")
+    binding = {
+        "id": f"binding-{len(TIMESERIES_BINDINGS) + 1}",
+        "stream_id": stream_id,
+        "influx_measurement": measurement,
+        "bucket": payload.get("bucket", "heartguard-timeseries"),
+        "org": payload.get("org", "heartguard"),
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    TIMESERIES_BINDINGS.append(binding)
+    return render_response({"binding": binding}, status_code=201)
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/devices")

--- a/Microservicios/docker-compose.yml
+++ b/Microservicios/docker-compose.yml
@@ -1,0 +1,312 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_SUPERUSER}
+      POSTGRES_PASSWORD: ${POSTGRES_SUPERPASS}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./db/init.sql:/docker-entrypoint-initdb.d/00-init.sql:ro
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_SUPERUSER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - heartguard_net
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - heartguard_net
+
+  rabbitmq:
+    image: rabbitmq:3.12-management-alpine
+    restart: unless-stopped
+    environment:
+      RABBITMQ_DEFAULT_USER: heartguard
+      RABBITMQ_DEFAULT_PASS: change_me
+      RABBITMQ_DEFAULT_VHOST: heartguard
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - heartguard_net
+
+  influxdb:
+    image: influxdb:2.7
+    restart: unless-stopped
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: heartguard
+      DOCKER_INFLUXDB_INIT_PASSWORD: change_me
+      DOCKER_INFLUXDB_INIT_ORG: ${INFLUX_ORG}
+      DOCKER_INFLUXDB_INIT_BUCKET: ${INFLUX_BUCKET}
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUX_TOKEN}
+    ports:
+      - "8086:8086"
+    volumes:
+      - influx_data:/var/lib/influxdb2
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - heartguard_net
+
+  gateway:
+    build: ./gateway
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: gateway
+      SERVICE_PORT: ${GATEWAY_PORT}
+    ports:
+      - "5000:5000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+  auth_service:
+    build: ./auth_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: auth
+      DATABASE_URL: ${POSTGRES_URL_AUTH}
+    ports:
+      - "5001:5001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - heartguard_net
+
+  organization_service:
+    build: ./organization_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: organization
+      DATABASE_URL: ${POSTGRES_URL_ORGANIZATION}
+    ports:
+      - "5002:5002"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+  user_service:
+    build: ./user_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: user
+      DATABASE_URL: ${POSTGRES_URL_USER}
+    ports:
+      - "5003:5003"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+  patient_service:
+    build: ./patient_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: patient
+      DATABASE_URL: ${POSTGRES_URL_PATIENT}
+    ports:
+      - "5004:5004"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+  device_service:
+    build: ./device_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: device
+      DATABASE_URL: ${POSTGRES_URL_DEVICE}
+    ports:
+      - "5005:5005"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+      influx_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+  influx_service:
+    build: ./influx_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: influx
+      INFLUX_URL: ${INFLUX_URL}
+      INFLUX_TOKEN: ${INFLUX_TOKEN}
+      INFLUX_ORG: ${INFLUX_ORG}
+    ports:
+      - "5006:5006"
+    depends_on:
+      influxdb:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+  inference_service:
+    build: ./inference_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: inference
+      DATABASE_URL: ${POSTGRES_URL_INFERENCE}
+    ports:
+      - "5007:5007"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    volumes:
+      - inference_models:/models
+    networks:
+      - heartguard_net
+
+  alert_service:
+    build: ./alert_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: alert
+      DATABASE_URL: ${POSTGRES_URL_ALERT}
+    ports:
+      - "5008:5008"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+  notification_service:
+    build: ./notification_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: notification
+      DATABASE_URL: ${POSTGRES_URL_NOTIFICATION}
+    ports:
+      - "5009:5009"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+  media_service:
+    build: ./media_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: media
+      DATABASE_URL: ${POSTGRES_URL_MEDIA}
+    ports:
+      - "5010:5010"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    secrets:
+      - gcp-sa
+    networks:
+      - heartguard_net
+
+  audit_service:
+    build: ./audit_service
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      SERVICE_NAME: audit
+      DATABASE_URL: ${POSTGRES_URL_AUDIT}
+    ports:
+      - "5011:5011"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      auth_service:
+        condition: service_started
+    networks:
+      - heartguard_net
+
+networks:
+  heartguard_net:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  influx_data:
+  inference_models:
+
+secrets:
+  gcp-sa:
+    file: ./secrets/gcp-sa.json

--- a/Microservicios/gateway/__init__.py
+++ b/Microservicios/gateway/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/gateway/app.py
+++ b/Microservicios/gateway/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "gateway"
+DEFAULT_PORT = 5000
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/gateway/requirements.txt
+++ b/Microservicios/gateway/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/gateway/routes.py
+++ b/Microservicios/gateway/routes.py
@@ -1,0 +1,53 @@
+"""Gateway service routes providing routing metadata."""
+from __future__ import annotations
+
+from typing import List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("gateway", __name__)
+
+# Static registry of service routes exposed by the gateway for documentation purposes.
+SERVICE_ROUTES = [
+    {"service": "auth", "path": "/auth/login", "methods": ["POST"]},
+    {"service": "organization", "path": "/organization", "methods": ["GET", "PUT"]},
+    {"service": "user", "path": "/users/me", "methods": ["GET", "PATCH"]},
+    {"service": "patient", "path": "/patients", "methods": ["GET", "POST"]},
+    {"service": "device", "path": "/devices", "methods": ["GET", "POST"]},
+    {"service": "media", "path": "/media/upload", "methods": ["POST"]},
+    {"service": "alerts", "path": "/alerts", "methods": ["GET", "POST"]},
+]
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "gateway", "status": "healthy"})
+
+
+@bp.route("/routes", methods=["GET"])
+def list_routes() -> "Response":
+    return render_response({"routes": SERVICE_ROUTES}, meta={"total": len(SERVICE_ROUTES)})
+
+
+@bp.route("/echo", methods=["POST"])
+def echo() -> "Response":
+    payload, content_type = parse_request_data(request)
+    meta = {"content_type": content_type}
+    return render_response({"echo": payload}, status_code=201, meta=meta)
+
+
+@bp.route("/forward/<service_name>", methods=["GET"])
+@require_auth(optional=True)
+def forward(service_name: str) -> "Response":
+    matching: List[dict] = [route for route in SERVICE_ROUTES if route["service"] == service_name]
+    if not matching:
+        raise APIError("Unknown service", status_code=404, error_id="HG-GW-UNKNOWN-SERVICE")
+    return render_response({"service": service_name, "registered_routes": matching})
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/gateway")

--- a/Microservicios/inference_service/__init__.py
+++ b/Microservicios/inference_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/inference_service/app.py
+++ b/Microservicios/inference_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "inference"
+DEFAULT_PORT = 5007
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/inference_service/requirements.txt
+++ b/Microservicios/inference_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/inference_service/routes.py
+++ b/Microservicios/inference_service/routes.py
@@ -1,0 +1,85 @@
+"""Inference service orchestrating ML model metadata and inference records."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Dict, List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("inference", __name__)
+
+MODELS: Dict[str, Dict] = {
+    "model-ecg-risk": {
+        "id": "model-ecg-risk",
+        "name": "ECG Risk Classifier",
+        "version": "1.0.0",
+        "status": "active",
+    }
+}
+
+EVENT_TYPES: List[Dict] = [
+    {"id": "evt-1", "name": "tachycardia", "severity": "high"},
+    {"id": "evt-2", "name": "bradycardia", "severity": "medium"},
+]
+
+INFERENCES: List[Dict] = []
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "inference", "status": "healthy", "models": len(MODELS)})
+
+
+@bp.route("/models", methods=["GET"])
+@require_auth(optional=True)
+def list_models() -> "Response":
+    return render_response({"models": list(MODELS.values())}, meta={"total": len(MODELS)})
+
+
+@bp.route("/models", methods=["POST"])
+@require_auth(required_roles=["admin"])
+def register_model() -> "Response":
+    payload, _ = parse_request_data(request)
+    model_id = payload.get("id")
+    if not model_id:
+        raise APIError("id is required", status_code=400, error_id="HG-INFERENCE-MODEL")
+    MODELS[model_id] = {
+        "id": model_id,
+        "name": payload.get("name", model_id),
+        "version": payload.get("version", "1.0.0"),
+        "status": payload.get("status", "active"),
+    }
+    return render_response({"model": MODELS[model_id]}, status_code=201)
+
+
+@bp.route("/events", methods=["GET"])
+@require_auth(optional=True)
+def list_event_types() -> "Response":
+    return render_response({"event_types": EVENT_TYPES}, meta={"total": len(EVENT_TYPES)})
+
+
+@bp.route("/inferences", methods=["POST"])
+@require_auth(optional=True)
+def record_inference() -> "Response":
+    payload, _ = parse_request_data(request)
+    model_id = payload.get("model_id")
+    if model_id not in MODELS:
+        raise APIError("Unknown model", status_code=404, error_id="HG-INFERENCE-MODEL")
+    inference = {
+        "id": f"inf-{len(INFERENCES) + 1}",
+        "model_id": model_id,
+        "patient_id": payload.get("patient_id"),
+        "event_type": payload.get("event_type"),
+        "score": payload.get("score", 0.0),
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    INFERENCES.append(inference)
+    return render_response({"inference": inference}, status_code=201)
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/inference")

--- a/Microservicios/influx_service/__init__.py
+++ b/Microservicios/influx_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/influx_service/app.py
+++ b/Microservicios/influx_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "influx"
+DEFAULT_PORT = 5006
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/influx_service/requirements.txt
+++ b/Microservicios/influx_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/influx_service/routes.py
+++ b/Microservicios/influx_service/routes.py
@@ -1,0 +1,85 @@
+"""InfluxDB wrapper service providing write/query endpoints."""
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Dict, List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("influx", __name__)
+
+WRITTEN_POINTS: List[Dict] = []
+BUCKETS: Dict[str, Dict] = {
+    os.getenv("INFLUX_BUCKET", "heartguard-timeseries"): {
+        "name": os.getenv("INFLUX_BUCKET", "heartguard-timeseries"),
+        "retention_days": 30,
+        "org": os.getenv("INFLUX_ORG", "heartguard"),
+    }
+}
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "influx", "status": "healthy", "points_cached": len(WRITTEN_POINTS)})
+
+
+@bp.route("/ready", methods=["GET"])
+def ready() -> "Response":
+    token_available = bool(os.getenv("INFLUX_TOKEN"))
+    status = "ready" if token_available else "degraded"
+    return render_response({"status": status, "token": token_available})
+
+
+@bp.route("/write", methods=["POST"])
+@require_auth(optional=True)
+def write_points() -> "Response":
+    payload, _ = parse_request_data(request)
+    points = payload.get("points") or []
+    if not isinstance(points, list) or not points:
+        raise APIError("points must be a non-empty list", status_code=400, error_id="HG-INFLUX-VALIDATION")
+    for point in points:
+        point.setdefault("received_at", dt.datetime.utcnow().isoformat() + "Z")
+        WRITTEN_POINTS.append(point)
+    return render_response({"ingested": len(points)})
+
+
+@bp.route("/query", methods=["POST"])
+@require_auth(optional=True)
+def query_points() -> "Response":
+    payload, _ = parse_request_data(request)
+    measurement = payload.get("measurement")
+    limit = int(payload.get("limit", 100))
+    filtered = [p for p in WRITTEN_POINTS if measurement is None or p.get("measurement") == measurement]
+    return render_response({"results": filtered[:limit]}, meta={"returned": min(limit, len(filtered))})
+
+
+@bp.route("/buckets", methods=["GET"])
+@require_auth(optional=True)
+def list_buckets() -> "Response":
+    return render_response({"buckets": list(BUCKETS.values())}, meta={"total": len(BUCKETS)})
+
+
+@bp.route("/buckets", methods=["POST"])
+@require_auth(required_roles=["admin"])
+def create_bucket() -> "Response":
+    payload, _ = parse_request_data(request)
+    name = payload.get("name")
+    if not name:
+        raise APIError("name is required", status_code=400, error_id="HG-INFLUX-BUCKET")
+    bucket = {
+        "name": name,
+        "retention_days": payload.get("retention_days", 30),
+        "org": payload.get("org", os.getenv("INFLUX_ORG", "heartguard")),
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    BUCKETS[name] = bucket
+    return render_response({"bucket": bucket}, status_code=201)
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/influx")

--- a/Microservicios/media_service/__init__.py
+++ b/Microservicios/media_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/media_service/app.py
+++ b/Microservicios/media_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "media"
+DEFAULT_PORT = 5010
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/media_service/requirements.txt
+++ b/Microservicios/media_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/media_service/routes.py
+++ b/Microservicios/media_service/routes.py
@@ -1,0 +1,100 @@
+"""Media service for managing objects and signed URLs."""
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import os
+from typing import Dict
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("media", __name__)
+
+MEDIA_ITEMS: Dict[str, Dict] = {
+    "media-1": {
+        "id": "media-1",
+        "filename": "report.pdf",
+        "mime_type": "application/pdf",
+        "size_bytes": 12048,
+        "owner_id": "usr-2",
+        "bucket": os.getenv("GCS_BUCKET", "heartguard-system"),
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+}
+
+
+def _signed_url(media_id: str) -> str:
+    secret = os.getenv("MEDIA_SIGNING_SECRET", "demo-secret")
+    digest = hashlib.sha256(f"{media_id}:{secret}".encode("utf-8")).hexdigest()
+    return f"https://storage.googleapis.com/{os.getenv('GCS_BUCKET', 'heartguard-system')}/{media_id}?signature={digest}"
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "media", "status": "healthy", "items": len(MEDIA_ITEMS)})
+
+
+@bp.route("", methods=["GET"])
+@require_auth(optional=True)
+def list_media() -> "Response":
+    items = []
+    for item in MEDIA_ITEMS.values():
+        enriched = dict(item)
+        enriched["signed_url"] = _signed_url(item["id"])
+        items.append(enriched)
+    return render_response({"media": items}, meta={"total": len(items)})
+
+
+@bp.route("/upload", methods=["POST"])
+@require_auth(optional=True)
+def upload_media() -> "Response":
+    payload, _ = parse_request_data(request)
+    filename = payload.get("filename")
+    mime_type = payload.get("mime_type")
+    size_bytes = payload.get("size_bytes")
+    if not filename or not mime_type:
+        raise APIError("filename and mime_type are required", status_code=400, error_id="HG-MEDIA-VALIDATION")
+    if size_bytes and int(size_bytes) > int(os.getenv("MEDIA_MAX_FILE_SIZE_MB", "50")) * 1024 * 1024:
+        raise APIError("File exceeds maximum allowed size", status_code=400, error_id="HG-MEDIA-SIZE")
+    media_id = f"media-{len(MEDIA_ITEMS) + 1}"
+    item = {
+        "id": media_id,
+        "filename": filename,
+        "mime_type": mime_type,
+        "size_bytes": size_bytes or 0,
+        "owner_id": payload.get("owner_id"),
+        "bucket": os.getenv("GCS_BUCKET", "heartguard-system"),
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    MEDIA_ITEMS[media_id] = item
+    item_with_url = dict(item)
+    item_with_url["signed_url"] = _signed_url(media_id)
+    return render_response({"media": item_with_url}, status_code=201)
+
+
+@bp.route("/<media_id>", methods=["GET"])
+@require_auth(optional=True)
+def get_media(media_id: str) -> "Response":
+    item = MEDIA_ITEMS.get(media_id)
+    if not item:
+        raise APIError("Media item not found", status_code=404, error_id="HG-MEDIA-NOT-FOUND")
+    enriched = dict(item)
+    enriched["signed_url"] = _signed_url(media_id)
+    return render_response({"media": enriched})
+
+
+@bp.route("/<media_id>", methods=["DELETE"])
+@require_auth(required_roles=["admin", "org_admin"])
+def delete_media(media_id: str) -> "Response":
+    if media_id not in MEDIA_ITEMS:
+        raise APIError("Media item not found", status_code=404, error_id="HG-MEDIA-NOT-FOUND")
+    MEDIA_ITEMS.pop(media_id)
+    return render_response({"message": "Media deleted"})
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/media")

--- a/Microservicios/notification_service/__init__.py
+++ b/Microservicios/notification_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/notification_service/app.py
+++ b/Microservicios/notification_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "notifications"
+DEFAULT_PORT = 5009
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/notification_service/requirements.txt
+++ b/Microservicios/notification_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/notification_service/routes.py
+++ b/Microservicios/notification_service/routes.py
@@ -1,0 +1,79 @@
+"""Notification service to manage push devices and alert deliveries."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Dict, List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("notifications", __name__)
+
+PUSH_DEVICES: Dict[str, Dict] = {
+    "pd-1": {
+        "id": "pd-1",
+        "user_id": "usr-2",
+        "platform": "ios",
+        "token": "ios-token-123",
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+}
+
+ALERT_DELIVERIES: List[Dict] = []
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "notification", "status": "healthy", "devices": len(PUSH_DEVICES)})
+
+
+@bp.route("/push-devices", methods=["GET"])
+@require_auth(optional=True)
+def list_devices() -> "Response":
+    return render_response({"push_devices": list(PUSH_DEVICES.values())}, meta={"total": len(PUSH_DEVICES)})
+
+
+@bp.route("/push-devices", methods=["POST"])
+@require_auth(optional=True)
+def register_device() -> "Response":
+    payload, _ = parse_request_data(request)
+    user_id = payload.get("user_id")
+    token = payload.get("token")
+    if not user_id or not token:
+        raise APIError("user_id and token are required", status_code=400, error_id="HG-NOTIFY-VALIDATION")
+    device_id = f"pd-{len(PUSH_DEVICES) + 1}"
+    device = {
+        "id": device_id,
+        "user_id": user_id,
+        "platform": payload.get("platform", "ios"),
+        "token": token,
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    PUSH_DEVICES[device_id] = device
+    return render_response({"push_device": device}, status_code=201)
+
+
+@bp.route("/deliveries", methods=["POST"])
+@require_auth(optional=True)
+def create_delivery() -> "Response":
+    payload, _ = parse_request_data(request)
+    alert_id = payload.get("alert_id")
+    device_id = payload.get("device_id")
+    if not alert_id or not device_id:
+        raise APIError("alert_id and device_id are required", status_code=400, error_id="HG-NOTIFY-DELIVERY")
+    delivery = {
+        "id": f"delivery-{len(ALERT_DELIVERIES) + 1}",
+        "alert_id": alert_id,
+        "device_id": device_id,
+        "status": "sent",
+        "sent_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    ALERT_DELIVERIES.append(delivery)
+    return render_response({"delivery": delivery}, status_code=201)
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/notifications")

--- a/Microservicios/organization_service/__init__.py
+++ b/Microservicios/organization_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/organization_service/app.py
+++ b/Microservicios/organization_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "organization"
+DEFAULT_PORT = 5002
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/organization_service/requirements.txt
+++ b/Microservicios/organization_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/organization_service/routes.py
+++ b/Microservicios/organization_service/routes.py
@@ -1,0 +1,84 @@
+"""Organization service exposing organization management endpoints."""
+from __future__ import annotations
+
+import copy
+import datetime as dt
+from typing import Dict, List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("organization", __name__)
+
+ORGANIZATION_PROFILE: Dict[str, Dict] = {
+    "default": {
+        "id": "org-1",
+        "name": "HeartGuard Inc.",
+        "website": "https://heartguard.example.com",
+        "policy_version": "2024-01",
+        "support_email": "support@heartguard.example.com",
+        "logo_url": "https://cdn.heartguard.example.com/logo.png",
+    }
+}
+
+ORG_INVITATIONS: List[Dict] = [
+    {
+        "id": "inv-1",
+        "email": "new-clinician@example.com",
+        "role": "clinician",
+        "expires_at": (dt.datetime.utcnow() + dt.timedelta(days=7)).isoformat() + "Z",
+    }
+]
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "organization", "status": "healthy"})
+
+
+@bp.route("", methods=["GET"])
+@require_auth(optional=True)
+def get_profile() -> "Response":
+    profile = copy.deepcopy(ORGANIZATION_PROFILE["default"])
+    return render_response({"organization": profile})
+
+
+@bp.route("", methods=["PUT"])
+@require_auth(required_roles=["admin", "org_admin"])
+def update_profile() -> "Response":
+    payload, _ = parse_request_data(request)
+    profile = ORGANIZATION_PROFILE["default"]
+    profile.update({k: v for k, v in payload.items() if k in profile})
+    profile["updated_at"] = dt.datetime.utcnow().isoformat() + "Z"
+    return render_response({"organization": profile})
+
+
+@bp.route("/invitations", methods=["GET"])
+@require_auth(optional=True)
+def list_invitations() -> "Response":
+    return render_response({"invitations": ORG_INVITATIONS}, meta={"total": len(ORG_INVITATIONS)})
+
+
+@bp.route("/invitations", methods=["POST"])
+@require_auth(required_roles=["admin", "org_admin"])
+def create_invitation() -> "Response":
+    payload, _ = parse_request_data(request)
+    email = payload.get("email")
+    role = payload.get("role", "user")
+    if not email:
+        raise APIError("email is required", status_code=400, error_id="HG-ORG-VALIDATION")
+    invitation = {
+        "id": f"inv-{len(ORG_INVITATIONS) + 1}",
+        "email": email,
+        "role": role,
+        "expires_at": (dt.datetime.utcnow() + dt.timedelta(days=7)).isoformat() + "Z",
+    }
+    ORG_INVITATIONS.append(invitation)
+    return render_response({"invitation": invitation}, status_code=201)
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/organization")

--- a/Microservicios/patient_service/__init__.py
+++ b/Microservicios/patient_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/patient_service/app.py
+++ b/Microservicios/patient_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "patient"
+DEFAULT_PORT = 5004
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/patient_service/requirements.txt
+++ b/Microservicios/patient_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/patient_service/routes.py
+++ b/Microservicios/patient_service/routes.py
@@ -1,0 +1,97 @@
+"""Patient service managing clinical subject data."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Dict, List
+
+from flask import Blueprint, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("patients", __name__)
+
+PATIENTS: Dict[str, Dict] = {
+    "pat-1": {
+        "id": "pat-1",
+        "mrn": "MRN-1001",
+        "first_name": "Elena",
+        "last_name": "Heart",
+        "birth_date": "1985-05-20",
+        "sex": "F",
+        "organization_id": "org-1",
+    }
+}
+
+CARE_TEAMS: Dict[str, List[Dict]] = {
+    "pat-1": [
+        {
+            "id": "team-1",
+            "name": "Primary Care",
+            "members": [
+                {"user_id": "usr-2", "role": "clinician"},
+                {"user_id": "usr-1", "role": "admin"},
+            ],
+        }
+    ]
+}
+
+CAREGIVER_LINKS: List[Dict] = [
+    {"caregiver_id": "usr-1", "patient_id": "pat-1", "relationship": "spouse"}
+]
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "patient", "status": "healthy", "patients": len(PATIENTS)})
+
+
+@bp.route("", methods=["GET"])
+@require_auth(optional=True)
+def list_patients() -> "Response":
+    return render_response({"patients": list(PATIENTS.values())}, meta={"total": len(PATIENTS)})
+
+
+@bp.route("", methods=["POST"])
+@require_auth(required_roles=["clinician", "admin"])
+def create_patient() -> "Response":
+    payload, _ = parse_request_data(request)
+    first_name = payload.get("first_name")
+    last_name = payload.get("last_name")
+    if not first_name or not last_name:
+        raise APIError("first_name and last_name are required", status_code=400, error_id="HG-PATIENT-VALIDATION")
+    patient_id = f"pat-{len(PATIENTS) + 1}"
+    patient = {
+        "id": patient_id,
+        "mrn": payload.get("mrn", f"MRN-{len(PATIENTS) + 1000}"),
+        "first_name": first_name,
+        "last_name": last_name,
+        "birth_date": payload.get("birth_date"),
+        "sex": payload.get("sex", "U"),
+        "organization_id": payload.get("organization_id", "org-1"),
+        "created_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+    PATIENTS[patient_id] = patient
+    return render_response({"patient": patient}, status_code=201)
+
+
+@bp.route("/<patient_id>", methods=["GET"])
+@require_auth(optional=True)
+def get_patient(patient_id: str) -> "Response":
+    patient = PATIENTS.get(patient_id)
+    if not patient:
+        raise APIError("Patient not found", status_code=404, error_id="HG-PATIENT-NOT-FOUND")
+    return render_response({"patient": patient})
+
+
+@bp.route("/<patient_id>/care-team", methods=["GET"])
+@require_auth(optional=True)
+def get_care_team(patient_id: str) -> "Response":
+    team = CARE_TEAMS.get(patient_id, [])
+    caregivers = [link for link in CAREGIVER_LINKS if link["patient_id"] == patient_id]
+    return render_response({"care_teams": team, "caregivers": caregivers})
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/patients")

--- a/Microservicios/schemas/json/alert.json
+++ b/Microservicios/schemas/json/alert.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heartguard.example/schemas/alert.json",
+  "title": "Alert",
+  "type": "object",
+  "required": ["id", "patient_id", "level", "status", "created_at"],
+  "properties": {
+    "id": {"type": "string", "format": "uuid"},
+    "patient_id": {"type": "string", "format": "uuid"},
+    "source": {"type": "string", "enum": ["inference", "manual", "device"]},
+    "event_type": {"type": "string", "maxLength": 120},
+    "level": {"type": "string", "enum": ["info", "low", "medium", "high", "critical"]},
+    "status": {"type": "string", "enum": ["open", "assigned", "acknowledged", "resolved", "cancelled"]},
+    "assigned_to": {"type": "string", "format": "uuid"},
+    "acknowledged_by": {"type": "string", "format": "uuid"},
+    "acknowledged_at": {"type": "string", "format": "date-time"},
+    "resolution": {
+      "type": "object",
+      "properties": {
+        "resolved_by": {"type": "string", "format": "uuid"},
+        "resolved_at": {"type": "string", "format": "date-time"},
+        "notes": {"type": "string", "maxLength": 2000}
+      },
+      "additionalProperties": false
+    },
+    "delivery": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["channel", "status"],
+        "properties": {
+          "channel": {"type": "string", "enum": ["push", "sms", "email"]},
+          "status": {"type": "string", "enum": ["pending", "sent", "failed"]},
+          "delivered_at": {"type": "string", "format": "date-time"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/json/device.json
+++ b/Microservicios/schemas/json/device.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heartguard.example/schemas/device.json",
+  "title": "Device",
+  "type": "object",
+  "required": ["id", "serial_number", "device_type", "status", "created_at"],
+  "properties": {
+    "id": {"type": "string", "format": "uuid"},
+    "serial_number": {"type": "string", "maxLength": 120},
+    "device_type": {
+      "type": "object",
+      "required": ["id", "code", "label"],
+      "properties": {
+        "id": {"type": "string", "format": "uuid"},
+        "code": {"type": "string", "maxLength": 40},
+        "label": {"type": "string", "maxLength": 80}
+      },
+      "additionalProperties": false
+    },
+    "status": {"type": "string", "enum": ["active", "inactive", "maintenance", "retired"]},
+    "assigned_patient_id": {"type": "string", "format": "uuid"},
+    "signal_streams": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "signal_type", "sampling_rate", "timeseries_binding"],
+        "properties": {
+          "id": {"type": "string", "format": "uuid"},
+          "signal_type": {"type": "string", "maxLength": 40},
+          "sampling_rate": {"type": "number", "minimum": 0},
+          "timeseries_binding": {
+            "type": "object",
+            "required": ["bucket", "measurement", "retention_policy"],
+            "properties": {
+              "bucket": {"type": "string", "maxLength": 120},
+              "measurement": {"type": "string", "maxLength": 120},
+              "retention_policy": {"type": "string", "maxLength": 120},
+              "tags": {
+                "type": "object",
+                "additionalProperties": {"type": "string"}
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "last_seen_at": {"type": "string", "format": "date-time"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/json/inference.json
+++ b/Microservicios/schemas/json/inference.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heartguard.example/schemas/inference.json",
+  "title": "Inference",
+  "type": "object",
+  "required": ["id", "model_id", "event_type", "input_reference", "created_at"],
+  "properties": {
+    "id": {"type": "string", "format": "uuid"},
+    "model_id": {"type": "string", "format": "uuid"},
+    "model_version": {"type": "string", "maxLength": 40},
+    "event_type": {"type": "string", "maxLength": 120},
+    "input_reference": {"type": "string", "maxLength": 200},
+    "patient_id": {"type": "string", "format": "uuid"},
+    "device_id": {"type": "string", "format": "uuid"},
+    "score": {"type": "number"},
+    "threshold": {"type": "number"},
+    "payload": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "generated_alert_id": {"type": "string", "format": "uuid"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "processed_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/json/media_item.json
+++ b/Microservicios/schemas/json/media_item.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heartguard.example/schemas/media_item.json",
+  "title": "MediaItem",
+  "type": "object",
+  "required": ["id", "filename", "mime_type", "size_bytes", "bucket", "created_at"],
+  "properties": {
+    "id": {"type": "string", "format": "uuid"},
+    "filename": {"type": "string", "maxLength": 255},
+    "mime_type": {"type": "string", "pattern": "^[\w.+-]+\/[\w.+-]+$"},
+    "size_bytes": {"type": "integer", "minimum": 0},
+    "bucket": {"type": "string", "maxLength": 120},
+    "object_name": {"type": "string", "maxLength": 512},
+    "owner_id": {"type": "string", "format": "uuid"},
+    "checksum": {"type": "string", "maxLength": 128},
+    "signed_url": {"type": "string", "format": "uri"},
+    "signed_url_expires_at": {"type": "string", "format": "date-time"},
+    "tags": {
+      "type": "array",
+      "items": {"type": "string", "maxLength": 50},
+      "uniqueItems": true
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/json/organization.json
+++ b/Microservicios/schemas/json/organization.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heartguard.example/schemas/organization.json",
+  "title": "Organization",
+  "type": "object",
+  "required": ["id", "name", "status", "created_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "name": {
+      "type": "string",
+      "maxLength": 200
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "suspended", "pending"]
+    },
+    "branding": {
+      "type": "object",
+      "properties": {
+        "logo_url": {"type": "string", "format": "uri"},
+        "primary_color": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"},
+        "secondary_color": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"}
+      },
+      "additionalProperties": false
+    },
+    "policies": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+        "email": {"type": "string", "format": "email"},
+        "phone": {"type": "string", "maxLength": 30},
+        "address": {"type": "string", "maxLength": 255}
+      },
+      "additionalProperties": false
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/json/patient.json
+++ b/Microservicios/schemas/json/patient.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heartguard.example/schemas/patient.json",
+  "title": "Patient",
+  "type": "object",
+  "required": ["id", "first_name", "last_name", "birth_date", "sex", "created_at"],
+  "properties": {
+    "id": {"type": "string", "format": "uuid"},
+    "first_name": {"type": "string", "maxLength": 80},
+    "last_name": {"type": "string", "maxLength": 80},
+    "middle_name": {"type": "string", "maxLength": 80},
+    "birth_date": {"type": "string", "format": "date"},
+    "sex": {"type": "string", "enum": ["male", "female", "other", "unknown"]},
+    "contact": {
+      "type": "object",
+      "properties": {
+        "email": {"type": "string", "format": "email"},
+        "phone": {"type": "string", "maxLength": 30},
+        "address": {"type": "string", "maxLength": 255}
+      },
+      "additionalProperties": false
+    },
+    "care_team_ids": {
+      "type": "array",
+      "items": {"type": "string", "format": "uuid"},
+      "uniqueItems": true
+    },
+    "risk_level": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/json/timeseries_point.json
+++ b/Microservicios/schemas/json/timeseries_point.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heartguard.example/schemas/timeseries_point.json",
+  "title": "TimeseriesPoint",
+  "type": "object",
+  "required": ["measurement", "timestamp", "fields"],
+  "properties": {
+    "measurement": {"type": "string", "maxLength": 120},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "bucket": {"type": "string", "maxLength": 120},
+    "org": {"type": "string", "maxLength": 120},
+    "tags": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "fields": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "oneOf": [
+          {"type": "string"},
+          {"type": "number"},
+          {"type": "integer"},
+          {"type": "boolean"}
+        ]
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/json/user.json
+++ b/Microservicios/schemas/json/user.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heartguard.example/schemas/user.json",
+  "title": "User",
+  "type": "object",
+  "required": ["id", "email", "status", "created_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "maxLength": 255
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "invited", "disabled", "pending"]
+    },
+    "roles": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "preferences": {
+      "type": "object",
+      "properties": {
+        "language": {
+          "type": "string",
+          "maxLength": 10
+        },
+        "timezone": {
+          "type": "string",
+          "maxLength": 50
+        },
+        "notifications": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "organization_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/xsd/alert.xsd
+++ b/Microservicios/schemas/xsd/alert.xsd
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="alert" type="AlertType"/>
+
+  <xs:complexType name="AlertType">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="patient_id" type="UUIDType"/>
+      <xs:element name="source" type="AlertSourceType" minOccurs="0"/>
+      <xs:element name="event_type" type="xs:string" minOccurs="0"/>
+      <xs:element name="level" type="AlertLevelType"/>
+      <xs:element name="status" type="AlertStatusType"/>
+      <xs:element name="assigned_to" type="UUIDType" minOccurs="0"/>
+      <xs:element name="acknowledged_by" type="UUIDType" minOccurs="0"/>
+      <xs:element name="acknowledged_at" type="xs:dateTime" minOccurs="0"/>
+      <xs:element name="resolution" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="resolved_by" type="UUIDType" minOccurs="0"/>
+            <xs:element name="resolved_at" type="xs:dateTime" minOccurs="0"/>
+            <xs:element name="notes" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="delivery" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="channel" type="AlertChannelType"/>
+            <xs:element name="status" type="DeliveryStatusType"/>
+            <xs:element name="delivered_at" type="xs:dateTime" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="created_at" type="xs:dateTime"/>
+      <xs:element name="updated_at" type="xs:dateTime" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="UUIDType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="AlertSourceType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="inference"/>
+      <xs:enumeration value="manual"/>
+      <xs:enumeration value="device"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="AlertLevelType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="info"/>
+      <xs:enumeration value="low"/>
+      <xs:enumeration value="medium"/>
+      <xs:enumeration value="high"/>
+      <xs:enumeration value="critical"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="AlertStatusType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="open"/>
+      <xs:enumeration value="assigned"/>
+      <xs:enumeration value="acknowledged"/>
+      <xs:enumeration value="resolved"/>
+      <xs:enumeration value="cancelled"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="AlertChannelType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="push"/>
+      <xs:enumeration value="sms"/>
+      <xs:enumeration value="email"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="DeliveryStatusType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="pending"/>
+      <xs:enumeration value="sent"/>
+      <xs:enumeration value="failed"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/Microservicios/schemas/xsd/device.xsd
+++ b/Microservicios/schemas/xsd/device.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="device" type="DeviceType"/>
+
+  <xs:complexType name="DeviceType">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="serial_number" type="xs:string"/>
+      <xs:element name="device_type" type="DeviceTypeInfo"/>
+      <xs:element name="status" type="DeviceStatusType"/>
+      <xs:element name="assigned_patient_id" type="UUIDType" minOccurs="0"/>
+      <xs:element name="signal_streams" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="signal_stream" type="SignalStreamType" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="last_seen_at" type="xs:dateTime" minOccurs="0"/>
+      <xs:element name="created_at" type="xs:dateTime"/>
+      <xs:element name="updated_at" type="xs:dateTime" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="DeviceTypeInfo">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="code" type="xs:string"/>
+      <xs:element name="label" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SignalStreamType">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="signal_type" type="xs:string"/>
+      <xs:element name="sampling_rate" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="timeseries_binding" type="TimeseriesBindingType"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="TimeseriesBindingType">
+    <xs:sequence>
+      <xs:element name="bucket" type="xs:string"/>
+      <xs:element name="measurement" type="xs:string"/>
+      <xs:element name="retention_policy" type="xs:string"/>
+      <xs:element name="tags" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="tag" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="UUIDType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="DeviceStatusType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="active"/>
+      <xs:enumeration value="inactive"/>
+      <xs:enumeration value="maintenance"/>
+      <xs:enumeration value="retired"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/Microservicios/schemas/xsd/inference.xsd
+++ b/Microservicios/schemas/xsd/inference.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="inference" type="InferenceType"/>
+
+  <xs:complexType name="InferenceType">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="model_id" type="UUIDType"/>
+      <xs:element name="model_version" type="xs:string" minOccurs="0"/>
+      <xs:element name="event_type" type="xs:string"/>
+      <xs:element name="input_reference" type="xs:string"/>
+      <xs:element name="patient_id" type="UUIDType" minOccurs="0"/>
+      <xs:element name="device_id" type="UUIDType" minOccurs="0"/>
+      <xs:element name="score" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="threshold" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="payload" minOccurs="0" type="xs:string"/>
+      <xs:element name="generated_alert_id" type="UUIDType" minOccurs="0"/>
+      <xs:element name="created_at" type="xs:dateTime"/>
+      <xs:element name="processed_at" type="xs:dateTime" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="UUIDType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/Microservicios/schemas/xsd/media_item.xsd
+++ b/Microservicios/schemas/xsd/media_item.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="media_item" type="MediaItemType"/>
+
+  <xs:complexType name="MediaItemType">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="filename" type="xs:string"/>
+      <xs:element name="mime_type" type="xs:string"/>
+      <xs:element name="size_bytes" type="xs:unsignedLong"/>
+      <xs:element name="bucket" type="xs:string"/>
+      <xs:element name="object_name" type="xs:string" minOccurs="0"/>
+      <xs:element name="owner_id" type="UUIDType" minOccurs="0"/>
+      <xs:element name="checksum" type="xs:string" minOccurs="0"/>
+      <xs:element name="signed_url" type="xs:anyURI" minOccurs="0"/>
+      <xs:element name="signed_url_expires_at" type="xs:dateTime" minOccurs="0"/>
+      <xs:element name="tags" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="tag" type="xs:string" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="created_at" type="xs:dateTime"/>
+      <xs:element name="updated_at" type="xs:dateTime" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="UUIDType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/Microservicios/schemas/xsd/organization.xsd
+++ b/Microservicios/schemas/xsd/organization.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="organization" type="OrganizationType"/>
+
+  <xs:complexType name="OrganizationType">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="name" type="xs:string"/>
+      <xs:element name="status" type="OrganizationStatusType"/>
+      <xs:element name="branding" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="logo_url" type="xs:anyURI" minOccurs="0"/>
+            <xs:element name="primary_color" type="HexColor" minOccurs="0"/>
+            <xs:element name="secondary_color" type="HexColor" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="policies" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="policy" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="contact" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="email" type="xs:string" minOccurs="0"/>
+            <xs:element name="phone" type="xs:string" minOccurs="0"/>
+            <xs:element name="address" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="created_at" type="xs:dateTime"/>
+      <xs:element name="updated_at" type="xs:dateTime" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="UUIDType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="OrganizationStatusType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="active"/>
+      <xs:enumeration value="suspended"/>
+      <xs:enumeration value="pending"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="HexColor">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#[0-9A-Fa-f]{6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/Microservicios/schemas/xsd/patient.xsd
+++ b/Microservicios/schemas/xsd/patient.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="patient" type="PatientType"/>
+
+  <xs:complexType name="PatientType">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="first_name" type="xs:string"/>
+      <xs:element name="last_name" type="xs:string"/>
+      <xs:element name="middle_name" type="xs:string" minOccurs="0"/>
+      <xs:element name="birth_date" type="xs:date"/>
+      <xs:element name="sex" type="SexType"/>
+      <xs:element name="contact" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="email" type="xs:string" minOccurs="0"/>
+            <xs:element name="phone" type="xs:string" minOccurs="0"/>
+            <xs:element name="address" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="care_team_ids" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="care_team_id" type="UUIDType" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="risk_level" type="RiskLevelType" minOccurs="0"/>
+      <xs:element name="created_at" type="xs:dateTime"/>
+      <xs:element name="updated_at" type="xs:dateTime" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="UUIDType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="SexType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="male"/>
+      <xs:enumeration value="female"/>
+      <xs:enumeration value="other"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="RiskLevelType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="low"/>
+      <xs:enumeration value="medium"/>
+      <xs:enumeration value="high"/>
+      <xs:enumeration value="critical"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/Microservicios/schemas/xsd/timeseries_point.xsd
+++ b/Microservicios/schemas/xsd/timeseries_point.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="timeseries_point" type="TimeseriesPointType"/>
+
+  <xs:complexType name="TimeseriesPointType">
+    <xs:sequence>
+      <xs:element name="measurement" type="xs:string"/>
+      <xs:element name="timestamp" type="xs:dateTime"/>
+      <xs:element name="bucket" type="xs:string" minOccurs="0"/>
+      <xs:element name="org" type="xs:string" minOccurs="0"/>
+      <xs:element name="tags" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="tag" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="fields">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="field" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="type" type="FieldType" use="optional"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="FieldType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="integer"/>
+      <xs:enumeration value="float"/>
+      <xs:enumeration value="boolean"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/Microservicios/schemas/xsd/user.xsd
+++ b/Microservicios/schemas/xsd/user.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="user" type="UserType"/>
+
+  <xs:complexType name="UserType">
+    <xs:sequence>
+      <xs:element name="id" type="UUIDType"/>
+      <xs:element name="email" type="xs:string"/>
+      <xs:element name="status" type="UserStatusType"/>
+      <xs:element name="roles" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="role" type="xs:string" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="preferences" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="language" type="xs:string" minOccurs="0"/>
+            <xs:element name="timezone" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="notifications" type="xs:string" use="optional"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="organization_id" type="UUIDType" minOccurs="0"/>
+      <xs:element name="created_at" type="xs:dateTime"/>
+      <xs:element name="updated_at" type="xs:dateTime" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="UUIDType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="UserStatusType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="active"/>
+      <xs:enumeration value="invited"/>
+      <xs:enumeration value="disabled"/>
+      <xs:enumeration value="pending"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/Microservicios/start_services.sh
+++ b/Microservicios/start_services.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f .env ]]; then
+  echo "[ERROR] .env file not found in $(pwd)/Microservicios" >&2
+  echo "Copy .env.example to .env and configure real values." >&2
+  exit 1
+fi
+
+if [[ ! -f secrets/gcp-sa.json ]]; then
+  echo "[WARN] secrets/gcp-sa.json not found. Media service will fail to start." >&2
+fi
+
+export COMPOSE_PROJECT_NAME=heartguard_micro
+
+docker compose --env-file .env pull
+
+docker compose --env-file .env up -d --build
+
+docker compose --env-file .env ps

--- a/Microservicios/stop_services.sh
+++ b/Microservicios/stop_services.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export COMPOSE_PROJECT_NAME=heartguard_micro
+
+docker compose --env-file .env down --remove-orphans

--- a/Microservicios/user_service/__init__.py
+++ b/Microservicios/user_service/__init__.py
@@ -1,0 +1,1 @@
+"""HeartGuard microservice package."""

--- a/Microservicios/user_service/app.py
+++ b/Microservicios/user_service/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from common.app_factory import create_app
+from .routes import register_blueprint
+
+
+SERVICE_NAME = "user"
+DEFAULT_PORT = 5003
+
+
+app = create_app(SERVICE_NAME, register_blueprint)
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", os.getenv("SERVICE_PORT", DEFAULT_PORT)))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/user_service/requirements.txt
+++ b/Microservicios/user_service/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.3
+Flask-Cors>=4.0
+PyJWT>=2.8
+dicttoxml>=1.7
+xmltodict>=0.13
+gunicorn>=21.2

--- a/Microservicios/user_service/routes.py
+++ b/Microservicios/user_service/routes.py
@@ -1,0 +1,102 @@
+"""User service managing application user profiles."""
+from __future__ import annotations
+
+import copy
+import datetime as dt
+from typing import Dict
+
+from flask import Blueprint, g, request
+
+from common.auth import require_auth
+from common.errors import APIError
+from common.serialization import parse_request_data, render_response
+
+bp = Blueprint("users", __name__)
+
+USER_STORE: Dict[str, Dict] = {
+    "usr-1": {
+        "id": "usr-1",
+        "email": "admin@example.com",
+        "first_name": "Alicia",
+        "last_name": "Admin",
+        "language": "es",
+        "timezone": "America/Mexico_City",
+        "organization_id": "org-1",
+        "preferences": {"notifications": True, "theme": "dark"},
+    },
+    "usr-2": {
+        "id": "usr-2",
+        "email": "clinician@example.com",
+        "first_name": "Carlos",
+        "last_name": "Clinician",
+        "language": "en",
+        "timezone": "America/New_York",
+        "organization_id": "org-1",
+        "preferences": {"notifications": True, "theme": "light"},
+    },
+}
+
+
+@bp.route("/health", methods=["GET"])
+def health() -> "Response":
+    return render_response({"service": "user", "status": "healthy", "users": len(USER_STORE)})
+
+
+@bp.route("", methods=["GET"])
+@require_auth(optional=True)
+def list_users() -> "Response":
+    return render_response({"users": list(USER_STORE.values())}, meta={"total": len(USER_STORE)})
+
+
+@bp.route("/<user_id>", methods=["GET"])
+@require_auth(optional=True)
+def get_user(user_id: str) -> "Response":
+    user = USER_STORE.get(user_id)
+    if not user:
+        raise APIError("User not found", status_code=404, error_id="HG-USER-NOT-FOUND")
+    return render_response({"user": user})
+
+
+@bp.route("/<user_id>", methods=["PATCH"])
+@require_auth(required_roles=["admin", "clinician", "org_admin"])
+def update_user(user_id: str) -> "Response":
+    payload, _ = parse_request_data(request)
+    user = USER_STORE.get(user_id)
+    if not user:
+        raise APIError("User not found", status_code=404, error_id="HG-USER-NOT-FOUND")
+    allowed = {"first_name", "last_name", "language", "timezone", "preferences"}
+    for key, value in payload.items():
+        if key in allowed:
+            user[key] = value
+    user["updated_at"] = dt.datetime.utcnow().isoformat() + "Z"
+    return render_response({"user": user})
+
+
+@bp.route("/me", methods=["GET"])
+@require_auth()
+def get_me() -> "Response":
+    user_id = g.current_user.get("sub")
+    user = USER_STORE.get(user_id)
+    if not user:
+        raise APIError("User not found", status_code=404, error_id="HG-USER-NOT-FOUND")
+    return render_response({"user": user})
+
+
+@bp.route("/me", methods=["PATCH"])
+@require_auth()
+def update_me() -> "Response":
+    payload, _ = parse_request_data(request)
+    user_id = g.current_user.get("sub")
+    user = USER_STORE.get(user_id)
+    if not user:
+        raise APIError("User not found", status_code=404, error_id="HG-USER-NOT-FOUND")
+    allowed = {"language", "timezone", "preferences"}
+    for key, value in payload.items():
+        if key in allowed:
+            user[key] = value
+    user["updated_at"] = dt.datetime.utcnow().isoformat() + "Z"
+    return render_response({"user": user})
+
+
+def register_blueprint(app):
+    app.register_blueprint(bp, url_prefix="/users")

--- a/Microservicios/validate_endpoints.sh
+++ b/Microservicios/validate_endpoints.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="34.70.7.33"
+PROTOCOL="http"
+TIMEOUT=10
+
+usage() {
+  cat <<USAGE
+Uso: $0 [--host HOST] [--protocol http|https] [--timeout SECONDS]
+Ejecuta pruebas de salud contra los microservicios HeartGuard verificando respuestas JSON y XML.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --protocol)
+      PROTOCOL="$2"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Argumento desconocido: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[ERROR] curl no está disponible en este sistema." >&2
+  exit 1
+fi
+
+declare -a CHECKS=(
+  "Gateway|5000|/gateway/health|GET"
+  "Auth|5001|/auth/health|GET"
+  "Organization|5002|/organization/health|GET"
+  "User|5003|/users/health|GET"
+  "Patient|5004|/patients/health|GET"
+  "Device|5005|/devices/health|GET"
+  "Influx|5006|/influx/health|GET"
+  "Inference|5007|/inference/health|GET"
+  "Alert|5008|/alerts/health|GET"
+  "Notification|5009|/notifications/health|GET"
+  "Media|5010|/media/health|GET"
+  "Audit|5011|/audit/health|GET"
+)
+
+JSON_OK=0
+XML_OK=0
+JSON_TOTAL=0
+XML_TOTAL=0
+
+printf "\n%-15s %-8s %-30s %-6s %-12s %-8s %-8s\n" "Servicio" "Puerto" "Endpoint" "Verbo" "Formato" "HTTP" "Tiempo"
+printf '%s\n' "-------------------------------------------------------------------------------------------------------------"
+
+for entry in "${CHECKS[@]}"; do
+  IFS='|' read -r NAME PORT PATH METHOD <<<"$entry"
+  URL="${PROTOCOL}://${HOST}:${PORT}${PATH}"
+
+  for ACCEPT in "application/json" "application/xml"; do
+    FORMAT=$( [[ "$ACCEPT" == "application/json" ]] && echo "JSON" || echo "XML" )
+    HTTP_CODE=$(mktemp)
+    BODY=$(mktemp)
+    START=$(date +%s%3N)
+    curl -sS -o "$BODY" \
+         -w "%{http_code}" \
+         --max-time "$TIMEOUT" \
+         -H "Accept: ${ACCEPT}" \
+         "${URL}" > "$HTTP_CODE" || true
+    END=$(date +%s%3N)
+    LATENCY=$(printf '%0.3f' "$(echo "scale=3; ($END - $START)/1000" | bc)")
+    CODE=$(cat "$HTTP_CODE")
+
+    STATUS="FAIL"
+    if [[ "$CODE" =~ ^2 ]]; then
+      STATUS="OK"
+      if [[ "$FORMAT" == "JSON" ]]; then
+        ((JSON_OK++))
+      else
+        ((XML_OK++))
+      fi
+    fi
+
+    if [[ "$FORMAT" == "JSON" ]]; then
+      ((JSON_TOTAL++))
+    else
+      ((XML_TOTAL++))
+    fi
+
+    printf "%-15s %-8s %-30s %-6s %-12s %-8s %-8s\n" "$NAME" "$PORT" "$PATH" "$METHOD" "$FORMAT" "$CODE" "$LATENCY"
+
+    rm -f "$HTTP_CODE" "$BODY"
+  done
+
+done
+
+printf '%s\n' "-------------------------------------------------------------------------------------------------------------"
+printf "Resumen JSON: %d/%d OK\n" "$JSON_OK" "$JSON_TOTAL"
+printf "Resumen XML: %d/%d OK\n" "$XML_OK" "$XML_TOTAL"
+
+if [[ "$JSON_OK" -eq "$JSON_TOTAL" && "$XML_OK" -eq "$XML_TOTAL" ]]; then
+  echo "Estado general: OK"
+else
+  echo "Estado general: FALLA"
+fi


### PR DESCRIPTION
## Summary
- implement shared Flask utilities that handle content negotiation, JWT helpers, logging, and CORS for all services
- add Flask blueprints and app entry points for gateway, auth, organization, user, patient, device, influx, inference, alert, notification, media, and audit domains based on the init.sql contexts
- provide per-service requirements files so docker-compose builds the new microservices images with consistent dependencies

## Testing
- python -m compileall Microservicios

------
https://chatgpt.com/codex/tasks/task_e_6902a783c7e883228a8e1be07d3ed046