### PR TITLE
feat: implement organization invitations endpoints

### DIFF
--- a/Microservicios/organization_service/README.md
+++ b/Microservicios/organization_service/README.md
@@ -1,0 +1,92 @@
+# Organization Service
+
+Este microservicio gestiona entidades de organización, incluyendo la emisión y ciclo de vida de invitaciones.
+
+## Endpoints relevantes
+
+### `GET /organization/invitations`
+
+Lista invitaciones existentes. Parámetros:
+
+- `org_id` (opcional): UUID de la organización para filtrar resultados.
+
+Respuesta de ejemplo:
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "invitations": [
+      {
+        "id": "8f6a…",
+        "org_id": "d91c…",
+        "email": "user@example.com",
+        "role": "org_admin",
+        "status": "pending",
+        "token": "fc3b…",
+        "created_at": "2024-05-18T12:00:00+00:00",
+        "expires_at": "2024-05-20T12:00:00+00:00",
+        "used_at": null,
+        "revoked_at": null
+      }
+    ]
+  },
+  "meta": {"total": 1}
+}
+```
+
+### `POST /organization/invitations`
+
+Crea una invitación para una organización. Cuerpo JSON o XML con los campos:
+
+- `org_id` (UUID) – requerido.
+- `role` u `org_role_id` – requerido. Puede ser el código o el UUID del rol.
+- `email` (opcional) – correo de la persona invitada.
+- `ttl_hours` (int) – requerido, entre 1 y 720.
+
+Ejemplo JSON:
+
+```json
+{
+  "org_id": "d91c…",
+  "role": "org_admin",
+  "email": "user@example.com",
+  "ttl_hours": 24
+}
+```
+
+Respuesta `201 Created`:
+
+```json
+{
+  "status": "success",
+  "code": 201,
+  "data": {
+    "invitation": {
+      "id": "8f6a…",
+      "org_id": "d91c…",
+      "email": "user@example.com",
+      "role": "org_admin",
+      "status": "pending",
+      "token": "fc3b…",
+      "created_at": "2024-05-18T12:00:00+00:00",
+      "expires_at": "2024-05-19T12:00:00+00:00",
+      "used_at": null,
+      "revoked_at": null
+    }
+  }
+}
+```
+
+### `POST /organization/invitations/<invitation_id>/cancel`
+
+Revoca una invitación pendiente. No acepta cuerpo. Devuelve `204 No Content` si la invitación estaba activa. Las invitaciones ya usadas o canceladas responden `404`.
+
+## Modelos
+
+El servicio define modelos SQLAlchemy para `organizations`, `org_roles`, `users` (mínimo) y `org_invitations`, con propiedades convenientes para serializar el estado de las invitaciones y su relación con organizaciones y roles.
+
+## Pruebas
+
+Ejecuta `pytest` desde la raíz del proyecto para validar la lógica del servicio.

--- a/Microservicios/organization_service/models.py
+++ b/Microservicios/organization_service/models.py
@@ -1,14 +1,27 @@
 """Database models for the organization service."""
 from __future__ import annotations
 
-from sqlalchemy.dialects.postgresql import UUID
+from datetime import datetime, timezone
 import uuid
+
+from sqlalchemy.dialects.postgresql import UUID
 
 from common.database import db
 
 
+def _utcnow() -> datetime:
+    """Return a timezone-aware UTC datetime.
+
+    SQLite (used in tests) stores naive datetimes, so we fall back to naive when
+    SQLAlchemy gives us one.
+    """
+
+    return datetime.now(timezone.utc)
+
+
 class Organization(db.Model):
     """Represents an organization, mapping to the 'organizations' table."""
+
     __tablename__ = 'organizations'
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -16,11 +29,125 @@ class Organization(db.Model):
     name = db.Column(db.String(160), nullable=False)
     created_at = db.Column(db.TIMESTAMP, nullable=False, server_default=db.func.now())
 
-    def to_dict(self):
+    invitations = db.relationship('OrgInvitation', back_populates='organization', cascade='all, delete-orphan')
+
+    def to_dict(self) -> dict[str, str]:
         """Serializes the organization object to a dictionary."""
+
+        created = self.created_at
+        if isinstance(created, datetime):
+            created_value = created if created.tzinfo else created.replace(tzinfo=timezone.utc)
+        else:  # pragma: no cover - defensive, SQLAlchemy always returns datetime
+            created_value = _utcnow()
+
         return {
             'id': str(self.id),
             'code': self.code,
             'name': self.name,
-            'created_at': self.created_at.isoformat(),
+            'created_at': created_value.isoformat(),
         }
+
+
+class User(db.Model):
+    """Minimal user model to satisfy foreign key constraints for invitations."""
+
+    __tablename__ = 'users'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+
+class OrgRole(db.Model):
+    """Organization-level role."""
+
+    __tablename__ = 'org_roles'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    code = db.Column(db.String(40), unique=True, nullable=False)
+    label = db.Column(db.String(80), nullable=False)
+
+    invitations = db.relationship('OrgInvitation', back_populates='role')
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            'id': str(self.id),
+            'code': self.code,
+            'label': self.label,
+        }
+
+
+class OrgInvitationQuery:
+    """Typed helper query for invitations."""
+
+    @staticmethod
+    def for_org(org_id: uuid.UUID | str | None):
+        query = OrgInvitation.query
+        if org_id:
+            org_uuid = uuid.UUID(str(org_id))
+            query = query.filter(OrgInvitation.org_id == org_uuid)
+        return query.order_by(OrgInvitation.created_at.desc())
+
+
+class OrgInvitation(db.Model):
+    """Invitation for a user to join an organization."""
+
+    __tablename__ = 'org_invitations'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organizations.id', ondelete='CASCADE'), nullable=False)
+    email = db.Column(db.String(150))
+    org_role_id = db.Column(UUID(as_uuid=True), db.ForeignKey('org_roles.id', ondelete='RESTRICT'), nullable=False)
+    token = db.Column(db.String(120), unique=True, nullable=False, default=lambda: uuid.uuid4().hex)
+    expires_at = db.Column(db.TIMESTAMP, nullable=False)
+    used_at = db.Column(db.TIMESTAMP)
+    revoked_at = db.Column(db.TIMESTAMP)
+    created_by = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id', ondelete='SET NULL'))
+    created_at = db.Column(db.TIMESTAMP, nullable=False, server_default=db.func.now())
+
+    organization = db.relationship('Organization', back_populates='invitations')
+    role = db.relationship('OrgRole', back_populates='invitations')
+
+    @property
+    def status(self) -> str:
+        """Derive the invitation status mirroring backend behaviour."""
+
+        if self.revoked_at:
+            return 'revoked'
+        if self.used_at:
+            return 'used'
+
+        expires = self._coerce_datetime(self.expires_at)
+        if expires <= _utcnow():
+            return 'expired'
+        return 'pending'
+
+    @staticmethod
+    def _coerce_datetime(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize invitation according to frontend expectations."""
+
+        created = self._coerce_datetime(self.created_at) or _utcnow()
+        expires = self._coerce_datetime(self.expires_at)
+        used = self._coerce_datetime(self.used_at)
+        revoked = self._coerce_datetime(self.revoked_at)
+
+        return {
+            'id': str(self.id),
+            'org_id': str(self.org_id),
+            'email': self.email,
+            'role': self.role.code if self.role else None,
+            'status': self.status,
+            'token': self.token,
+            'created_at': created.isoformat(),
+            'expires_at': expires.isoformat() if expires else None,
+            'used_at': used.isoformat() if used else None,
+            'revoked_at': revoked.isoformat() if revoked else None,
+            'org_role_id': str(self.org_role_id),
+            'created_by': str(self.created_by) if self.created_by else None,
+        }
+

--- a/Microservicios/organization_service/routes.py
+++ b/Microservicios/organization_service/routes.py
@@ -1,9 +1,10 @@
-"""models.Organization service exposing organization management endpoints."""
+"""Organization service exposing organization management endpoints."""
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 import uuid
 
-from flask import Blueprint, request
+from flask import Blueprint, Response, g, request
 
 from common.auth import require_auth
 from common.database import db
@@ -56,23 +57,123 @@ def get_organization(org_id: str) -> "Response":
 @bp.route("/invitations", methods=["GET"])
 @require_auth(optional=True)
 def list_invitations() -> "Response":
-    # This would query the 'org_invitations' table in a real application.
-    return render_response({"invitations": []}, meta={"total": 0})
+    org_id = request.args.get("org_id")
+    try:
+        invitations_query = models.OrgInvitationQuery.for_org(org_id)
+    except (TypeError, ValueError) as exc:
+        raise APIError("org_id must be a valid UUID", status_code=400, error_id="HG-ORG-INVITE-BAD-ORG") from exc
+
+    invitations = [invite.to_dict() for invite in invitations_query.all()]
+    return render_response({"invitations": invitations}, meta={"total": len(invitations)})
 
 
 @bp.route("/invitations", methods=["POST"])
 @require_auth(required_roles=["admin", "org_admin"])
 def create_invitation() -> "Response":
-    # This would create a new entry in the 'org_invitations' table.
     payload, _ = parse_request_data(request)
+    org_id = payload.get("org_id")
     email = payload.get("email")
-    if not email:
-        raise APIError("email is required", status_code=400, error_id="HG-ORG-VALIDATION")
+    role_identifier = payload.get("role") or payload.get("org_role_id")
+    ttl_value = payload.get("ttl_hours")
 
-    # Placeholder for the new invitation
-    new_invitation = {"id": str(uuid.uuid4()), "email": email}
+    if not org_id:
+        raise APIError("org_id is required", status_code=400, error_id="HG-ORG-INVITE-VALIDATION")
+    if not role_identifier:
+        raise APIError("role is required", status_code=400, error_id="HG-ORG-INVITE-VALIDATION")
+    if ttl_value is None:
+        raise APIError("ttl_hours is required", status_code=400, error_id="HG-ORG-INVITE-VALIDATION")
 
-    return render_response({"invitation": new_invitation}, status_code=201)
+    try:
+        ttl_hours = int(ttl_value)
+    except (TypeError, ValueError) as exc:
+        raise APIError("ttl_hours must be an integer", status_code=400, error_id="HG-ORG-INVITE-VALIDATION") from exc
+
+    if ttl_hours < 1 or ttl_hours > 720:
+        raise APIError("ttl_hours must be between 1 and 720", status_code=400, error_id="HG-ORG-INVITE-TTL-RANGE")
+
+    try:
+        org_uuid = uuid.UUID(str(org_id))
+    except (TypeError, ValueError) as exc:
+        raise APIError("org_id must be a valid UUID", status_code=400, error_id="HG-ORG-INVITE-BAD-ORG") from exc
+
+    organization = db.session.get(models.Organization, org_uuid)
+    if not organization:
+        raise APIError("Organization not found", status_code=404, error_id="HG-ORG-NOT-FOUND")
+
+    role = _resolve_org_role(role_identifier)
+    if not role:
+        raise APIError("Organization role not found", status_code=404, error_id="HG-ORG-ROLE-NOT-FOUND")
+
+    now = datetime.utcnow()
+    expires_at = now + timedelta(hours=ttl_hours)
+    token = uuid.uuid4().hex
+
+    created_by = None
+    current_user = getattr(g, "current_user", None)
+    if current_user:
+        created_by_val = current_user.get("sub")
+        if created_by_val:
+            try:
+                created_by = uuid.UUID(str(created_by_val))
+            except (TypeError, ValueError):
+                created_by = None
+
+    invitation = models.OrgInvitation(
+        organization=organization,
+        role=role,
+        email=email,
+        expires_at=expires_at,
+        token=token,
+        created_at=now,
+    )
+    if created_by:
+        invitation.created_by = created_by
+
+    db.session.add(invitation)
+    db.session.commit()
+
+    return render_response({"invitation": invitation.to_dict()}, status_code=201)
+
+
+@bp.route("/invitations/<invitation_id>/cancel", methods=["POST"])
+@require_auth(required_roles=["admin", "org_admin"])
+def cancel_invitation(invitation_id: str) -> "Response":
+    try:
+        invitation_uuid = uuid.UUID(str(invitation_id))
+    except (TypeError, ValueError) as exc:
+        raise APIError("invitation_id must be a valid UUID", status_code=400, error_id="HG-ORG-INVITE-BAD-ID") from exc
+
+    invitation = db.session.get(models.OrgInvitation, invitation_uuid)
+    if not invitation or invitation.revoked_at or invitation.used_at:
+        raise APIError(
+            "Invitation not found or already processed",
+            status_code=404,
+            error_id="HG-ORG-INVITE-NOT-FOUND",
+        )
+
+    invitation.revoked_at = datetime.utcnow()
+    db.session.commit()
+
+    return Response(status=204)
+
+
+def _resolve_org_role(identifier: str | None):
+    if not identifier:
+        return None
+
+    candidate = None
+    try:
+        candidate_uuid = uuid.UUID(str(identifier))
+    except (TypeError, ValueError):
+        candidate_uuid = None
+
+    if candidate_uuid:
+        candidate = db.session.get(models.OrgRole, candidate_uuid)
+    if not candidate:
+        candidate = models.OrgRole.query.filter(
+            db.func.lower(models.OrgRole.code) == str(identifier).lower()
+        ).first()
+    return candidate
 
 
 def register_blueprint(app):

--- a/Microservicios/organization_service/tests/test_invitations.py
+++ b/Microservicios/organization_service/tests/test_invitations.py
@@ -1,0 +1,181 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+import uuid
+
+import pytest
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+
+for path in (BASE_DIR, SERVICE_DIR):
+    if str(path) not in sys.path:
+        sys.path.append(str(path))
+
+from common.app_factory import create_app
+from common import auth as common_auth
+from common.database import db
+import models
+import routes
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    common_auth._jwt_manager = None
+
+    app = create_app("organization", routes.register_blueprint)
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db.create_all()
+        # Seed base organization and roles for tests
+        org = models.Organization(id=uuid.uuid4(), code="acme", name="Acme Corp", created_at=datetime.utcnow())
+        role = models.OrgRole(id=uuid.uuid4(), code="org_admin", label="Admin")
+        db.session.add_all([org, role])
+        db.session.commit()
+
+    yield app
+
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def issue_token(user_id: str, roles: list[str]):
+    token_payload = {"sub": user_id, "roles": roles}
+    manager = common_auth.get_jwt_manager()
+    return manager.encode(token_payload)
+
+
+def auth_headers(app, roles=("org_admin",)):
+    user_id = str(uuid.uuid4())
+    token = issue_token(user_id, list(roles))
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }, user_id
+
+
+def test_create_invitation_success(app, client):
+    headers, user_id = auth_headers(app)
+    with app.app_context():
+        org = models.Organization.query.first()
+        role = models.OrgRole.query.first()
+
+    payload = {
+        "org_id": str(org.id),
+        "email": "invitee@example.com",
+        "role": role.code,
+        "ttl_hours": 24,
+    }
+
+    response = client.post("/organization/invitations", json=payload, headers=headers)
+
+    assert response.status_code == 201
+    body = response.get_json()
+    invitation = body["data"]["invitation"]
+    assert invitation["org_id"] == str(org.id)
+    assert invitation["email"] == "invitee@example.com"
+    assert invitation["role"] == role.code
+    assert invitation["status"] == "pending"
+    assert invitation["token"]
+    assert invitation["created_by"] == user_id
+
+
+def test_create_invitation_rejects_invalid_ttl(app, client):
+    headers, _ = auth_headers(app)
+    with app.app_context():
+        org = models.Organization.query.first()
+        role = models.OrgRole.query.first()
+
+    payload = {
+        "org_id": str(org.id),
+        "role": role.code,
+        "ttl_hours": 0,
+    }
+
+    response = client.post("/organization/invitations", json=payload, headers=headers)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["status"] == "error"
+    assert body["error"]["id"] == "HG-ORG-INVITE-TTL-RANGE"
+
+
+def test_list_invitations_filters_by_org(app, client):
+    _, user_id = auth_headers(app)
+    with app.app_context():
+        org = models.Organization.query.first()
+        role = models.OrgRole.query.first()
+        org_id = str(org.id)
+
+        other_org = models.Organization(id=uuid.uuid4(), code="beta", name="Beta", created_at=datetime.utcnow())
+        db.session.add(other_org)
+
+        now = datetime.utcnow()
+        invite_org = models.OrgInvitation(
+            organization=org,
+            role=role,
+            email="user1@example.com",
+            token="token-1",
+            expires_at=now + timedelta(hours=24),
+            created_at=now,
+            created_by=uuid.UUID(user_id),
+        )
+        invite_other = models.OrgInvitation(
+            organization=other_org,
+            role=role,
+            email="user2@example.com",
+            token="token-2",
+            expires_at=now + timedelta(hours=24),
+            created_at=now,
+        )
+        db.session.add_all([invite_org, invite_other])
+        db.session.commit()
+
+    response = client.get(f"/organization/invitations?org_id={org_id}", headers={"Accept": "application/json"})
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    invitations = data["invitations"]
+    assert len(invitations) == 1
+    assert invitations[0]["org_id"] == org_id
+    assert invitations[0]["email"] == "user1@example.com"
+
+
+def test_cancel_invitation(app, client):
+    headers, _ = auth_headers(app)
+    with app.app_context():
+        org = models.Organization.query.first()
+        role = models.OrgRole.query.first()
+
+        invitation = models.OrgInvitation(
+            organization=org,
+            role=role,
+            email="user3@example.com",
+            token="token-3",
+            expires_at=datetime.utcnow() + timedelta(hours=24),
+            created_at=datetime.utcnow(),
+        )
+        db.session.add(invitation)
+        db.session.commit()
+        invitation_uuid = invitation.id
+        invitation_id = str(invitation_uuid)
+
+    response = client.post(
+        f"/organization/invitations/{invitation_id}/cancel",
+        headers=headers,
+        json={},
+    )
+    assert response.status_code == 204
+
+    with app.app_context():
+        refreshed = db.session.get(models.OrgInvitation, invitation_uuid)
+        assert refreshed.revoked_at is not None


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for organization roles and invitations with serialization helpers
- implement invitations listing, creation, and cancel endpoints including TTL validation and token issuance
- document the new API surface and cover invitation flows with pytest tests

## Testing
- pytest Microservicios/organization_service/tests/test_invitations.py

------
https://chatgpt.com/codex/tasks/task_e_6905acb876d483228e203e56a3cad83a