### PR TITLE
Add Flask-based microservices backend stack

### DIFF
--- a/Microservicios/.env.example
+++ b/Microservicios/.env.example
@@ -1,0 +1,66 @@
+############################################
+# LOGGING / SECURITY / GLOBAL
+############################################
+LOG_LEVEL=INFO
+ALLOWED_ORIGINS=https://admin.heartguard.com,https://app.heartguard.com
+RATE_LIMIT=60                    # req/min/ip
+MAX_JSON_BODY_BYTES=1048576      # 1MB
+MAX_MEDIA_BYTES=10485760         # 10MB
+
+JWT_SECRET=CHANGE_ME_SUPER_SECRET_KEY
+JWT_EXPIRES_IN=900               # 15 min (s)
+REFRESH_TOKEN_TTL=604800         # 7 días (s)
+
+############################################
+# SERVICE URLS (usadas por gateway para enrutar)
+############################################
+GATEWAY_URL=http://gateway:5000
+AUTH_URL=http://auth:5001
+ORG_URL=http://organization:5002
+USER_URL=http://user:5003
+MEDIA_URL=http://media:5004
+INFLUX_URL=http://timeseries:5005
+AUDIT_URL=http://audit:5006
+
+############################################
+# REDIS
+############################################
+REDIS_URL=redis://redis:6379/0
+
+############################################
+# INFLUX / TIMESERIES
+############################################
+INFLUX_TOKEN=CHANGE_ME_INFLUX_TOKEN
+INFLUX_ORG=heartguard-org
+INFLUX_BUCKET=heartguard-metrics
+INFLUX_RETENTION_HOURS=720
+INFLUX_INTERNAL_URL=http://influxdb:8086
+
+############################################
+# GCS / MEDIA
+############################################
+GCS_BUCKET=heartguard-system
+SERVICE_ACCOUNT_EMAIL=751259101579-compute@developer.gserviceaccount.com
+GOOGLE_APPLICATION_CREDENTIALS=/app/gcp-key.json
+
+############################################
+# PORTS (cada servicio expondrá su puerto interno)
+############################################
+GATEWAY_PORT=5000
+AUTH_PORT=5001
+ORG_PORT=5002
+USER_PORT=5003
+MEDIA_PORT=5004
+TIMESERIES_PORT=5005
+AUDIT_PORT=5006
+
+############################################
+# FUTURO: DB relacional si se agrega Postgres
+############################################
+POSTGRES_URL=postgresql://user:pass@postgres:5432/heartguard
+
+############################################
+# INFO VM DESTINO (producción futura)
+############################################
+PUBLIC_VM_IP=34.70.7.33
+

--- a/Microservicios/PLAN.md
+++ b/Microservicios/PLAN.md
@@ -1,0 +1,127 @@
+# Heartguard Microservicios Backend
+
+## Arquitectura lógica
+```
+                       +----------------+
+                       |  Frontends     |
+                       | (Web & Móvil)  |
+                       +----------------+
+                               |
+                               v
+                       +----------------+
+                       |   Gateway      |
+                       |  (Flask 5000)  |
+                       +----------------+
+        _________ _________ _________ _________ _________ _________
+       /         |         |         |         |         |         \
+      v          v         v         v         v         v          v
++---------+ +---------+ +---------+ +---------+ +---------+ +---------+
+|  Auth   | | Org     | | User    | | Media   | |Timeseries| | Audit   |
+| 5001    | | 5002    | | 5003    | | 5004    | | 5005     | | 5006    |
++---------+ +---------+ +---------+ +---------+ +---------+ +---------+
+      |          |         |          |            |            |
+      |          |         |          |            |            |
+      |          |         |          |            v            |
+      |          |         |          |     +-------------+     |
+      |          |         |          |     |  InfluxDB   |     |
+      |          |         |          |     |  (8086)     |     |
+      |          |         |          |     +-------------+     |
+      |          |         |          |                          |
+      v          v         v          v                          v
++---------+                                        +-------------------+
+| Redis   |                                        |   Persistencia    |
+| 6379    |                                        | (Archivos Audit)  |
++---------+                                        +-------------------+
+```
+
+## Puertos de servicio
+
+| Servicio     | Puerto |
+|--------------|--------|
+| Gateway      | 5000   |
+| Auth         | 5001   |
+| Organization | 5002   |
+| User         | 5003   |
+| Media        | 5004   |
+| Timeseries   | 5005   |
+| Audit        | 5006   |
+| Redis        | 6379   |
+| InfluxDB     | 8086   |
+
+## Flujo de autenticación
+1. El cliente envía `POST /auth/login` al gateway con credenciales.
+2. Gateway enruta al microservicio `auth` que valida usuario/contraseña usando bcrypt.
+3. Auth emite un **access token** JWT (HS256) con TTL corto (`JWT_EXPIRES_IN`) y un **refresh token** (UUID) guardado en Redis con TTL (`REFRESH_TOKEN_TTL`).
+4. Gateway responde al cliente respetando negociación JSON/XML.
+5. El cliente usa el access token en `Authorization: Bearer ...` para acceder al resto de microservicios.
+6. Cuando el access token expira, cliente llama `POST /auth/refresh` con refresh token; auth valida presencia en Redis y entrega nuevo access token.
+7. Para cerrar sesión, cliente ejecuta `POST /auth/logout`, auth elimina el refresh token de Redis y el token deja de ser válido.
+
+## Flujo de subida de media a GCS
+1. Cliente autenticado invoca `POST /media/upload` vía gateway con archivo (multipart u octet-stream).
+2. Gateway aplica CORS, JWT, RBAC y reenruta al servicio `media`.
+3. `media` valida MIME y tamaño (`MAX_MEDIA_BYTES`), sube directo al bucket `heartguard-system` usando la cuenta de servicio configurada (`google-cloud-storage`).
+4. Se genera `media_id`, metadata y URL firmada temporal.
+5. Gateway devuelve metadata + `signed_url` en formato negociado.
+
+## Flujo de ingestión/consulta de métricas (timeseries)
+1. Dispositivos o servicios autorizados llaman `POST /timeseries/write` con mediciones.
+2. `timeseries` valida payload contra los esquemas JSON/XSD y escribe en InfluxDB usando el cliente oficial.
+3. Consultas `GET /timeseries/query` aplican RBAC (usuarios solo ven sus datos) y ejecutan consultas agregadas en InfluxDB.
+4. Resultados paginados son devueltos respetando JSON/XML.
+
+## Negociación de contenido JSON/XML
+- Cada servicio analiza el header `Accept` y prioriza `application/xml` sobre JSON. Si no se especifica, responde JSON.
+- Para peticiones de escritura (`POST/PUT/PATCH`) se valida `Content-Type` (JSON o XML) y se parsea al diccionario interno usando `utils_format.parse_body`.
+- Las respuestas se producen con `utils_format.make_response`, lo que garantiza consistencia en formato.
+
+## Manejo de errores y logging
+- `error_handler.py` captura excepciones y devuelve estructura estándar:
+  ```json
+  {
+    "error": {
+      "code": 401,
+      "message": "Unauthorized",
+      "request_id": "...",
+      "timestamp": "2025-10-29T18:00:00Z",
+      "details": {}
+    }
+  }
+  ```
+- `middleware.py` genera `request_id`, calcula latencia, aplica límites de tamaño y escribe logs estructurados en stdout con datos de método, ruta, usuario y rol.
+- `REQUEST_STATS` centraliza métricas para `/metrics`.
+
+## Observabilidad
+- `/health` comprueba que el proceso está vivo.
+- `/ready` verifica dependencias (Redis, InfluxDB, credenciales GCS).
+- `/metrics` entrega `requests_total`, `avg_latency_ms`, `uptime_seconds` y el nombre del servicio en JSON/XML.
+
+## Levantar el stack localmente en Windows
+1. `cd Microservicios`
+2. Copiar `.env.example` a `.env` y ajustar secretos:
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+3. Ejecutar servicios:
+   ```powershell
+   .\start_services.bat
+   ```
+4. Validar endpoints:
+   ```powershell
+   .\validate_endpoints.bat localhost
+   ```
+5. Consumir el gateway en `http://localhost:5000`.
+
+## Despliegue en VM Linux pública (ej. 34.70.7.33)
+1. Copiar repositorio a la VM (`scp` o Git clone).
+2. Configurar `.env` con secretos reales.
+3. Ejecutar:
+   ```bash
+   ./start_services.sh
+   ```
+4. Validar salud remota:
+   ```bash
+   ./validate_endpoints.sh 34.70.7.33
+   ```
+5. Exponer puertos 5000-5006, 6379 y 8086 según políticas de firewall.
+

--- a/Microservicios/audit/Dockerfile
+++ b/Microservicios/audit/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 5006
+
+CMD ["python", "app.py"]

--- a/Microservicios/audit/app.py
+++ b/Microservicios/audit/app.py
@@ -1,0 +1,86 @@
+import os
+
+from flask import Flask, g, request
+
+from .error_handler import register_error_handlers
+from .middleware import get_metrics, init_app
+from .models import append_event, list_events
+from .utils_format import error_response, make_response, parse_body
+
+app = Flask(__name__)
+init_app(app)
+register_error_handlers(app)
+
+ALLOWED_ROLES = {"admin", "org_admin"}
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return make_response({"status": "ok", "service": "audit"})
+
+
+@app.route("/ready", methods=["GET"])
+def ready():
+    return make_response({"status": "ready"})
+
+
+@app.route("/metrics", methods=["GET"])
+def metrics():
+    return make_response(get_metrics(), root_tag="Metrics")
+
+
+# POST /audit/event
+# Request JSON/XML:
+# {
+#   "actor_user_id": "42",
+#   "action": "user.login",
+#   "entity_type": "user",
+#   "entity_id": "42",
+#   "ip": "203.0.113.5",
+#   "metadata": {"method": "POST"}
+# }
+# Response:
+# {
+#   "event_id": "...",
+#   "timestamp": "2025-10-29T18:00:00Z"
+# }
+@app.route("/audit/event", methods=["POST"])
+def create_event():
+    if g.get("user_role") not in ALLOWED_ROLES:
+        return error_response(403, "Forbidden for role")
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    required = ["actor_user_id", "action", "entity_type", "entity_id", "ip"]
+    missing = [field for field in required if field not in body]
+    if missing:
+        return error_response(400, f"Missing fields: {', '.join(missing)}")
+    event = append_event(body)
+    return make_response({"event": event}, status=201, root_tag="AuditEvent")
+
+
+# GET /audit/events?actor_user_id=42&entity_type=user
+# Response JSON/XML:
+# {
+#   "events": [
+#     {"event_id": "...", "action": "user.login"}
+#   ]
+# }
+@app.route("/audit/events", methods=["GET"])
+def get_events():
+    if g.get("user_role") not in ALLOWED_ROLES:
+        return error_response(403, "Forbidden for role")
+    filters = {
+        "actor_user_id": request.args.get("actor_user_id"),
+        "entity_type": request.args.get("entity_type"),
+        "since": request.args.get("since"),
+        "until": request.args.get("until"),
+    }
+    events = list_events(filters)
+    return make_response({"events": events}, root_tag="AuditEvents")
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("AUDIT_PORT", "5006"))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/audit/error_handler.py
+++ b/Microservicios/audit/error_handler.py
@@ -1,0 +1,15 @@
+from werkzeug.exceptions import HTTPException
+from flask import Flask
+
+from .utils_format import error_response
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http(exc: HTTPException):
+        return error_response(exc.code or 500, exc.description)
+
+    @app.errorhandler(Exception)
+    def handle_generic(exc: Exception):  # pragma: no cover
+        app.logger.exception("Unhandled error")
+        return error_response(500, "Internal server error")

--- a/Microservicios/audit/middleware.py
+++ b/Microservicios/audit/middleware.py
@@ -1,0 +1,61 @@
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict
+
+from flask import Flask, g, request
+
+from .utils_format import error_response
+
+SERVICE_NAME = "audit"
+MAX_BODY_BYTES = int(os.getenv("MAX_JSON_BODY_BYTES", "1048576"))
+REQUEST_STATS: Dict[str, Any] = {
+    "count": 0,
+    "total_latency_ms": 0.0,
+    "start_time": time.time(),
+}
+
+
+def init_app(app: Flask) -> None:
+    @app.before_request
+    def _before_request():
+        g.start_time = time.time()
+        g.request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        g.user_id = request.headers.get("X-User-ID")
+        g.user_role = request.headers.get("X-User-Role")
+        if request.content_length and request.content_length > MAX_BODY_BYTES:
+            return error_response(413, "Payload too large")
+
+    @app.after_request
+    def _after_request(response):
+        latency_ms = int((time.time() - getattr(g, "start_time", time.time())) * 1000)
+        REQUEST_STATS["count"] += 1
+        REQUEST_STATS["total_latency_ms"] += latency_ms
+        response.headers["X-Request-ID"] = getattr(g, "request_id", "")
+        log_entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "service": SERVICE_NAME,
+            "request_id": getattr(g, "request_id", ""),
+            "method": request.method,
+            "path": request.path,
+            "status": response.status_code,
+            "latency_ms": latency_ms,
+            "ip": request.headers.get("X-Forwarded-For", request.remote_addr),
+            "user_id": getattr(g, "user_id", None),
+            "role": getattr(g, "user_role", None),
+        }
+        app.logger.info(json.dumps(log_entry, ensure_ascii=False))
+        return response
+
+
+def get_metrics() -> Dict[str, Any]:
+    uptime_seconds = time.time() - REQUEST_STATS["start_time"]
+    count = REQUEST_STATS["count"] or 1
+    avg_latency = REQUEST_STATS["total_latency_ms"] / count
+    return {
+        "service": SERVICE_NAME,
+        "requests_total": REQUEST_STATS["count"],
+        "avg_latency_ms": round(avg_latency, 2),
+        "uptime_seconds": int(uptime_seconds),
+    }

