### PR TITLE
Remove preferences option from user menu

### DIFF
--- a/frontend/alerts.html
+++ b/frontend/alerts.html
@@ -70,12 +70,12 @@
           </div>
           <div class="topbar__actions">
             <div class="topbar__user">
+              <a class="topbar__preferences" href="profile.html">Preferencias de la cuenta</a>
               <button class="user-menu__button" type="button" data-user-menu-button aria-expanded="false">
                 <span class="status-dot status-dot--success"></span>
                 Mi cuenta
               </button>
               <ul class="user-menu__list" data-user-menu aria-hidden="true">
-                <li><button type="button" onclick="window.location.href='profile.html'">Preferencias</button></li>
                 <li><button type="button" data-logout>Cerrar sesión</button></li>
               </ul>
             </div>

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -261,6 +261,25 @@ body.auth-layout {
 
 .topbar__user {
   position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.topbar__preferences {
+  color: var(--color-primary);
+  font-weight: 500;
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.topbar__preferences:focus,
+.topbar__preferences:hover {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary-dark, var(--color-primary));
+  outline: none;
 }
 
 .user-menu__button {

--- a/frontend/devices.html
+++ b/frontend/devices.html
@@ -70,12 +70,12 @@
           </div>
           <div class="topbar__actions">
             <div class="topbar__user">
+              <a class="topbar__preferences" href="profile.html">Preferencias de la cuenta</a>
               <button class="user-menu__button" type="button" data-user-menu-button aria-expanded="false">
                 <span class="status-dot status-dot--success"></span>
                 Mi cuenta
               </button>
               <ul class="user-menu__list" data-user-menu aria-hidden="true">
-                <li><button type="button" onclick="window.location.href='profile.html'">Preferencias</button></li>
                 <li><button type="button" data-logout>Cerrar sesión</button></li>
               </ul>
             </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,12 +74,12 @@
               <span data-critical-indicator>0</span> alertas críticas
             </div>
             <div class="topbar__user">
+              <a class="topbar__preferences" href="profile.html">Preferencias de la cuenta</a>
               <button class="user-menu__button" type="button" data-user-menu-button aria-expanded="false">
                 <span class="status-dot status-dot--success"></span>
                 Mi cuenta
               </button>
               <ul class="user-menu__list" data-user-menu aria-hidden="true">
-                <li><button type="button" onclick="window.location.href='profile.html'">Preferencias</button></li>
                 <li><button type="button" data-logout>Cerrar sesión</button></li>
               </ul>
             </div>

--- a/frontend/invitations.html
+++ b/frontend/invitations.html
@@ -70,12 +70,12 @@
           </div>
           <div class="topbar__actions">
             <div class="topbar__user">
+              <a class="topbar__preferences" href="profile.html">Preferencias de la cuenta</a>
               <button class="user-menu__button" type="button" data-user-menu-button aria-expanded="false">
                 <span class="status-dot status-dot--success"></span>
                 Mi cuenta
               </button>
               <ul class="user-menu__list" data-user-menu aria-hidden="true">
-                <li><button type="button" onclick="window.location.href='profile.html'">Preferencias</button></li>
                 <li><button type="button" data-logout>Cerrar sesión</button></li>
               </ul>
             </div>

--- a/frontend/organization.html
+++ b/frontend/organization.html
@@ -70,12 +70,12 @@
           </div>
           <div class="topbar__actions">
             <div class="topbar__user">
+              <a class="topbar__preferences" href="profile.html">Preferencias de la cuenta</a>
               <button class="user-menu__button" type="button" data-user-menu-button aria-expanded="false">
                 <span class="status-dot status-dot--success"></span>
                 Mi cuenta
               </button>
               <ul class="user-menu__list" data-user-menu aria-hidden="true">
-                <li><button type="button" onclick="window.location.href='profile.html'">Preferencias</button></li>
                 <li><button type="button" data-logout>Cerrar sesión</button></li>
               </ul>
             </div>

--- a/frontend/patients.html
+++ b/frontend/patients.html
@@ -70,12 +70,12 @@
           </div>
           <div class="topbar__actions">
             <div class="topbar__user">
+              <a class="topbar__preferences" href="profile.html">Preferencias de la cuenta</a>
               <button class="user-menu__button" type="button" data-user-menu-button aria-expanded="false">
                 <span class="status-dot status-dot--success"></span>
                 Mi cuenta
               </button>
               <ul class="user-menu__list" data-user-menu aria-hidden="true">
-                <li><button type="button" onclick="window.location.href='profile.html'">Preferencias</button></li>
                 <li><button type="button" data-logout>Cerrar sesión</button></li>
               </ul>
             </div>

--- a/frontend/users.html
+++ b/frontend/users.html
@@ -70,12 +70,12 @@
           </div>
           <div class="topbar__actions">
             <div class="topbar__user">
+              <a class="topbar__preferences" href="profile.html">Preferencias de la cuenta</a>
               <button class="user-menu__button" type="button" data-user-menu-button aria-expanded="false">
                 <span class="status-dot status-dot--success"></span>
                 Mi cuenta
               </button>
               <ul class="user-menu__list" data-user-menu aria-hidden="true">
-                <li><button type="button" onclick="window.location.href='profile.html'">Preferencias</button></li>
                 <li><button type="button" data-logout>Cerrar sesión</button></li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary
- replace the preferences button in the topbar user menu with an inline account link across the dashboard templates
- keep only the logout action inside the user dropdown and style the new preferences link

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_6905acbbca1c8322816763739ddc1278