--- a/Microservicios/audit/models.py
+++ b/Microservicios/audit/models.py
@@ -1,0 +1,40 @@
+"""Simple in-memory append-only audit log.
+TODO: replace with durable storage (e.g., BigQuery/Cloud Logging).
+"""
+from datetime import datetime, timezone
+from typing import Dict, List
+from uuid import uuid4
+
+AUDIT_EVENTS: List[Dict] = []
+
+
+def append_event(payload: Dict) -> Dict:
+    event = {
+        "event_id": str(uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "actor_user_id": payload.get("actor_user_id"),
+        "action": payload.get("action"),
+        "entity_type": payload.get("entity_type"),
+        "entity_id": payload.get("entity_id"),
+        "ip": payload.get("ip"),
+        "metadata": payload.get("metadata", {}),
+    }
+    AUDIT_EVENTS.append(event)
+    return event
+
+
+def list_events(filters: Dict) -> List[Dict]:
+    results = AUDIT_EVENTS
+    actor = filters.get("actor_user_id")
+    if actor:
+        results = [event for event in results if event.get("actor_user_id") == actor]
+    entity_type = filters.get("entity_type")
+    if entity_type:
+        results = [event for event in results if event.get("entity_type") == entity_type]
+    since = filters.get("since")
+    until = filters.get("until")
+    if since:
+        results = [event for event in results if event["timestamp"] >= since]
+    if until:
+        results = [event for event in results if event["timestamp"] <= until]
+    return results[-1000:]

--- a/Microservicios/audit/requirements.txt
+++ b/Microservicios/audit/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.3
+xmltodict==0.13.0
+dicttoxml==1.7.16

--- a/Microservicios/audit/utils_format.py
+++ b/Microservicios/audit/utils_format.py
@@ -1,0 +1,65 @@
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Tuple
+
+from dicttoxml import dicttoxml
+from flask import Response, g, request
+import xmltodict
+
+DEFAULT_ROOT = "response"
+
+
+def _negotiate() -> str:
+    accept = request.headers.get("Accept", "application/json")
+    if "application/xml" in accept.lower():
+        return "xml"
+    return "json"
+
+
+def parse_body() -> Tuple[Dict[str, Any], str]:
+    content_type = request.headers.get("Content-Type", "application/json").lower()
+    raw = request.get_data(cache=False) or b"{}"
+    if "application/json" in content_type:
+        try:
+            return json.loads(raw.decode("utf-8")), "json"
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON payload: {exc}")
+    if "application/xml" in content_type:
+        try:
+            parsed = xmltodict.parse(raw)
+            if isinstance(parsed, dict) and len(parsed) == 1:
+                parsed = next(iter(parsed.values()))
+            return dict(parsed), "xml"
+        except Exception as exc:
+            raise ValueError(f"Invalid XML payload: {exc}")
+    raise ValueError("Unsupported Content-Type. Use application/json or application/xml")
+
+
+def _to_xml(data: Any, root_tag: str) -> bytes:
+    if not isinstance(data, dict):
+        data = {"data": data}
+    return dicttoxml(data, custom_root=root_tag, attr_type=False)
+
+
+def make_response(data: Dict[str, Any], status: int = 200, root_tag: str = DEFAULT_ROOT) -> Response:
+    fmt = _negotiate()
+    if fmt == "xml":
+        payload = _to_xml(data, root_tag=root_tag)
+        return Response(payload, status=status, mimetype="application/xml")
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return Response(payload, status=status, mimetype="application/json")
+
+
+def error_response(code: int, message: str, details: Any = None) -> Response:
+    request_id = getattr(g, "request_id", None)
+    body = {
+        "error": {
+            "code": code,
+            "message": message,
+            "request_id": request_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    if details is not None:
+        body["error"]["details"] = details
+    return make_response(body, status=code, root_tag="Error")

--- a/Microservicios/auth/Dockerfile
+++ b/Microservicios/auth/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 5001
+
+CMD ["python", "app.py"]

--- a/Microservicios/auth/app.py
+++ b/Microservicios/auth/app.py
@@ -1,0 +1,188 @@
+import os
+from typing import Dict
+
+from flask import Flask, g, request
+
+from .error_handler import register_error_handlers
+from .middleware import get_metrics, init_app
+from .models import create_user, get_user_by_id, verify_credentials
+from .tokens import (
+    generate_access_token,
+    generate_refresh_token,
+    is_refresh_token_valid,
+    revoke_refresh_token,
+    store_refresh_token,
+)
+from .utils_format import error_response, make_response, parse_body
+
+app = Flask(__name__)
+init_app(app)
+register_error_handlers(app)
+
+JWT_SECRET = os.getenv("JWT_SECRET", "dev_secret")
+JWT_EXPIRES_IN = int(os.getenv("JWT_EXPIRES_IN", "900"))
+REFRESH_TOKEN_TTL = int(os.getenv("REFRESH_TOKEN_TTL", "604800"))
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return make_response({"status": "ok", "service": "auth"})
+
+
+@app.route("/ready", methods=["GET"])
+def ready():
+    from .tokens import _get_client
+
+    status = 200
+    details: Dict[str, str] = {}
+    try:
+        _get_client().ping()
+        details["redis"] = "ok"
+    except Exception as exc:  # pragma: no cover - depends on runtime
+        details["redis"] = str(exc)
+        status = 503
+    return make_response({"status": "ready" if status == 200 else "degraded", "dependencies": details}, status=status)
+
+
+@app.route("/metrics", methods=["GET"])
+def metrics():
+    return make_response(get_metrics(), root_tag="Metrics")
+
+
+# POST /auth/register
+# JSON Request example:
+# {
+#   "email": "admin@example.com",
+#   "password": "Secret123",
+#   "name": "Admin",
+#   "org_id": "org-1"
+# }
+# XML Request example:
+# <AuthRegister>
+#   <email>admin@example.com</email>
+#   <password>Secret123</password>
+#   <name>Admin</name>
+#   <org_id>org-1</org_id>
+# </AuthRegister>
+# Response JSON/XML:
+# {
+#   "user": {
+#     "user_id": "...",
+#     "org_id": "org-1",
+#     "role": "org_admin"
+#   }
+# }
+@app.route("/auth/register", methods=["POST"])
+def register():
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    required = ["email", "password", "name", "org_id"]
+    missing = [field for field in required if field not in body]
+    if missing:
+        return error_response(400, f"Missing fields: {', '.join(missing)}")
+    try:
+        user_info = create_user(body["email"], body["password"], body["name"], body["org_id"])
+    except ValueError as exc:
+        return error_response(409, str(exc))
+    return make_response({"user": user_info}, status=201, root_tag="AuthRegisterResponse")
+
+
+# POST /auth/login
+# Request JSON/XML:
+# {
+#   "email": "admin@example.com",
+#   "password": "Secret123"
+# }
+# Response JSON/XML:
+# {
+#   "access_token": "...",
+#   "expires_in": 900,
+#   "refresh_token": "...",
+#   "refresh_expires_in": 604800,
+#   "token_type": "Bearer",
+#   "role": "org_admin"
+# }
+@app.route("/auth/login", methods=["POST"])
+def login():
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    required = ["email", "password"]
+    missing = [field for field in required if field not in body]
+    if missing:
+        return error_response(400, f"Missing fields: {', '.join(missing)}")
+    record = verify_credentials(body["email"], body["password"])
+    if not record:
+        return error_response(401, "Invalid credentials")
+    access_token = generate_access_token(record["user_id"], record["role"], record["org_id"], JWT_EXPIRES_IN, JWT_SECRET)
+    refresh_token = generate_refresh_token()
+    store_refresh_token(refresh_token, record["user_id"])
+    response_body = {
+        "access_token": access_token,
+        "expires_in": JWT_EXPIRES_IN,
+        "refresh_token": refresh_token,
+        "refresh_expires_in": REFRESH_TOKEN_TTL,
+        "token_type": "Bearer",
+        "role": record["role"],
+    }
+    return make_response(response_body, root_tag="AuthToken")
+
+
+# POST /auth/refresh
+# Request:
+# {
+#   "refresh_token": "..."
+# }
+# Response:
+# {
+#   "access_token": "...",
+#   "expires_in": 900,
+#   "token_type": "Bearer"
+# }
+@app.route("/auth/refresh", methods=["POST"])
+def refresh():
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    token = body.get("refresh_token")
+    if not token:
+        return error_response(400, "Missing refresh_token")
+    user_id = is_refresh_token_valid(token)
+    if not user_id:
+        return error_response(401, "Invalid or expired refresh token")
+    user = get_user_by_id(user_id)
+    if not user:
+        return error_response(401, "User not found")
+    access_token = generate_access_token(user["user_id"], user["role"], user["org_id"], JWT_EXPIRES_IN, JWT_SECRET)
+    return make_response({"access_token": access_token, "expires_in": JWT_EXPIRES_IN, "token_type": "Bearer"}, root_tag="AuthRefreshResponse")
+
+
+# POST /auth/logout
+# Request:
+# {
+#   "refresh_token": "..."
+# }
+# Response:
+# {
+#   "status": "logged_out"
+# }
+@app.route("/auth/logout", methods=["POST"])
+def logout():
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    token = body.get("refresh_token")
+    if not token:
+        return error_response(400, "Missing refresh_token")
+    revoke_refresh_token(token)
+    return make_response({"status": "logged_out"}, root_tag="AuthLogoutResponse")
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("AUTH_PORT", "5001"))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/auth/error_handler.py
+++ b/Microservicios/auth/error_handler.py
@@ -1,0 +1,15 @@
+from werkzeug.exceptions import HTTPException
+from flask import Flask
+
+from .utils_format import error_response
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http(exc: HTTPException):
+        return error_response(exc.code or 500, exc.description)
+
+    @app.errorhandler(Exception)
+    def handle_generic(exc: Exception):  # pragma: no cover
+        app.logger.exception("Unhandled error")
+        return error_response(500, "Internal server error")

--- a/Microservicios/auth/middleware.py
+++ b/Microservicios/auth/middleware.py
@@ -1,0 +1,61 @@
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict
+
+from flask import Flask, g, request
+
+from .utils_format import error_response
+
+SERVICE_NAME = "auth"
+MAX_BODY_BYTES = int(os.getenv("MAX_JSON_BODY_BYTES", "1048576"))
+REQUEST_STATS: Dict[str, Any] = {
+    "count": 0,
+    "total_latency_ms": 0.0,
+    "start_time": time.time(),
+}
+
+
+def init_app(app: Flask) -> None:
+    @app.before_request
+    def _before_request():
+        g.start_time = time.time()
+        g.request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        g.user_id = request.headers.get("X-User-ID")
+        g.user_role = request.headers.get("X-User-Role")
+        if request.content_length and request.content_length > MAX_BODY_BYTES:
+            return error_response(413, "Payload too large")
+
+    @app.after_request
+    def _after_request(response):
+        latency_ms = int((time.time() - getattr(g, "start_time", time.time())) * 1000)
+        REQUEST_STATS["count"] += 1
+        REQUEST_STATS["total_latency_ms"] += latency_ms
+        response.headers["X-Request-ID"] = getattr(g, "request_id", "")
+        log_entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "service": SERVICE_NAME,
+            "request_id": getattr(g, "request_id", ""),
+            "method": request.method,
+            "path": request.path,
+            "status": response.status_code,
+            "latency_ms": latency_ms,
+            "ip": request.headers.get("X-Forwarded-For", request.remote_addr),
+            "user_id": getattr(g, "user_id", None),
+            "role": getattr(g, "user_role", None),
+        }
+        app.logger.info(json.dumps(log_entry, ensure_ascii=False))
+        return response
+
+
+def get_metrics() -> Dict[str, Any]:
+    uptime_seconds = time.time() - REQUEST_STATS["start_time"]
+    count = REQUEST_STATS["count"] or 1
+    avg_latency = REQUEST_STATS["total_latency_ms"] / count
+    return {
+        "service": SERVICE_NAME,
+        "requests_total": REQUEST_STATS["count"],
+        "avg_latency_ms": round(avg_latency, 2),
+        "uptime_seconds": int(uptime_seconds),
+    }

--- a/Microservicios/auth/models.py
+++ b/Microservicios/auth/models.py
@@ -1,0 +1,50 @@
+"""In-memory user store for the Auth service.
+TODO: replace with persistent storage (Postgres/Mongo) when available.
+"""
+from typing import Dict, Optional
+from uuid import uuid4
+
+from werkzeug.security import check_password_hash, generate_password_hash
+
+USERS: Dict[str, Dict] = {}
+USERS_BY_EMAIL: Dict[str, str] = {}
+
+
+def create_user(email: str, password: str, name: str, org_id: str) -> Dict:
+    if email.lower() in USERS_BY_EMAIL:
+        raise ValueError("User already exists")
+    user_id = str(uuid4())
+    hashed_password = generate_password_hash(password)
+    existing_roles = [u for u in USERS.values() if u["org_id"] == org_id]
+    role = "org_admin" if not existing_roles else "user"
+    record = {
+        "user_id": user_id,
+        "email": email.lower(),
+        "password_hash": hashed_password,
+        "name": name,
+        "org_id": org_id,
+        "role": role,
+    }
+    USERS[user_id] = record
+    USERS_BY_EMAIL[email.lower()] = user_id
+    return {k: record[k] for k in ("user_id", "email", "name", "org_id", "role")}
+
+
+def get_user_by_email(email: str) -> Optional[Dict]:
+    user_id = USERS_BY_EMAIL.get(email.lower())
+    if not user_id:
+        return None
+    return USERS.get(user_id)
+
+
+def get_user_by_id(user_id: str) -> Optional[Dict]:
+    return USERS.get(user_id)
+
+
+def verify_credentials(email: str, password: str) -> Optional[Dict]:
+    record = get_user_by_email(email)
+    if not record:
+        return None
+    if check_password_hash(record["password_hash"], password):
+        return record
+    return None

--- a/Microservicios/auth/requirements.txt
+++ b/Microservicios/auth/requirements.txt
@@ -1,0 +1,6 @@
+Flask==3.0.3
+PyJWT==2.8.0
+redis==5.0.4
+xmltodict==0.13.0
+dicttoxml==1.7.16
+Werkzeug==3.0.3

--- a/Microservicios/auth/tokens.py
+++ b/Microservicios/auth/tokens.py
@@ -1,0 +1,59 @@
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import uuid4
+
+import jwt
+import redis
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+JWT_SECRET = os.getenv("JWT_SECRET", "dev_secret")
+JWT_EXPIRES_IN = int(os.getenv("JWT_EXPIRES_IN", "900"))
+REFRESH_TOKEN_TTL = int(os.getenv("REFRESH_TOKEN_TTL", "604800"))
+
+redis_client: Optional[redis.Redis] = None
+
+
+def _get_client() -> redis.Redis:
+    global redis_client
+    if redis_client is None:
+        redis_client = redis.from_url(REDIS_URL)
+    return redis_client
+
+
+def generate_access_token(user_id: str, role: str, org_id: str, expires_in_s: int = JWT_EXPIRES_IN, secret: str = JWT_SECRET) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": user_id,
+        "role": role,
+        "org_id": org_id,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(seconds=expires_in_s)).timestamp()),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def decode_access_token(token: str, secret: str = JWT_SECRET) -> dict:
+    return jwt.decode(token, secret, algorithms=["HS256"])
+
+
+def generate_refresh_token() -> str:
+    return str(uuid4())
+
+
+def store_refresh_token(token: str, user_id: str) -> None:
+    client = _get_client()
+    client.setex(f"refresh:{token}", REFRESH_TOKEN_TTL, value=user_id)
+
+
+def revoke_refresh_token(token: str) -> None:
+    client = _get_client()
+    client.delete(f"refresh:{token}")
+
+
+def is_refresh_token_valid(token: str) -> Optional[str]:
+    client = _get_client()
+    value = client.get(f"refresh:{token}")
+    if value is None:
+        return None
+    return value.decode("utf-8")

--- a/Microservicios/auth/utils_format.py
+++ b/Microservicios/auth/utils_format.py
@@ -1,0 +1,65 @@
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Tuple
+
+from dicttoxml import dicttoxml
+from flask import Response, g, request
+import xmltodict
+
+DEFAULT_ROOT = "response"
+
+
+def _negotiate() -> str:
+    accept = request.headers.get("Accept", "application/json")
+    if "application/xml" in accept.lower():
+        return "xml"
+    return "json"
+
+
+def parse_body() -> Tuple[Dict[str, Any], str]:
+    content_type = request.headers.get("Content-Type", "application/json").lower()
+    raw = request.get_data(cache=False) or b"{}"
+    if "application/json" in content_type:
+        try:
+            return json.loads(raw.decode("utf-8")), "json"
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON payload: {exc}")
+    if "application/xml" in content_type:
+        try:
+            parsed = xmltodict.parse(raw)
+            if isinstance(parsed, dict) and len(parsed) == 1:
+                parsed = next(iter(parsed.values()))
+            return dict(parsed), "xml"
+        except Exception as exc:
+            raise ValueError(f"Invalid XML payload: {exc}")
+    raise ValueError("Unsupported Content-Type. Use application/json or application/xml")
+
+
+def _to_xml(data: Any, root_tag: str) -> bytes:
+    if not isinstance(data, dict):
+        data = {"data": data}
+    return dicttoxml(data, custom_root=root_tag, attr_type=False)
+
+
+def make_response(data: Dict[str, Any], status: int = 200, root_tag: str = DEFAULT_ROOT) -> Response:
+    fmt = _negotiate()
+    if fmt == "xml":
+        payload = _to_xml(data, root_tag=root_tag)
+        return Response(payload, status=status, mimetype="application/xml")
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return Response(payload, status=status, mimetype="application/json")
+
+
+def error_response(code: int, message: str, details: Any = None) -> Response:
+    request_id = getattr(g, "request_id", None)
+    body = {
+        "error": {
+            "code": code,
+            "message": message,
+            "request_id": request_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    if details is not None:
+        body["error"]["details"] = details
+    return make_response(body, status=code, root_tag="Error")

--- a/Microservicios/docker-compose.yml
+++ b/Microservicios/docker-compose.yml
@@ -1,0 +1,106 @@
+version: "3.9"
+
+networks:
+  heartguard_net:
+    driver: bridge
+
+volumes:
+  influxdb-data:
+
+services:
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    networks:
+      - heartguard_net
+    ports:
+      - "6379:6379"
+
+  influxdb:
+    image: influxdb:2.7
+    restart: unless-stopped
+    networks:
+      - heartguard_net
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=admin
+      - DOCKER_INFLUXDB_INIT_PASSWORD=admin123
+      - DOCKER_INFLUXDB_INIT_ORG=heartguard-org
+      - DOCKER_INFLUXDB_INIT_BUCKET=heartguard-metrics
+
+  gateway:
+    build: ./gateway
+    env_file: .env
+    depends_on:
+      - auth
+      - organization
+      - user
+      - media
+      - timeseries
+      - audit
+      - redis
+    ports:
+      - "5000:5000"
+    networks:
+      - heartguard_net
+
+  auth:
+    build: ./auth
+    env_file: .env
+    depends_on:
+      - redis
+    ports:
+      - "5001:5001"
+    networks:
+      - heartguard_net
+
+  organization:
+    build: ./organization
+    env_file: .env
+    ports:
+      - "5002:5002"
+    networks:
+      - heartguard_net
+
+  user:
+    build: ./user
+    env_file: .env
+    ports:
+      - "5003:5003"
+    networks:
+      - heartguard_net
+
+  media:
+    build: ./media
+    env_file: .env
+    depends_on:
+      - redis
+    ports:
+      - "5004:5004"
+    networks:
+      - heartguard_net
+    volumes:
+      - ./media/gcp-key.json:/app/gcp-key.json:ro
+
+  timeseries:
+    build: ./timeseries
+    env_file: .env
+    depends_on:
+      - influxdb
+    ports:
+      - "5005:5005"
+    networks:
+      - heartguard_net
+
+  audit:
+    build: ./audit
+    env_file: .env
+    ports:
+      - "5006:5006"
+    networks:
+      - heartguard_net
+

--- a/Microservicios/gateway/Dockerfile
+++ b/Microservicios/gateway/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/Microservicios/gateway/app.py
+++ b/Microservicios/gateway/app.py
@@ -1,0 +1,377 @@
+import os
+from typing import Any, Dict, Optional
+
+import requests
+from flask import Flask, g, request
+import jwt
+
+from .error_handler import register_error_handlers
+from .middleware import get_metrics, init_app
+from .rate_limit import check_rate_limit
+from .rbac import check_access
+from .utils_format import error_response, make_response, parse_body
+
+app = Flask(__name__)
+
+init_app(app)
+register_error_handlers(app)
+
+JWT_SECRET = os.getenv("JWT_SECRET", "dev_secret")
+ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv("ALLOWED_ORIGINS", "*").split(",")]
+SERVICE_URLS = {
+    "auth": os.getenv("AUTH_URL", "http://auth:5001"),
+    "organization": os.getenv("ORG_URL", "http://organization:5002"),
+    "user": os.getenv("USER_URL", "http://user:5003"),
+    "media": os.getenv("MEDIA_URL", "http://media:5004"),
+    "timeseries": os.getenv("INFLUX_URL", "http://timeseries:5005"),
+    "audit": os.getenv("AUDIT_URL", "http://audit:5006"),
+}
+
+
+@app.before_request
+def enforce_cors_and_rate_limits():
+    if request.method == "OPTIONS":
+        return _options_response()
+    origin = request.headers.get("Origin")
+    if origin and origin not in ALLOWED_ORIGINS and "*" not in ALLOWED_ORIGINS:
+        return error_response(403, "Origin not allowed")
+    client_ip = request.headers.get("X-Forwarded-For", request.remote_addr or "")
+    if not check_rate_limit(client_ip, request.path):
+        return error_response(429, "Rate limit exceeded")
+
+
+def _options_response():
+    resp = make_response({"status": "ok"}, status=204)
+    return resp
+
+
+@app.after_request
+def add_cors_headers(response):
+    origin = request.headers.get("Origin")
+    if origin and (origin in ALLOWED_ORIGINS or "*" in ALLOWED_ORIGINS):
+        response.headers["Access-Control-Allow-Origin"] = origin
+    response.headers["Access-Control-Allow-Headers"] = "Authorization,Content-Type,Accept,X-Request-ID"
+    response.headers["Access-Control-Allow-Methods"] = "GET,POST,PUT,DELETE,OPTIONS"
+    response.headers["Access-Control-Allow-Credentials"] = "true"
+    response.headers.setdefault("Vary", "Origin")
+    return response
+
+
+def _decode_jwt(required: bool = True) -> Optional[Dict[str, Any]]:
+    auth_header = request.headers.get("Authorization", "")
+    token = None
+    if auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1]
+    if not token:
+        if required:
+            raise PermissionError("Missing bearer token")
+        return None
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+        g.user_id = payload.get("sub")
+        g.user_role = payload.get("role")
+        g.org_id = payload.get("org_id")
+        return payload
+    except jwt.ExpiredSignatureError:
+        raise PermissionError("Token expired")
+    except jwt.InvalidTokenError:
+        raise PermissionError("Invalid token")
+
+
+def _authorized(path: str, required: bool = True, extra_context: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+    payload = _decode_jwt(required=required)
+    if not payload:
+        return None
+    allowed = check_access(payload.get("role"), path, payload.get("sub"), payload.get("org_id"), extra_context)
+    if not allowed:
+        raise PermissionError("Forbidden")
+    return payload
+
+
+def _permission_error_response(exc: PermissionError):
+    message = str(exc)
+    status = 403
+    lowered = message.lower()
+    if any(keyword in lowered for keyword in ["missing", "expired", "invalid", "bearer"]):
+        status = 401
+    return error_response(status, message)
+
+
+def _proxy_request(method: str, service: str, endpoint: str, *, json_body: Optional[Dict[str, Any]] = None, params: Optional[Dict[str, Any]] = None, files: Any = None, data: Any = None, headers: Optional[Dict[str, str]] = None):
+    base_url = SERVICE_URLS[service]
+    url = f"{base_url}{endpoint}"
+    outbound_headers = {
+        "Accept": "application/json",
+        "X-Request-ID": getattr(g, "request_id", ""),
+    }
+    if g.get("user_id"):
+        outbound_headers["X-User-ID"] = str(g.user_id)
+    if g.get("user_role"):
+        outbound_headers["X-User-Role"] = str(g.user_role)
+    if g.get("org_id"):
+        outbound_headers["X-Org-ID"] = str(g.org_id)
+    auth_header = request.headers.get("Authorization")
+    if auth_header:
+        outbound_headers["Authorization"] = auth_header
+    if headers:
+        outbound_headers.update(headers)
+    if json_body is not None:
+        outbound_headers.setdefault("Content-Type", "application/json")
+
+    try:
+        response = requests.request(
+            method,
+            url,
+            json=json_body,
+            params=params,
+            files=files,
+            data=data,
+            headers=outbound_headers,
+            timeout=15,
+        )
+    except requests.RequestException as exc:
+        return error_response(502, f"Downstream {service} service unavailable", {"error": str(exc)})
+
+    return _format_downstream_response(response)
+
+
+def _format_downstream_response(response: requests.Response):
+    content_type = response.headers.get("Content-Type", "application/json")
+    status = response.status_code
+    try:
+        if "application/json" in content_type:
+            payload = response.json()
+            body = payload
+            root_tag = "response"
+        elif "application/xml" in content_type:
+            import xmltodict
+
+            parsed = xmltodict.parse(response.text)
+            payload = dict(parsed)
+            if isinstance(payload, dict) and len(payload) == 1:
+                root_tag = next(iter(payload.keys()))
+                body = payload[root_tag]
+            else:
+                root_tag = "response"
+                body = payload
+        else:
+            body = {"raw": response.text}
+            root_tag = "response"
+    except Exception as exc:  # pragma: no cover - fallback
+        body = {"raw": response.text, "error": str(exc)}
+        root_tag = "response"
+    if not isinstance(body, dict):
+        body = {"data": body}
+    return make_response(body, status=status, root_tag=root_tag)
+
+
+@app.route("/health", methods=["GET"])
+@app.route("/gateway/health", methods=["GET"])
+def health():
+    return make_response({"status": "ok", "service": "gateway"})
+
+
+@app.route("/ready", methods=["GET"])
+@app.route("/gateway/ready", methods=["GET"])
+def ready():
+    dependencies = {}
+    from .rate_limit import get_client  # local import to avoid circular
+
+    try:
+        get_client().ping()
+        dependencies["redis"] = True
+    except Exception as exc:  # pragma: no cover - runtime env
+        dependencies["redis"] = str(exc)
+    healthy = all(v is True for v in dependencies.values())
+    status = 200 if healthy else 503
+    return make_response({"status": "ready" if healthy else "degraded", "dependencies": dependencies}, status=status)
+
+
+@app.route("/metrics", methods=["GET"])
+@app.route("/gateway/metrics", methods=["GET"])
+def metrics():
+    return make_response(get_metrics(), root_tag="Metrics")
+
+
+@app.route("/auth/register", methods=["POST"])
+def gateway_register():
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    return _proxy_request("POST", "auth", "/auth/register", json_body=body)
+
+
+@app.route("/auth/login", methods=["POST"])
+def gateway_login():
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    return _proxy_request("POST", "auth", "/auth/login", json_body=body)
+
+
+@app.route("/auth/refresh", methods=["POST"])
+def gateway_refresh():
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    return _proxy_request("POST", "auth", "/auth/refresh", json_body=body)
+
+
+@app.route("/auth/logout", methods=["POST"])
+def gateway_logout():
+    try:
+        _authorized("/auth/logout", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    return _proxy_request("POST", "auth", "/auth/logout", json_body=body)
+
+
+@app.route("/user/me", methods=["GET"])
+def get_user_me():
+    try:
+        payload = _authorized("/user/me", required=True, extra_context={"requested_user_id": request.args.get("user_id", None)})
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    return _proxy_request("GET", "user", "/user/me")
+
+
+@app.route("/user/me", methods=["PUT"])
+def update_user_me():
+    try:
+        payload = _authorized("/user/me", required=True, extra_context={"requested_user_id": getattr(g, "user_id", None)})
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    body.setdefault("user_id", payload.get("sub"))
+    return _proxy_request("PUT", "user", "/user/me", json_body=body)
+
+
+@app.route("/organization/info", methods=["GET"])
+def organization_info():
+    try:
+        _authorized("/organization/info", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    return _proxy_request("GET", "organization", "/organization/info")
+
+
+@app.route("/organization/info", methods=["PUT"])
+def update_organization_info():
+    try:
+        _authorized("/organization/info", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    return _proxy_request("PUT", "organization", "/organization/info", json_body=body)
+
+
+@app.route("/media/upload", methods=["POST"])
+def media_upload():
+    try:
+        _authorized("/media/upload", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    if request.content_type and "multipart/form-data" in request.content_type:
+        files = {name: (file.filename, file.stream, file.content_type) for name, file in request.files.items()}
+        data = request.form.to_dict(flat=True)
+        return _proxy_request("POST", "media", "/media/upload", files=files, data=data)
+    raw = request.get_data()
+    headers = {"Content-Type": request.headers.get("Content-Type", "application/octet-stream")}
+    return _proxy_request("POST", "media", "/media/upload", data=raw, headers=headers)
+
+
+@app.route("/media/file/<media_id>", methods=["GET"])
+def media_get(media_id: str):
+    try:
+        _authorized("/media/file", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    return _proxy_request("GET", "media", f"/media/file/{media_id}")
+
+
+@app.route("/media/list", methods=["GET"])
+def media_list():
+    try:
+        _authorized("/media/list", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    return _proxy_request("GET", "media", "/media/list")
+
+
+@app.route("/media/file/<media_id>", methods=["DELETE"])
+def media_delete(media_id: str):
+    try:
+        _authorized("/media/file", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    return _proxy_request("DELETE", "media", f"/media/file/{media_id}")
+
+
+@app.route("/timeseries/write", methods=["POST"])
+def timeseries_write():
+    try:
+        payload = _authorized("/timeseries/write", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    if request.headers.get("Content-Type", "").startswith("text/plain"):
+        data = request.get_data()
+        headers = {"Content-Type": request.headers.get("Content-Type")}
+        return _proxy_request("POST", "timeseries", "/timeseries/write", data=data, headers=headers)
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    return _proxy_request("POST", "timeseries", "/timeseries/write", json_body=body)
+
+
+@app.route("/timeseries/query", methods=["GET"])
+def timeseries_query():
+    try:
+        payload = _authorized(
+            "/timeseries/query",
+            required=True,
+            extra_context={"user_id": request.args.get("user_id")},
+        )
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    return _proxy_request("GET", "timeseries", "/timeseries/query", params=request.args.to_dict(flat=True))
+
+
+@app.route("/audit/event", methods=["POST"])
+def audit_event():
+    try:
+        _authorized("/audit", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    return _proxy_request("POST", "audit", "/audit/event", json_body=body)
+
+
+@app.route("/audit/events", methods=["GET"])
+def audit_events():
+    try:
+        _authorized("/audit", required=True)
+    except PermissionError as exc:
+        return _permission_error_response(exc)
+    return _proxy_request("GET", "audit", "/audit/events", params=request.args.to_dict(flat=True))
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("GATEWAY_PORT", "5000"))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/gateway/error_handler.py
+++ b/Microservicios/gateway/error_handler.py
@@ -1,0 +1,15 @@
+from werkzeug.exceptions import HTTPException
+from flask import Flask
+
+from .utils_format import error_response
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(exc: HTTPException):
+        return error_response(exc.code or 500, exc.description)
+
+    @app.errorhandler(Exception)
+    def handle_exception(exc: Exception):  # pragma: no cover - generic safeguard
+        app.logger.exception("Unhandled exception")
+        return error_response(500, "Internal server error")

--- a/Microservicios/gateway/middleware.py
+++ b/Microservicios/gateway/middleware.py
@@ -1,0 +1,64 @@
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict
+
+from flask import Flask, Request, g, request
+
+from .utils_format import error_response
+
+SERVICE_NAME = "gateway"
+MAX_BODY_BYTES = int(os.getenv("MAX_JSON_BODY_BYTES", "1048576"))
+REQUEST_STATS: Dict[str, Any] = {
+    "count": 0,
+    "total_latency_ms": 0.0,
+    "start_time": time.time(),
+}
+
+
+def init_app(app: Flask) -> None:
+    @app.before_request
+    def _before_request():
+        g.start_time = time.time()
+        g.request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        g.user_id = None
+        g.user_role = None
+        content_length = request.content_length
+        limit = MAX_BODY_BYTES
+        if content_length is not None and content_length > limit:
+            return error_response(413, "Payload too large")
+
+    @app.after_request
+    def _after_request(response):
+        latency_ms = int((time.time() - getattr(g, "start_time", time.time())) * 1000)
+        REQUEST_STATS["count"] += 1
+        REQUEST_STATS["total_latency_ms"] += latency_ms
+        response.headers["X-Request-ID"] = getattr(g, "request_id", "")
+
+        log_entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "service": SERVICE_NAME,
+            "request_id": getattr(g, "request_id", ""),
+            "method": request.method,
+            "path": request.path,
+            "status": response.status_code,
+            "latency_ms": latency_ms,
+            "ip": request.headers.get("X-Forwarded-For", request.remote_addr),
+            "user_id": getattr(g, "user_id", None),
+            "role": getattr(g, "user_role", None),
+        }
+        app.logger.info(json.dumps(log_entry, ensure_ascii=False))
+        return response
+
+
+def get_metrics() -> Dict[str, Any]:
+    uptime_seconds = time.time() - REQUEST_STATS["start_time"]
+    count = REQUEST_STATS["count"] or 1
+    avg_latency = REQUEST_STATS["total_latency_ms"] / count
+    return {
+        "service": SERVICE_NAME,
+        "requests_total": REQUEST_STATS["count"],
+        "avg_latency_ms": round(avg_latency, 2),
+        "uptime_seconds": int(uptime_seconds),
+    }

--- a/Microservicios/gateway/rate_limit.py
+++ b/Microservicios/gateway/rate_limit.py
@@ -1,0 +1,27 @@
+import os
+import time
+from typing import Optional
+
+import redis
+
+RATE_LIMIT = int(os.getenv("RATE_LIMIT", "60"))
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+redis_client: Optional[redis.Redis] = None
+
+
+def get_client() -> redis.Redis:
+    global redis_client
+    if redis_client is None:
+        redis_client = redis.from_url(REDIS_URL)
+    return redis_client
+
+
+def check_rate_limit(client_ip: str, endpoint: str) -> bool:
+    if RATE_LIMIT <= 0:
+        return True
+    key = f"rate:{client_ip}:{endpoint}:{int(time.time() // 60)}"
+    client = get_client()
+    current = client.incr(key)
+    if current == 1:
+        client.expire(key, 120)
+    return current <= RATE_LIMIT

--- a/Microservicios/gateway/rbac.py
+++ b/Microservicios/gateway/rbac.py
@@ -1,0 +1,41 @@
+from typing import Dict, List, Optional
+
+ALLOWED_ROUTES: Dict[str, List[str]] = {
+    "/organization": ["admin", "org_admin"],
+    "/media": ["admin", "org_admin", "user"],
+    "/audit": ["admin", "org_admin"],
+    "/timeseries/write": ["device", "system", "admin"],
+    "/timeseries/query": ["admin", "org_admin", "user"],
+    "/user/me": ["admin", "org_admin", "user"],
+}
+
+
+def _route_matches(path: str, prefix: str) -> bool:
+    if prefix.endswith("*"):
+        return path.startswith(prefix[:-1])
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def check_access(user_role: Optional[str], request_path: str, jwt_sub: Optional[str], jwt_org_id: Optional[str], extra_context: Optional[Dict] = None) -> bool:
+    if user_role == "admin":
+        return True
+
+    for prefix, roles in ALLOWED_ROUTES.items():
+        if _route_matches(request_path, prefix):
+            if user_role in roles:
+                if request_path.startswith("/user/me"):
+                    if extra_context and extra_context.get("requested_user_id") != jwt_sub and user_role not in {"org_admin"}:
+                        return False
+                if request_path.startswith("/media") and user_role == "user":
+                    # users only access own resources; validations handled downstream using sub
+                    return True
+                if request_path.startswith("/organization") and user_role not in {"admin", "org_admin"}:
+                    return False
+                if request_path.startswith("/timeseries/query") and user_role == "user":
+                    requested_user = (extra_context or {}).get("user_id")
+                    return requested_user in (None, jwt_sub)
+                return True
+            return False
+
+    # default allow for system/device paths explicitly covered above
+    return user_role in {"device", "system"}

--- a/Microservicios/gateway/requirements.txt
+++ b/Microservicios/gateway/requirements.txt
@@ -1,0 +1,6 @@
+Flask==3.0.3
+PyJWT==2.8.0
+redis==5.0.4
+requests==2.31.0
+xmltodict==0.13.0
+dicttoxml==1.7.16

--- a/Microservicios/gateway/utils_format.py
+++ b/Microservicios/gateway/utils_format.py
@@ -1,0 +1,66 @@
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Tuple
+
+from dicttoxml import dicttoxml
+from flask import Response, g, request
+import xmltodict
+
+DEFAULT_ROOT = "response"
+
+
+def _negotiate() -> str:
+    accept = request.headers.get("Accept", "application/json")
+    if "application/xml" in accept.lower():
+        return "xml"
+    return "json"
+
+
+def parse_body() -> Tuple[Dict[str, Any], str]:
+    content_type = request.headers.get("Content-Type", "application/json").lower()
+    raw = request.get_data(cache=False) or b"{}"
+    if "application/json" in content_type:
+        try:
+            return json.loads(raw.decode("utf-8")), "json"
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON payload: {exc}")
+    if "application/xml" in content_type:
+        try:
+            parsed = xmltodict.parse(raw)
+            if isinstance(parsed, dict) and len(parsed) == 1:
+                parsed = next(iter(parsed.values()))
+            return dict(parsed), "xml"
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid XML payload: {exc}")
+    raise ValueError("Unsupported Content-Type. Use application/json or application/xml")
+
+
+def _to_xml(data: Any, root_tag: str) -> bytes:
+    if not isinstance(data, dict):
+        data = {"data": data}
+    xml_bytes = dicttoxml(data, custom_root=root_tag, attr_type=False)
+    return xml_bytes
+
+
+def make_response(data: Dict[str, Any], status: int = 200, root_tag: str = DEFAULT_ROOT) -> Response:
+    fmt = _negotiate()
+    if fmt == "xml":
+        payload = _to_xml(data, root_tag=root_tag)
+        return Response(payload, status=status, mimetype="application/xml")
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return Response(payload, status=status, mimetype="application/json")
+
+
+def error_response(code: int, message: str, details: Any = None) -> Response:
+    request_id = getattr(g, "request_id", None)
+    body = {
+        "error": {
+            "code": code,
+            "message": message,
+            "request_id": request_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    if details is not None:
+        body["error"]["details"] = details
+    return make_response(body, status=code, root_tag="Error")

--- a/Microservicios/media/Dockerfile
+++ b/Microservicios/media/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends gcc && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 5004
+
+CMD ["python", "app.py"]

--- a/Microservicios/media/app.py
+++ b/Microservicios/media/app.py
@@ -1,0 +1,148 @@
+import os
+
+from flask import Flask, g, request
+
+from .error_handler import register_error_handlers
+from .gcs_client import delete_file, generate_signed_url, get_media, list_media, upload_file
+from .middleware import get_metrics, init_app
+from .utils_format import error_response, make_response
+
+app = Flask(__name__)
+init_app(app)
+register_error_handlers(app)
+
+ALLOWED_MIME_TYPES = {"image/jpeg", "image/png", "application/pdf", "text/plain"}
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return make_response({"status": "ok", "service": "media"})
+
+
+@app.route("/ready", methods=["GET"])
+def ready():
+    status = 200
+    details = {}
+    credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    if credentials_path and os.path.exists(credentials_path):
+        details["credentials"] = "found"
+    else:
+        details["credentials"] = "missing"
+        status = 503
+    try:
+        from google.cloud import storage
+
+        storage.Client().bucket(os.getenv("GCS_BUCKET", "heartguard-system"))
+        details["gcs"] = "ok"
+    except Exception as exc:  # pragma: no cover
+        details["gcs"] = str(exc)
+        status = 503
+    return make_response({"status": "ready" if status == 200 else "degraded", "dependencies": details}, status=status)
+
+
+@app.route("/metrics", methods=["GET"])
+def metrics():
+    return make_response(get_metrics(), root_tag="Metrics")
+
+
+# POST /media/upload
+# Multipart example (curl):
+#   curl -F "file=@document.pdf" http://localhost:5004/media/upload
+# Octet-stream example:
+#   curl -H "Content-Type: application/octet-stream" -H "X-Filename: note.txt" -H "X-Mime-Type: text/plain" --data-binary @note.txt
+# Response JSON/XML:
+# {
+#   "media": {
+#     "media_id": "...",
+#     "gcs_path": "user/uuid.pdf",
+#     "mime_type": "application/pdf",
+#     "size_bytes": 1024,
+#     "signed_url": "https://...",
+#     "created_at": "2025-10-29T18:07:00Z"
+#   }
+# }
+@app.route("/media/upload", methods=["POST"])
+def media_upload():
+    user_id = g.get("user_id")
+    if not user_id:
+        return error_response(401, "Missing user identity")
+    file_bytes = b""
+    filename = None
+    mime_type = None
+    if request.files:
+        file_storage = next(iter(request.files.values()))
+        file_bytes = file_storage.read()
+        filename = file_storage.filename
+        mime_type = file_storage.mimetype or request.headers.get("X-Mime-Type")
+    else:
+        file_bytes = request.get_data()
+        filename = request.headers.get("X-Filename", "upload.bin")
+        mime_type = request.headers.get("X-Mime-Type", request.headers.get("Content-Type", "application/octet-stream"))
+    if not mime_type:
+        return error_response(400, "Unable to determine MIME type")
+    if mime_type not in ALLOWED_MIME_TYPES:
+        return error_response(415, f"MIME type {mime_type} not allowed")
+    if len(file_bytes) > int(os.getenv("MAX_MEDIA_BYTES", "10485760")):
+        return error_response(413, "Payload too large")
+    metadata = upload_file(file_bytes, mime_type, user_id)
+    metadata["filename"] = filename
+    return make_response({"media": metadata}, status=201, root_tag="MediaUploadResponse")
+
+
+# GET /media/file/<media_id>
+# Response JSON/XML:
+# {
+#   "media": {
+#     "media_id": "...",
+#     "signed_url": "https://..."
+#   }
+# }
+@app.route("/media/file/<media_id>", methods=["GET"])
+def media_file(media_id: str):
+    user_id = g.get("user_id")
+    if not user_id:
+        return error_response(401, "Missing user identity")
+    meta = get_media(media_id)
+    if not meta or meta.get("owner_user_id") != user_id and g.get("user_role") != "admin":
+        return error_response(404, "Media not found")
+    signed_url = generate_signed_url(meta["gcs_path"]) or meta.get("signed_url")
+    return make_response({"media": {"media_id": media_id, "signed_url": signed_url}}, root_tag="MediaFile")
+
+
+# GET /media/list
+# Response JSON/XML:
+# {
+#   "media": [
+#     {"media_id": "...", "mime_type": "application/pdf", ...}
+#   ]
+# }
+@app.route("/media/list", methods=["GET"])
+def media_list():
+    user_id = g.get("user_id")
+    if not user_id:
+        return error_response(401, "Missing user identity")
+    owner = None if g.get("user_role") in {"admin", "org_admin"} else user_id
+    items = list_media(owner)
+    return make_response({"media": items}, root_tag="MediaList")
+
+
+# DELETE /media/file/<media_id>
+# Response JSON/XML:
+# {
+#   "status": "deleted"
+# }
+@app.route("/media/file/<media_id>", methods=["DELETE"])
+def media_delete(media_id: str):
+    user_id = g.get("user_id")
+    if not user_id:
+        return error_response(401, "Missing user identity")
+    meta = get_media(media_id)
+    if not meta or (meta.get("owner_user_id") != user_id and g.get("user_role") != "admin"):
+        return error_response(404, "Media not found")
+    delete_file(meta["gcs_path"])
+    return make_response({"status": "deleted"}, root_tag="MediaDeleteResponse")
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("MEDIA_PORT", "5004"))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/media/error_handler.py
+++ b/Microservicios/media/error_handler.py
@@ -1,0 +1,15 @@
+from werkzeug.exceptions import HTTPException
+from flask import Flask
+
+from .utils_format import error_response
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http(exc: HTTPException):
+        return error_response(exc.code or 500, exc.description)
+
+    @app.errorhandler(Exception)
+    def handle_generic(exc: Exception):  # pragma: no cover
+        app.logger.exception("Unhandled error")
+        return error_response(500, "Internal server error")

--- a/Microservicios/media/gcp-key.json
+++ b/Microservicios/media/gcp-key.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "heartguard-placeholder",
+  "private_key_id": "CHANGE_ME",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nCHANGE_ME\n-----END PRIVATE KEY-----\n",
+  "client_email": "751259101579-compute@developer.gserviceaccount.com",
+  "client_id": "000000000000000000000",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/751259101579-compute%40developer.gserviceaccount.com"
+}

--- a/Microservicios/media/gcs_client.py
+++ b/Microservicios/media/gcs_client.py
@@ -1,0 +1,87 @@
+"""Google Cloud Storage helper functions.
+The module uploads files to GCS and stores metadata in-memory for quick retrieval.
+"""
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from google.cloud import storage
+
+GCS_BUCKET = os.getenv("GCS_BUCKET", "heartguard-system")
+SERVICE_ACCOUNT_EMAIL = os.getenv("SERVICE_ACCOUNT_EMAIL")
+MEDIA_METADATA: Dict[str, Dict] = {}
+
+ALLOWED_EXTENSIONS = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "application/pdf": ".pdf",
+    "text/plain": ".txt",
+}
+
+
+def _client() -> storage.Client:
+    return storage.Client()
+
+
+def upload_file(file_bytes: bytes, mime_type: str, owner_user_id: str) -> Dict:
+    extension = ALLOWED_EXTENSIONS.get(mime_type, "")
+    media_id = str(uuid4())
+    object_path = f"{owner_user_id}/{media_id}{extension}"
+    metadata = {
+        "media_id": media_id,
+        "gcs_path": object_path,
+        "mime_type": mime_type,
+        "size_bytes": len(file_bytes),
+        "owner_user_id": owner_user_id,
+    }
+    try:
+        client = _client()
+        bucket = client.bucket(GCS_BUCKET)
+        blob = bucket.blob(object_path)
+        blob.upload_from_string(file_bytes, content_type=mime_type)
+        signed_url = blob.generate_signed_url(expiration=timedelta(minutes=5), method="GET")
+        metadata["signed_url"] = signed_url
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        metadata["signed_url"] = f"https://storage.googleapis.com/{GCS_BUCKET}/{object_path}"
+        metadata["warning"] = str(exc)
+    created_at = datetime.now(timezone.utc).isoformat()
+    MEDIA_METADATA[media_id] = {**metadata, "created_at": created_at}
+    return {**metadata, "created_at": created_at}
+
+
+def generate_signed_url(gcs_path: str) -> Optional[str]:
+    try:
+        client = _client()
+        bucket = client.bucket(GCS_BUCKET)
+        blob = bucket.blob(gcs_path)
+        return blob.generate_signed_url(expiration=timedelta(minutes=5), method="GET")
+    except Exception:  # pragma: no cover
+        for meta in MEDIA_METADATA.values():
+            if meta.get("gcs_path") == gcs_path:
+                return meta.get("signed_url")
+        return None
+
+
+def list_media(owner_user_id: Optional[str] = None) -> List[Dict]:
+    if owner_user_id is None:
+        return list(MEDIA_METADATA.values())
+    return [item for item in MEDIA_METADATA.values() if item.get("owner_user_id") == owner_user_id]
+
+
+def delete_file(gcs_path: str) -> None:
+    try:
+        client = _client()
+        bucket = client.bucket(GCS_BUCKET)
+        blob = bucket.blob(gcs_path)
+        blob.delete()
+    except Exception:  # pragma: no cover
+        pass
+    for media_id, meta in list(MEDIA_METADATA.items()):
+        if meta.get("gcs_path") == gcs_path:
+            MEDIA_METADATA.pop(media_id, None)
+            break
+
+
+def get_media(media_id: str) -> Optional[Dict]:
+    return MEDIA_METADATA.get(media_id)

--- a/Microservicios/media/middleware.py
+++ b/Microservicios/media/middleware.py
@@ -1,0 +1,62 @@
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict
+
+from flask import Flask, g, request
+
+from .utils_format import error_response
+
+SERVICE_NAME = "media"
+MAX_BODY_BYTES = int(os.getenv("MAX_MEDIA_BYTES", "10485760"))
+REQUEST_STATS: Dict[str, Any] = {
+    "count": 0,
+    "total_latency_ms": 0.0,
+    "start_time": time.time(),
+}
+
+
+def init_app(app: Flask) -> None:
+    @app.before_request
+    def _before_request():
+        g.start_time = time.time()
+        g.request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        g.user_id = request.headers.get("X-User-ID")
+        g.user_role = request.headers.get("X-User-Role")
+        g.org_id = request.headers.get("X-Org-ID")
+        if request.content_length and request.content_length > MAX_BODY_BYTES:
+            return error_response(413, "Payload too large")
+
+    @app.after_request
+    def _after_request(response):
+        latency_ms = int((time.time() - getattr(g, "start_time", time.time())) * 1000)
+        REQUEST_STATS["count"] += 1
+        REQUEST_STATS["total_latency_ms"] += latency_ms
+        response.headers["X-Request-ID"] = getattr(g, "request_id", "")
+        log_entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "service": SERVICE_NAME,
+            "request_id": getattr(g, "request_id", ""),
+            "method": request.method,
+            "path": request.path,
+            "status": response.status_code,
+            "latency_ms": latency_ms,
+            "ip": request.headers.get("X-Forwarded-For", request.remote_addr),
+            "user_id": getattr(g, "user_id", None),
+            "role": getattr(g, "user_role", None),
+        }
+        app.logger.info(json.dumps(log_entry, ensure_ascii=False))
+        return response
+
+
+def get_metrics() -> Dict[str, Any]:
+    uptime_seconds = time.time() - REQUEST_STATS["start_time"]
+    count = REQUEST_STATS["count"] or 1
+    avg_latency = REQUEST_STATS["total_latency_ms"] / count
+    return {
+        "service": SERVICE_NAME,
+        "requests_total": REQUEST_STATS["count"],
+        "avg_latency_ms": round(avg_latency, 2),
+        "uptime_seconds": int(uptime_seconds),
+    }

--- a/Microservicios/media/requirements.txt
+++ b/Microservicios/media/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.3
+google-cloud-storage==2.16.0
+xmltodict==0.13.0
+dicttoxml==1.7.16

--- a/Microservicios/media/utils_format.py
+++ b/Microservicios/media/utils_format.py
@@ -1,0 +1,65 @@
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Tuple
+
+from dicttoxml import dicttoxml
+from flask import Response, g, request
+import xmltodict
+
+DEFAULT_ROOT = "response"
+
+
+def _negotiate() -> str:
+    accept = request.headers.get("Accept", "application/json")
+    if "application/xml" in accept.lower():
+        return "xml"
+    return "json"
+
+
+def parse_body() -> Tuple[Dict[str, Any], str]:
+    content_type = request.headers.get("Content-Type", "application/json").lower()
+    raw = request.get_data(cache=False) or b"{}"
+    if "application/json" in content_type:
+        try:
+            return json.loads(raw.decode("utf-8")), "json"
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON payload: {exc}")
+    if "application/xml" in content_type:
+        try:
+            parsed = xmltodict.parse(raw)
+            if isinstance(parsed, dict) and len(parsed) == 1:
+                parsed = next(iter(parsed.values()))
+            return dict(parsed), "xml"
+        except Exception as exc:
+            raise ValueError(f"Invalid XML payload: {exc}")
+    raise ValueError("Unsupported Content-Type. Use application/json or application/xml")
+
+
+def _to_xml(data: Any, root_tag: str) -> bytes:
+    if not isinstance(data, dict):
+        data = {"data": data}
+    return dicttoxml(data, custom_root=root_tag, attr_type=False)
+
+
+def make_response(data: Dict[str, Any], status: int = 200, root_tag: str = DEFAULT_ROOT) -> Response:
+    fmt = _negotiate()
+    if fmt == "xml":
+        payload = _to_xml(data, root_tag=root_tag)
+        return Response(payload, status=status, mimetype="application/xml")
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return Response(payload, status=status, mimetype="application/json")
+
+
+def error_response(code: int, message: str, details: Any = None) -> Response:
+    request_id = getattr(g, "request_id", None)
+    body = {
+        "error": {
+            "code": code,
+            "message": message,
+            "request_id": request_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    if details is not None:
+        body["error"]["details"] = details
+    return make_response(body, status=code, root_tag="Error")

--- a/Microservicios/organization/Dockerfile
+++ b/Microservicios/organization/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 5002
+
+CMD ["python", "app.py"]

--- a/Microservicios/organization/app.py
+++ b/Microservicios/organization/app.py
@@ -1,0 +1,75 @@
+import os
+
+from flask import Flask, g
+
+from .error_handler import register_error_handlers
+from .middleware import get_metrics, init_app
+from .models import get_org, update_org
+from .utils_format import error_response, make_response, parse_body
+
+app = Flask(__name__)
+init_app(app)
+register_error_handlers(app)
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return make_response({"status": "ok", "service": "organization"})
+
+
+@app.route("/ready", methods=["GET"])
+def ready():
+    return make_response({"status": "ready"})
+
+
+@app.route("/metrics", methods=["GET"])
+def metrics():
+    return make_response(get_metrics(), root_tag="Metrics")
+
+
+# GET /organization/info
+# Response JSON/XML:
+# {
+#   "organization": {
+#     "name": "Heartguard Health",
+#     "logo_url": "https://...",
+#     "policies": "Default policies",
+#     "settings": {
+#       "alert_threshold_bpm": 120,
+#       "timezone": "UTC"
+#     }
+#   }
+# }
+@app.route("/organization/info", methods=["GET"])
+def organization_info():
+    org_id = g.get("org_id", "default") or "default"
+    profile = get_org(org_id)
+    return make_response({"organization": profile}, root_tag="OrganizationInfo")
+
+
+# PUT /organization/info
+# Request JSON/XML:
+# {
+#   "name": "New Name",
+#   "logo_url": "https://...",
+#   "policies": "<b>Policies</b>",
+#   "settings": {
+#     "alert_threshold_bpm": 110,
+#     "timezone": "America/Mexico_City"
+#   }
+# }
+# Response mirrors the updated organization.
+@app.route("/organization/info", methods=["PUT"])
+def update_organization_info():
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    org_id = g.get("org_id", "default") or "default"
+    profile = update_org(body, org_id)
+    return make_response({"organization": profile}, root_tag="OrganizationInfo")
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("ORG_PORT", "5002"))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/organization/error_handler.py
+++ b/Microservicios/organization/error_handler.py
@@ -1,0 +1,15 @@
+from werkzeug.exceptions import HTTPException
+from flask import Flask
+
+from .utils_format import error_response
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http(exc: HTTPException):
+        return error_response(exc.code or 500, exc.description)
+
+    @app.errorhandler(Exception)
+    def handle_generic(exc: Exception):  # pragma: no cover
+        app.logger.exception("Unhandled error")
+        return error_response(500, "Internal server error")

--- a/Microservicios/organization/middleware.py
+++ b/Microservicios/organization/middleware.py
@@ -1,0 +1,61 @@
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict
+
+from flask import Flask, g, request
+
+from .utils_format import error_response
+
+SERVICE_NAME = "organization"
+MAX_BODY_BYTES = int(os.getenv("MAX_JSON_BODY_BYTES", "1048576"))
+REQUEST_STATS: Dict[str, Any] = {
+    "count": 0,
+    "total_latency_ms": 0.0,
+    "start_time": time.time(),
+}
+
+
+def init_app(app: Flask) -> None:
+    @app.before_request
+    def _before_request():
+        g.start_time = time.time()
+        g.request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        g.user_id = request.headers.get("X-User-ID")
+        g.user_role = request.headers.get("X-User-Role")
+        if request.content_length and request.content_length > MAX_BODY_BYTES:
+            return error_response(413, "Payload too large")
+
+    @app.after_request
+    def _after_request(response):
+        latency_ms = int((time.time() - getattr(g, "start_time", time.time())) * 1000)
+        REQUEST_STATS["count"] += 1
+        REQUEST_STATS["total_latency_ms"] += latency_ms
+        response.headers["X-Request-ID"] = getattr(g, "request_id", "")
+        log_entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "service": SERVICE_NAME,
+            "request_id": getattr(g, "request_id", ""),
+            "method": request.method,
+            "path": request.path,
+            "status": response.status_code,
+            "latency_ms": latency_ms,
+            "ip": request.headers.get("X-Forwarded-For", request.remote_addr),
+            "user_id": getattr(g, "user_id", None),
+            "role": getattr(g, "user_role", None),
+        }
+        app.logger.info(json.dumps(log_entry, ensure_ascii=False))
+        return response
+
+
+def get_metrics() -> Dict[str, Any]:
+    uptime_seconds = time.time() - REQUEST_STATS["start_time"]
+    count = REQUEST_STATS["count"] or 1
+    avg_latency = REQUEST_STATS["total_latency_ms"] / count
+    return {
+        "service": SERVICE_NAME,
+        "requests_total": REQUEST_STATS["count"],
+        "avg_latency_ms": round(avg_latency, 2),
+        "uptime_seconds": int(uptime_seconds),
+    }

--- a/Microservicios/organization/models.py
+++ b/Microservicios/organization/models.py
@@ -1,0 +1,45 @@
+"""In-memory organization profile storage.
+TODO: replace with persistent storage (Postgres/Mongo).
+"""
+import html
+from typing import Dict
+
+ORGANIZATION_PROFILE: Dict[str, Dict] = {
+    "default": {
+        "name": "Heartguard Health",
+        "logo_url": "https://example.com/logo.png",
+        "policies": "Default policies",
+        "settings": {
+            "alert_threshold_bpm": 120,
+            "timezone": "UTC",
+        },
+    }
+}
+
+
+def get_org(org_id: str = "default") -> Dict:
+    return ORGANIZATION_PROFILE.setdefault(org_id, ORGANIZATION_PROFILE["default"].copy())
+
+
+def update_org(payload: Dict, org_id: str = "default") -> Dict:
+    profile = get_org(org_id)
+    if "name" in payload:
+        profile["name"] = str(payload["name"]).strip()
+    if "logo_url" in payload:
+        profile["logo_url"] = str(payload["logo_url"]).strip()
+    if "policies" in payload:
+        sanitized = html.escape(str(payload["policies"]))[:5000]
+        profile["policies"] = sanitized
+    if "settings" in payload:
+        settings = profile.setdefault("settings", {})
+        incoming = payload["settings"]
+        if "alert_threshold_bpm" in incoming:
+            try:
+                bpm = int(incoming["alert_threshold_bpm"])
+                settings["alert_threshold_bpm"] = max(30, min(250, bpm))
+            except (ValueError, TypeError):
+                pass
+        if "timezone" in incoming:
+            settings["timezone"] = str(incoming["timezone"]).strip()
+    ORGANIZATION_PROFILE[org_id] = profile
+    return profile

--- a/Microservicios/organization/requirements.txt
+++ b/Microservicios/organization/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.3
+xmltodict==0.13.0
+dicttoxml==1.7.16

--- a/Microservicios/organization/utils_format.py
+++ b/Microservicios/organization/utils_format.py
@@ -1,0 +1,65 @@
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Tuple
+
+from dicttoxml import dicttoxml
+from flask import Response, g, request
+import xmltodict
+
+DEFAULT_ROOT = "response"
+
+
+def _negotiate() -> str:
+    accept = request.headers.get("Accept", "application/json")
+    if "application/xml" in accept.lower():
+        return "xml"
+    return "json"
+
+
+def parse_body() -> Tuple[Dict[str, Any], str]:
+    content_type = request.headers.get("Content-Type", "application/json").lower()
+    raw = request.get_data(cache=False) or b"{}"
+    if "application/json" in content_type:
+        try:
+            return json.loads(raw.decode("utf-8")), "json"
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON payload: {exc}")
+    if "application/xml" in content_type:
+        try:
+            parsed = xmltodict.parse(raw)
+            if isinstance(parsed, dict) and len(parsed) == 1:
+                parsed = next(iter(parsed.values()))
+            return dict(parsed), "xml"
+        except Exception as exc:
+            raise ValueError(f"Invalid XML payload: {exc}")
+    raise ValueError("Unsupported Content-Type. Use application/json or application/xml")
+
+
+def _to_xml(data: Any, root_tag: str) -> bytes:
+    if not isinstance(data, dict):
+        data = {"data": data}
+    return dicttoxml(data, custom_root=root_tag, attr_type=False)
+
+
+def make_response(data: Dict[str, Any], status: int = 200, root_tag: str = DEFAULT_ROOT) -> Response:
+    fmt = _negotiate()
+    if fmt == "xml":
+        payload = _to_xml(data, root_tag=root_tag)
+        return Response(payload, status=status, mimetype="application/xml")
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return Response(payload, status=status, mimetype="application/json")
+
+
+def error_response(code: int, message: str, details: Any = None) -> Response:
+    request_id = getattr(g, "request_id", None)
+    body = {
+        "error": {
+            "code": code,
+            "message": message,
+            "request_id": request_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    if details is not None:
+        body["error"]["details"] = details
+    return make_response(body, status=code, root_tag="Error")

--- a/Microservicios/schemas/README.md
+++ b/Microservicios/schemas/README.md
@@ -1,0 +1,14 @@
+# Heartguard Schemas
+
+Este directorio contiene esquemas JSON Schema y XSD para validar los payloads principales de los microservicios. Cada servicio incluye ganchos para utilizarlos con librerías como `jsonschema` o validadores XML cuando se requiera.
+
+| Recurso       | JSON Schema                 | XML Schema |
+|---------------|----------------------------|------------|
+| Usuario       | `user.schema.json`          | `user.xsd` |
+| Organización  | `organization.schema.json`  | `organization.xsd` |
+| Token Auth    | `auth_token.schema.json`    | `auth_token.xsd` |
+| Media         | `media_item.schema.json`    | `media_item.xsd` |
+| Series de tiempo | `timeseries.schema.json` | `timeseries.xsd` |
+
+Los esquemas XSD están diseñados para representar estructuras equivalentes a los JSON Schema correspondientes.
+

--- a/Microservicios/schemas/auth_token.schema.json
+++ b/Microservicios/schemas/auth_token.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AuthToken",
+  "type": "object",
+  "required": ["access_token", "expires_in", "refresh_token", "refresh_expires_in", "token_type", "role"],
+  "properties": {
+    "access_token": {"type": "string"},
+    "expires_in": {"type": "integer", "minimum": 1},
+    "refresh_token": {"type": "string"},
+    "refresh_expires_in": {"type": "integer", "minimum": 1},
+    "token_type": {"type": "string"},
+    "role": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/auth_token.xsd
+++ b/Microservicios/schemas/auth_token.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="AuthToken">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="access_token" type="xs:string" />
+        <xs:element name="expires_in" type="xs:int" />
+        <xs:element name="refresh_token" type="xs:string" />
+        <xs:element name="refresh_expires_in" type="xs:int" />
+        <xs:element name="token_type" type="xs:string" />
+        <xs:element name="role" type="xs:string" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/Microservicios/schemas/media_item.schema.json
+++ b/Microservicios/schemas/media_item.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MediaItem",
+  "type": "object",
+  "required": ["media_id", "gcs_path", "mime_type", "size_bytes", "owner_user_id", "created_at"],
+  "properties": {
+    "media_id": {"type": "string"},
+    "gcs_path": {"type": "string"},
+    "mime_type": {"type": "string"},
+    "size_bytes": {"type": "integer", "minimum": 0},
+    "owner_user_id": {"type": "string"},
+    "signed_url": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/media_item.xsd
+++ b/Microservicios/schemas/media_item.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="MediaItem">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="media_id" type="xs:string" />
+        <xs:element name="gcs_path" type="xs:string" />
+        <xs:element name="mime_type" type="xs:string" />
+        <xs:element name="size_bytes" type="xs:int" />
+        <xs:element name="owner_user_id" type="xs:string" />
+        <xs:element name="signed_url" type="xs:string" minOccurs="0" />
+        <xs:element name="created_at" type="xs:dateTime" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/Microservicios/schemas/organization.schema.json
+++ b/Microservicios/schemas/organization.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Organization",
+  "type": "object",
+  "required": ["name", "logo_url", "policies", "settings"],
+  "properties": {
+    "name": {"type": "string", "minLength": 1},
+    "logo_url": {"type": "string"},
+    "policies": {"type": "string"},
+    "settings": {
+      "type": "object",
+      "properties": {
+        "alert_threshold_bpm": {"type": "integer", "minimum": 30, "maximum": 250},
+        "timezone": {"type": "string"}
+      },
+      "required": ["alert_threshold_bpm", "timezone"],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/organization.xsd
+++ b/Microservicios/schemas/organization.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="Organization">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="name" type="xs:string" />
+        <xs:element name="logo_url" type="xs:string" />
+        <xs:element name="policies" type="xs:string" />
+        <xs:element name="settings">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="alert_threshold_bpm" type="xs:int" />
+              <xs:element name="timezone" type="xs:string" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/Microservicios/schemas/timeseries.schema.json
+++ b/Microservicios/schemas/timeseries.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TimeSeriesWrite",
+  "type": "object",
+  "required": ["measurement", "tags", "fields", "timestamp"],
+  "properties": {
+    "measurement": {"type": "string"},
+    "tags": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "fields": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {"type": "number"},
+          {"type": "boolean"},
+          {"type": "string"}
+        ]
+      }
+    },
+    "timestamp": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/timeseries.xsd
+++ b/Microservicios/schemas/timeseries.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="TimeSeriesWrite">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="measurement" type="xs:string" />
+        <xs:element name="tags">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="fields">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="timestamp" type="xs:dateTime" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/Microservicios/schemas/user.schema.json
+++ b/Microservicios/schemas/user.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "User",
+  "type": "object",
+  "required": ["user_id", "email", "name", "org_id", "role"],
+  "properties": {
+    "user_id": {"type": "string"},
+    "email": {"type": "string", "format": "email"},
+    "name": {"type": "string", "minLength": 1},
+    "phone": {"type": ["string", "null"]},
+    "preferences": {
+      "type": "object",
+      "properties": {
+        "language": {"type": "string"},
+        "units": {"type": "string"}
+      },
+      "required": ["language", "units"],
+      "additionalProperties": false
+    },
+    "org_id": {"type": "string"},
+    "role": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/Microservicios/schemas/user.xsd
+++ b/Microservicios/schemas/user.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="User">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="user_id" type="xs:string" />
+        <xs:element name="email" type="xs:string" />
+        <xs:element name="name" type="xs:string" />
+        <xs:element name="phone" type="xs:string" minOccurs="0" />
+        <xs:element name="preferences">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="language" type="xs:string" />
+              <xs:element name="units" type="xs:string" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="org_id" type="xs:string" />
+        <xs:element name="role" type="xs:string" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/Microservicios/start_services.bat
+++ b/Microservicios/start_services.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal enabledelayedexpansion
+cd /d %~dp0
+
+echo [Heartguard] Starting services with docker-compose...
+docker-compose up -d
+
+echo [Heartguard] Current containers:
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+endlocal

--- a/Microservicios/start_services.sh
+++ b/Microservicios/start_services.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+echo "[Heartguard] Starting services with docker-compose..."
+docker-compose up -d
+
+echo "[Heartguard] Current containers:"
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"

--- a/Microservicios/stop_services.bat
+++ b/Microservicios/stop_services.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal enabledelayedexpansion
+cd /d %~dp0
+
+echo [Heartguard] Stopping services...
+docker-compose down
+endlocal

--- a/Microservicios/stop_services.sh
+++ b/Microservicios/stop_services.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+echo "[Heartguard] Stopping services..."
+docker-compose down

--- a/Microservicios/timeseries/Dockerfile
+++ b/Microservicios/timeseries/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 5005
+
+CMD ["python", "app.py"]

--- a/Microservicios/timeseries/app.py
+++ b/Microservicios/timeseries/app.py
@@ -1,0 +1,135 @@
+import os
+
+from flask import Flask, g, request
+
+from .error_handler import register_error_handlers
+from .influx_client import ping, query_aggregated, write_line_protocol, write_point
+from .middleware import get_metrics, init_app
+from .utils_format import error_response, make_response, parse_body
+
+app = Flask(__name__)
+init_app(app)
+register_error_handlers(app)
+
+ALLOWED_WRITE_ROLES = {"admin", "system", "device"}
+ALLOWED_QUERY_ROLES = {"admin", "org_admin", "user", "system"}
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return make_response({"status": "ok", "service": "timeseries"})
+
+
+@app.route("/ready", methods=["GET"])
+def ready():
+    is_ready = ping()
+    status = 200 if is_ready else 503
+    return make_response({"status": "ready" if is_ready else "degraded", "dependencies": {"influx": is_ready}}, status=status)
+
+
+@app.route("/metrics", methods=["GET"])
+def metrics():
+    return make_response(get_metrics(), root_tag="Metrics")
+
+
+def _format_flux_time(value: str, default: str) -> str:
+    if not value:
+        return default
+    if value.startswith("-") or value.endswith("()"):
+        return value
+    return f'time(v: "{value}")'
+
+
+# POST /timeseries/write
+# JSON/XML request:
+# {
+#   "measurement": "heart_rate",
+#   "tags": {"user_id": "42", "device_id": "abc"},
+#   "fields": {"bpm": 87.5, "hrv": 42.1},
+#   "timestamp": "2025-10-29T18:07:00Z"
+# }
+# Response:
+# {"status": "accepted"}
+@app.route("/timeseries/write", methods=["POST"])
+def timeseries_write():
+    role = g.get("user_role")
+    if role not in ALLOWED_WRITE_ROLES:
+        return error_response(403, "Forbidden for role")
+    if request.headers.get("Content-Type", "").startswith("text/plain"):
+        payload = request.get_data().decode("utf-8")
+        if not payload.strip():
+            return error_response(400, "Empty payload")
+        try:
+            write_line_protocol(payload)
+        except Exception as exc:  # pragma: no cover - depends on Influx
+            return error_response(500, "Failed to write line protocol", str(exc))
+        return make_response({"status": "accepted"}, status=202, root_tag="TimeSeriesWriteResponse")
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    required = ["measurement", "tags", "fields", "timestamp"]
+    missing = [field for field in required if field not in body]
+    if missing:
+        return error_response(400, f"Missing fields: {', '.join(missing)}")
+    if "user_id" not in body.get("tags", {}):
+        return error_response(400, "tags.user_id is required")
+    try:
+        write_point(body["measurement"], dict(body["tags"]), dict(body["fields"]), body["timestamp"])
+    except Exception as exc:  # pragma: no cover
+        return error_response(500, "Failed to write point", str(exc))
+    return make_response({"status": "accepted"}, status=202, root_tag="TimeSeriesWriteResponse")
+
+
+# GET /timeseries/query?measurement=heart_rate&user_id=42&start=-1h&agg=mean&window=1m
+# Response JSON/XML:
+# {
+#   "series": [
+#     {"time": "2025-10-29T18:07:00Z", "bpm_mean": 87.5}
+#   ],
+#   "page": 1,
+#   "next_page": 2,
+#   "window": "1m",
+#   "agg": "mean",
+#   "measurement": "heart_rate",
+#   "user_id": "42"
+# }
+@app.route("/timeseries/query", methods=["GET"])
+def timeseries_query():
+    role = g.get("user_role")
+    if role not in ALLOWED_QUERY_ROLES:
+        return error_response(403, "Forbidden for role")
+    measurement = request.args.get("measurement")
+    user_id = request.args.get("user_id") or g.get("user_id")
+    if not measurement or not user_id:
+        return error_response(400, "measurement and user_id are required")
+    if role == "user" and user_id != g.get("user_id"):
+        return error_response(403, "Users may only query their own data")
+    start_raw = request.args.get("start")
+    end_raw = request.args.get("end")
+    window = request.args.get("window", "1m")
+    agg = request.args.get("agg", "mean")
+    limit = int(request.args.get("limit", "100"))
+    page = int(request.args.get("page", "1"))
+    start = _format_flux_time(start_raw, "-1h")
+    end = _format_flux_time(end_raw, "now()")
+    try:
+        data = query_aggregated(measurement, user_id, start, end, window, agg, limit, page)
+    except Exception as exc:  # pragma: no cover
+        return error_response(500, "Failed to query timeseries", str(exc))
+    next_page = page + 1 if len(data) == limit else None
+    response_body = {
+        "series": data,
+        "page": page,
+        "next_page": next_page,
+        "window": window,
+        "agg": agg,
+        "measurement": measurement,
+        "user_id": user_id,
+    }
+    return make_response(response_body, root_tag="TimeSeriesQueryResult")
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("TIMESERIES_PORT", "5005"))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/timeseries/error_handler.py
+++ b/Microservicios/timeseries/error_handler.py
@@ -1,0 +1,15 @@
+from werkzeug.exceptions import HTTPException
+from flask import Flask
+
+from .utils_format import error_response
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http(exc: HTTPException):
+        return error_response(exc.code or 500, exc.description)
+
+    @app.errorhandler(Exception)
+    def handle_generic(exc: Exception):  # pragma: no cover
+        app.logger.exception("Unhandled error")
+        return error_response(500, "Internal server error")

--- a/Microservicios/timeseries/influx_client.py
+++ b/Microservicios/timeseries/influx_client.py
@@ -1,0 +1,84 @@
+"""InfluxDB client helpers for the timeseries service."""
+import os
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from influxdb_client import InfluxDBClient, Point
+from influxdb_client.client.write_api import SYNCHRONOUS
+
+INFLUX_TOKEN = os.getenv("INFLUX_TOKEN", "")
+INFLUX_ORG = os.getenv("INFLUX_ORG", "heartguard-org")
+INFLUX_BUCKET = os.getenv("INFLUX_BUCKET", "heartguard-metrics")
+INFLUX_INTERNAL_URL = os.getenv("INFLUX_INTERNAL_URL", "http://influxdb:8086")
+
+_client: Optional[InfluxDBClient] = None
+
+
+def get_client() -> InfluxDBClient:
+    global _client
+    if _client is None:
+        _client = InfluxDBClient(url=INFLUX_INTERNAL_URL, token=INFLUX_TOKEN, org=INFLUX_ORG, timeout=10_000)
+    return _client
+
+
+def write_point(measurement: str, tags: Dict[str, str], fields: Dict, timestamp: str) -> None:
+    client = get_client()
+    write_api = client.write_api(write_options=SYNCHRONOUS)
+    point = Point(measurement)
+    for key, value in tags.items():
+        point = point.tag(key, str(value))
+    for key, value in fields.items():
+        point = point.field(key, value)
+    try:
+        dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        point = point.time(dt)
+    except ValueError:
+        pass
+    write_api.write(bucket=INFLUX_BUCKET, record=point)
+
+
+def write_line_protocol(payload: str) -> None:
+    client = get_client()
+    write_api = client.write_api(write_options=SYNCHRONOUS)
+    write_api.write(bucket=INFLUX_BUCKET, record=payload)
+
+
+def query_aggregated(
+    measurement: str,
+    user_id: str,
+    start: str,
+    end: str,
+    window: str,
+    agg: str,
+    limit: int,
+    page: int,
+) -> List[Dict]:
+    client = get_client()
+    query_api = client.query_api()
+    offset = (page - 1) * limit
+    flux = f'''
+from(bucket: "{INFLUX_BUCKET}")
+  |> range(start: {start}, stop: {end})
+  |> filter(fn: (r) => r["_measurement"] == "{measurement}")
+  |> filter(fn: (r) => r["user_id"] == "{user_id}")
+  |> aggregateWindow(every: {window}, fn: {agg}, createEmpty: false)
+  |> sort(columns: ["_time"])
+  |> limit(n: {limit}, offset: {offset})
+'''
+    tables = query_api.query(flux)
+    results: Dict[str, Dict] = {}
+    for table in tables:
+        for record in table.records:
+            time_key = record.get_time().isoformat()
+            entry = results.setdefault(time_key, {"time": time_key})
+            field_name = f"{record.get_field()}_{agg}"
+            entry[field_name] = record.get_value()
+    ordered = [results[key] for key in sorted(results.keys())]
+    return ordered
+
+
+def ping() -> bool:
+    try:
+        return bool(get_client().ping())
+    except Exception:
+        return False

--- a/Microservicios/timeseries/middleware.py
+++ b/Microservicios/timeseries/middleware.py
@@ -1,0 +1,62 @@
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict
+
+from flask import Flask, g, request
+
+from .utils_format import error_response
+
+SERVICE_NAME = "timeseries"
+MAX_BODY_BYTES = int(os.getenv("MAX_JSON_BODY_BYTES", "1048576"))
+REQUEST_STATS: Dict[str, Any] = {
+    "count": 0,
+    "total_latency_ms": 0.0,
+    "start_time": time.time(),
+}
+
+
+def init_app(app: Flask) -> None:
+    @app.before_request
+    def _before_request():
+        g.start_time = time.time()
+        g.request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        g.user_id = request.headers.get("X-User-ID")
+        g.user_role = request.headers.get("X-User-Role")
+        g.org_id = request.headers.get("X-Org-ID")
+        if request.content_length and request.content_length > MAX_BODY_BYTES:
+            return error_response(413, "Payload too large")
+
+    @app.after_request
+    def _after_request(response):
+        latency_ms = int((time.time() - getattr(g, "start_time", time.time())) * 1000)
+        REQUEST_STATS["count"] += 1
+        REQUEST_STATS["total_latency_ms"] += latency_ms
+        response.headers["X-Request-ID"] = getattr(g, "request_id", "")
+        log_entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "service": SERVICE_NAME,
+            "request_id": getattr(g, "request_id", ""),
+            "method": request.method,
+            "path": request.path,
+            "status": response.status_code,
+            "latency_ms": latency_ms,
+            "ip": request.headers.get("X-Forwarded-For", request.remote_addr),
+            "user_id": getattr(g, "user_id", None),
+            "role": getattr(g, "user_role", None),
+        }
+        app.logger.info(json.dumps(log_entry, ensure_ascii=False))
+        return response
+
+
+def get_metrics() -> Dict[str, Any]:
+    uptime_seconds = time.time() - REQUEST_STATS["start_time"]
+    count = REQUEST_STATS["count"] or 1
+    avg_latency = REQUEST_STATS["total_latency_ms"] / count
+    return {
+        "service": SERVICE_NAME,
+        "requests_total": REQUEST_STATS["count"],
+        "avg_latency_ms": round(avg_latency, 2),
+        "uptime_seconds": int(uptime_seconds),
+    }

--- a/Microservicios/timeseries/requirements.txt
+++ b/Microservicios/timeseries/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.3
+influxdb-client==1.41.0
+xmltodict==0.13.0
+dicttoxml==1.7.16

--- a/Microservicios/timeseries/utils_format.py
+++ b/Microservicios/timeseries/utils_format.py
@@ -1,0 +1,65 @@
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Tuple
+
+from dicttoxml import dicttoxml
+from flask import Response, g, request
+import xmltodict
+
+DEFAULT_ROOT = "response"
+
+
+def _negotiate() -> str:
+    accept = request.headers.get("Accept", "application/json")
+    if "application/xml" in accept.lower():
+        return "xml"
+    return "json"
+
+
+def parse_body() -> Tuple[Dict[str, Any], str]:
+    content_type = request.headers.get("Content-Type", "application/json").lower()
+    raw = request.get_data(cache=False) or b"{}"
+    if "application/json" in content_type:
+        try:
+            return json.loads(raw.decode("utf-8")), "json"
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON payload: {exc}")
+    if "application/xml" in content_type:
+        try:
+            parsed = xmltodict.parse(raw)
+            if isinstance(parsed, dict) and len(parsed) == 1:
+                parsed = next(iter(parsed.values()))
+            return dict(parsed), "xml"
+        except Exception as exc:
+            raise ValueError(f"Invalid XML payload: {exc}")
+    raise ValueError("Unsupported Content-Type. Use application/json or application/xml")
+
+
+def _to_xml(data: Any, root_tag: str) -> bytes:
+    if not isinstance(data, dict):
+        data = {"data": data}
+    return dicttoxml(data, custom_root=root_tag, attr_type=False)
+
+
+def make_response(data: Dict[str, Any], status: int = 200, root_tag: str = DEFAULT_ROOT) -> Response:
+    fmt = _negotiate()
+    if fmt == "xml":
+        payload = _to_xml(data, root_tag=root_tag)
+        return Response(payload, status=status, mimetype="application/xml")
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return Response(payload, status=status, mimetype="application/json")
+
+
+def error_response(code: int, message: str, details: Any = None) -> Response:
+    request_id = getattr(g, "request_id", None)
+    body = {
+        "error": {
+            "code": code,
+            "message": message,
+            "request_id": request_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    if details is not None:
+        body["error"]["details"] = details
+    return make_response(body, status=code, root_tag="Error")

--- a/Microservicios/user/Dockerfile
+++ b/Microservicios/user/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 5003
+
+CMD ["python", "app.py"]

--- a/Microservicios/user/app.py
+++ b/Microservicios/user/app.py
@@ -1,0 +1,78 @@
+import os
+
+from flask import Flask, g
+
+from .error_handler import register_error_handlers
+from .middleware import get_metrics, init_app
+from .models import get_user, update_user
+from .utils_format import error_response, make_response, parse_body
+
+app = Flask(__name__)
+init_app(app)
+register_error_handlers(app)
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return make_response({"status": "ok", "service": "user"})
+
+
+@app.route("/ready", methods=["GET"])
+def ready():
+    return make_response({"status": "ready"})
+
+
+@app.route("/metrics", methods=["GET"])
+def metrics():
+    return make_response(get_metrics(), root_tag="Metrics")
+
+
+# GET /user/me
+# Response JSON/XML:
+# {
+#   "user": {
+#     "user_id": "123",
+#     "email": "demo@heartguard.com",
+#     "name": "Demo User",
+#     "phone": "+52-555-0101",
+#     "preferences": {
+#       "language": "es-MX",
+#       "units": "metric"
+#     },
+#     "org_id": "default",
+#     "role": "user"
+#   }
+# }
+@app.route("/user/me", methods=["GET"])
+def get_me():
+    user_id = g.get("user_id")
+    if not user_id:
+        return error_response(401, "Missing user identity")
+    profile = get_user(user_id)
+    return make_response({"user": profile}, root_tag="UserProfile")
+
+
+# PUT /user/me
+# Request JSON/XML:
+# {
+#   "name": "Nuevo Nombre",
+#   "phone": "+52-555-9999",
+#   "preferences": {"language": "es-MX", "units": "metric"}
+# }
+# Response mirrors the updated profile.
+@app.route("/user/me", methods=["PUT"])
+def update_me():
+    user_id = g.get("user_id")
+    if not user_id:
+        return error_response(401, "Missing user identity")
+    try:
+        body, _ = parse_body()
+    except ValueError as exc:
+        return error_response(400, str(exc))
+    profile = update_user(user_id, body)
+    return make_response({"user": profile}, root_tag="UserProfile")
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("USER_PORT", "5003"))
+    app.run(host="0.0.0.0", port=port)

--- a/Microservicios/user/error_handler.py
+++ b/Microservicios/user/error_handler.py
@@ -1,0 +1,15 @@
+from werkzeug.exceptions import HTTPException
+from flask import Flask
+
+from .utils_format import error_response
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http(exc: HTTPException):
+        return error_response(exc.code or 500, exc.description)
+
+    @app.errorhandler(Exception)
+    def handle_generic(exc: Exception):  # pragma: no cover
+        app.logger.exception("Unhandled error")
+        return error_response(500, "Internal server error")

--- a/Microservicios/user/middleware.py
+++ b/Microservicios/user/middleware.py
@@ -1,0 +1,62 @@
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict
+
+from flask import Flask, g, request
+
+from .utils_format import error_response
+
+SERVICE_NAME = "user"
+MAX_BODY_BYTES = int(os.getenv("MAX_JSON_BODY_BYTES", "1048576"))
+REQUEST_STATS: Dict[str, Any] = {
+    "count": 0,
+    "total_latency_ms": 0.0,
+    "start_time": time.time(),
+}
+
+
+def init_app(app: Flask) -> None:
+    @app.before_request
+    def _before_request():
+        g.start_time = time.time()
+        g.request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        g.user_id = request.headers.get("X-User-ID")
+        g.user_role = request.headers.get("X-User-Role")
+        g.org_id = request.headers.get("X-Org-ID")
+        if request.content_length and request.content_length > MAX_BODY_BYTES:
+            return error_response(413, "Payload too large")
+
+    @app.after_request
+    def _after_request(response):
+        latency_ms = int((time.time() - getattr(g, "start_time", time.time())) * 1000)
+        REQUEST_STATS["count"] += 1
+        REQUEST_STATS["total_latency_ms"] += latency_ms
+        response.headers["X-Request-ID"] = getattr(g, "request_id", "")
+        log_entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "service": SERVICE_NAME,
+            "request_id": getattr(g, "request_id", ""),
+            "method": request.method,
+            "path": request.path,
+            "status": response.status_code,
+            "latency_ms": latency_ms,
+            "ip": request.headers.get("X-Forwarded-For", request.remote_addr),
+            "user_id": getattr(g, "user_id", None),
+            "role": getattr(g, "user_role", None),
+        }
+        app.logger.info(json.dumps(log_entry, ensure_ascii=False))
+        return response
+
+
+def get_metrics() -> Dict[str, Any]:
+    uptime_seconds = time.time() - REQUEST_STATS["start_time"]
+    count = REQUEST_STATS["count"] or 1
+    avg_latency = REQUEST_STATS["total_latency_ms"] / count
+    return {
+        "service": SERVICE_NAME,
+        "requests_total": REQUEST_STATS["count"],
+        "avg_latency_ms": round(avg_latency, 2),
+        "uptime_seconds": int(uptime_seconds),
+    }

--- a/Microservicios/user/models.py
+++ b/Microservicios/user/models.py
@@ -1,0 +1,37 @@
+"""In-memory user profile storage.
+TODO: replace with persistent storage in future iterations.
+"""
+from typing import Dict
+
+USERS: Dict[str, Dict] = {}
+
+DEFAULT_PROFILE = {
+    "email": "demo@heartguard.com",
+    "name": "Demo User",
+    "phone": "+52-555-0101",
+    "preferences": {"language": "es-MX", "units": "metric"},
+    "org_id": "default",
+    "role": "user",
+}
+
+
+def get_user(user_id: str) -> Dict:
+    record = USERS.get(user_id)
+    if not record:
+        # Fallback to default profile clone
+        record = {**DEFAULT_PROFILE, "user_id": user_id}
+        USERS[user_id] = record
+    return record
+
+
+def update_user(user_id: str, payload: Dict) -> Dict:
+    profile = get_user(user_id)
+    for key in ["email", "name", "phone"]:
+        if key in payload:
+            profile[key] = str(payload[key]).strip()
+    if "preferences" in payload and isinstance(payload["preferences"], dict):
+        prefs = profile.setdefault("preferences", {})
+        for pref_key in ["language", "units"]:
+            if pref_key in payload["preferences"]:
+                prefs[pref_key] = str(payload["preferences"][pref_key]).strip()
+    return profile

--- a/Microservicios/user/requirements.txt
+++ b/Microservicios/user/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.3
+xmltodict==0.13.0
+dicttoxml==1.7.16

--- a/Microservicios/user/utils_format.py
+++ b/Microservicios/user/utils_format.py
@@ -1,0 +1,65 @@
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Tuple
+
+from dicttoxml import dicttoxml
+from flask import Response, g, request
+import xmltodict
+
+DEFAULT_ROOT = "response"
+
+
+def _negotiate() -> str:
+    accept = request.headers.get("Accept", "application/json")
+    if "application/xml" in accept.lower():
+        return "xml"
+    return "json"
+
+
+def parse_body() -> Tuple[Dict[str, Any], str]:
+    content_type = request.headers.get("Content-Type", "application/json").lower()
+    raw = request.get_data(cache=False) or b"{}"
+    if "application/json" in content_type:
+        try:
+            return json.loads(raw.decode("utf-8")), "json"
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON payload: {exc}")
+    if "application/xml" in content_type:
+        try:
+            parsed = xmltodict.parse(raw)
+            if isinstance(parsed, dict) and len(parsed) == 1:
+                parsed = next(iter(parsed.values()))
+            return dict(parsed), "xml"
+        except Exception as exc:
+            raise ValueError(f"Invalid XML payload: {exc}")
+    raise ValueError("Unsupported Content-Type. Use application/json or application/xml")
+
+
+def _to_xml(data: Any, root_tag: str) -> bytes:
+    if not isinstance(data, dict):
+        data = {"data": data}
+    return dicttoxml(data, custom_root=root_tag, attr_type=False)
+
+
+def make_response(data: Dict[str, Any], status: int = 200, root_tag: str = DEFAULT_ROOT) -> Response:
+    fmt = _negotiate()
+    if fmt == "xml":
+        payload = _to_xml(data, root_tag=root_tag)
+        return Response(payload, status=status, mimetype="application/xml")
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return Response(payload, status=status, mimetype="application/json")
+
+
+def error_response(code: int, message: str, details: Any = None) -> Response:
+    request_id = getattr(g, "request_id", None)
+    body = {
+        "error": {
+            "code": code,
+            "message": message,
+            "request_id": request_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    if details is not None:
+        body["error"]["details"] = details
+    return make_response(body, status=code, root_tag="Error")

--- a/Microservicios/validate_endpoints.bat
+++ b/Microservicios/validate_endpoints.bat
@@ -1,0 +1,42 @@
+@echo off
+setlocal enabledelayedexpansion
+if "%~1"=="" (
+  echo Usage: %0 ^<host^>
+  exit /b 1
+)
+set HOST=%~1
+set SERVICES=gateway:5000 auth:5001 organization:5002 user:5003 media:5004 timeseries:5005 audit:5006
+
+echo ==============================================
+echo Validating Heartguard endpoints on %HOST%
+echo ==============================================
+for %%S in (%SERVICES%) do (
+  for /f "tokens=1,2 delims=:" %%A in ("%%S") do (
+    set NAME=%%A
+    set PORT=%%B
+    for %%F in (application/json application/xml) do (
+      set ACCEPT=%%F
+      for /f "tokens=1-2 delims==" %%L in ('powershell -NoLogo -NoProfile -Command "\
+        $stopwatch=[System.Diagnostics.Stopwatch]::StartNew();\
+        $resp=Invoke-WebRequest -Uri ('http://%HOST%:'+"%PORT%"+'/health') -Headers @{'Accept'='%ACCEPT%'} -UseBasicParsing;\
+        $stopwatch.Stop();\
+        $lat=[math]::Round($stopwatch.Elapsed.TotalMilliseconds);\
+        $body=$resp.Content;\
+        $status=[int]$resp.StatusCode;\
+        Write-Output ('latency='+$lat);\
+        Write-Output ('status='+$status);\
+        Write-Output ('body='+$body.Replace("`r`n",""));"') do (
+        if %%L==latency set LATENCY=%%M
+        if %%L==status set STATUS=%%M
+        if %%L==body set BODY=%%M
+      )
+      if "!STATUS!"=="200" (set RESULT=OK) else (set RESULT=FAIL)
+      echo [!NAME!][!ACCEPT!] code=!STATUS! latency_ms=!LATENCY! status=!RESULT!
+      echo !BODY!
+      echo ----------------------------------------------
+    )
+    echo.
+    echo ==============================================
+  )
+)
+endlocal

--- a/Microservicios/validate_endpoints.sh
+++ b/Microservicios/validate_endpoints.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <host>"
+  exit 1
+fi
+HOST=$1
+SERVICES=("gateway:5000" "auth:5001" "organization:5002" "user:5003" "media:5004" "timeseries:5005" "audit:5006")
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+echo "=============================================="
+echo "Validating Heartguard endpoints on $HOST"
+echo "=============================================="
+for svc in "${SERVICES[@]}"; do
+  name=${svc%%:*}
+  port=${svc##*:}
+  for accept in "application/json" "application/xml"; do
+    start=$(date +%s%3N)
+    response=$(curl -s -w "HTTPSTATUS:%{http_code}" -H "Accept: $accept" "http://$HOST:$port/health")
+    end=$(date +%s%3N)
+    body=${response%%HTTPSTATUS:*}
+    status=${response##*HTTPSTATUS:}
+    latency=$((end - start))
+    if [ "$status" = "200" ]; then
+      result="OK"
+    else
+      result="FAIL"
+    fi
+    echo "[$name][$accept] code=$status latency_ms=$latency status=$result"
+    echo "$body"
+    echo "----------------------------------------------"
+  done
+  echo
+  echo "=============================================="
+done


### PR DESCRIPTION
## Summary
- create the Heartguard Microservicios backend with Flask gateway, auth, organization, user, media, timeseries, and audit services supporting JSON/XML negotiation, structured logging, JWT auth, health/ready/metrics, and rate limiting
- add docker-compose orchestration, environment example, JSON/XSD schemas, and helper scripts for starting, stopping, and validating the stack on Windows and Linux
- wire integrations for Redis-backed tokens, Google Cloud Storage media handling, and InfluxDB time-series ingestion/querying with RBAC enforcement

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902bb2d2ab48323be3f6c0a0d80e6a5