### PR TITLE
feat: enrich patient service listing response

### DIFF
--- a/Microservicios/patient_service/models.py
+++ b/Microservicios/patient_service/models.py
@@ -1,14 +1,22 @@
-"""Database models for the patient service."""
+"""Database models and query helpers for the patient service."""
 from __future__ import annotations
 
-from sqlalchemy.dialects.postgresql import UUID
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any, Dict, List
+
 import uuid
+
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import UUID
 
 from common.database import db
 
 
 class Patient(db.Model):
     """Represents a patient, mapping to the 'patients' table."""
+
     __tablename__ = 'patients'
     __table_args__ = {'extend_existing': True}
 
@@ -22,8 +30,10 @@ class Patient(db.Model):
     profile_photo_url = db.Column(db.Text)
     created_at = db.Column(db.TIMESTAMP, nullable=False, server_default=db.func.now())
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         """Serializes the patient object to a dictionary."""
+
+        created_at = _datetime_to_iso(self.created_at)
         return {
             'id': str(self.id),
             'org_id': str(self.org_id) if self.org_id else None,
@@ -32,5 +42,228 @@ class Patient(db.Model):
             'sex_id': str(self.sex_id) if self.sex_id else None,
             'risk_level_id': str(self.risk_level_id) if self.risk_level_id else None,
             'profile_photo_url': self.profile_photo_url,
-            'created_at': self.created_at.isoformat(),
+            'created_at': created_at,
         }
+
+
+class Sex(db.Model):
+    """Catalog of biological sex options."""
+
+    __tablename__ = 'sexes'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    code = db.Column(db.String(8), unique=True, nullable=False)
+    label = db.Column(db.String(40), nullable=False)
+
+
+class RiskLevel(db.Model):
+    """Catalog of risk levels for patients."""
+
+    __tablename__ = 'risk_levels'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    code = db.Column(db.String(20), unique=True, nullable=False)
+    label = db.Column(db.String(50), nullable=False)
+    weight = db.Column(db.Integer)
+
+
+class AlertLevel(db.Model):
+    """Catalog for alert severity levels."""
+
+    __tablename__ = 'alert_levels'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    code = db.Column(db.String(40), unique=True, nullable=False)
+    label = db.Column(db.String(80), nullable=False)
+
+
+class AlertStatus(db.Model):
+    """Catalog for alert workflow statuses."""
+
+    __tablename__ = 'alert_status'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    code = db.Column(db.String(30), unique=True, nullable=False)
+    description = db.Column(db.Text)
+
+
+class Alert(db.Model):
+    """Clinical alert generated for a patient."""
+
+    __tablename__ = 'alerts'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    patient_id = db.Column(UUID(as_uuid=True), db.ForeignKey('patients.id', ondelete='CASCADE'), nullable=False)
+    alert_level_id = db.Column(UUID(as_uuid=True), db.ForeignKey('alert_levels.id', ondelete='RESTRICT'), nullable=False)
+    status_id = db.Column(UUID(as_uuid=True), db.ForeignKey('alert_status.id', ondelete='RESTRICT'), nullable=False)
+    created_at = db.Column(db.TIMESTAMP, nullable=False, server_default=db.func.now())
+
+
+@dataclass
+class PatientAlertSummary:
+    """DTO describing a recent alert of a patient."""
+
+    severity: str
+    status: str
+    created_at: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            'severity': self.severity,
+            'status': self.status,
+            'created_at': self.created_at,
+        }
+
+
+@dataclass
+class PatientSummary:
+    """Aggregated view for patient list payloads."""
+
+    id: uuid.UUID
+    org_id: uuid.UUID | None
+    name: str
+    gender: str
+    age: int | None
+    risk_level: str | None
+    risk_level_label: str | None
+    admission_date: str | None
+    updated_at: str | None
+    alerts: List[PatientAlertSummary]
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            'id': str(self.id),
+            'org_id': str(self.org_id) if self.org_id else None,
+            'name': self.name,
+            'gender': self.gender,
+            'age': self.age,
+            'risk_level': self.risk_level,
+            'admission_date': self.admission_date,
+            'updated_at': self.updated_at,
+            'alerts': [alert.to_dict() for alert in self.alerts],
+        }
+        if self.risk_level_label:
+            data['risk_level_label'] = self.risk_level_label
+        return data
+
+
+def _calculate_age(birthdate: date | None) -> int | None:
+    """Return the patient's age in full years."""
+
+    if birthdate is None:
+        return None
+
+    today = date.today()
+    years = today.year - birthdate.year
+    if (today.month, today.day) < (birthdate.month, birthdate.day):
+        years -= 1
+    return max(years, 0)
+
+
+def _datetime_to_iso(value: datetime | None) -> str | None:
+    """Normalize datetimes to ISO-8601 strings in UTC."""
+
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat()
+
+
+class PatientQuery:
+    """Typed helpers for patient queries used by the API."""
+
+    RECENT_ALERT_LIMIT = 5
+
+    @classmethod
+    def list_with_details(cls, org_id: uuid.UUID | None = None) -> List[Dict[str, Any]]:
+        """Return serialized patients enriched with catalog data and alerts."""
+
+        query = (
+            db.session.query(
+                Patient.id.label('id'),
+                Patient.org_id.label('org_id'),
+                Patient.person_name.label('name'),
+                Patient.birthdate.label('birthdate'),
+                Patient.created_at.label('created_at'),
+                Sex.code.label('sex_code'),
+                Sex.label.label('sex_label'),
+                RiskLevel.code.label('risk_code'),
+                RiskLevel.label.label('risk_label'),
+                func.coalesce(func.max(Alert.created_at), Patient.created_at).label('updated_at'),
+            )
+            .outerjoin(Sex, Sex.id == Patient.sex_id)
+            .outerjoin(RiskLevel, RiskLevel.id == Patient.risk_level_id)
+            .outerjoin(Alert, Alert.patient_id == Patient.id)
+        )
+
+        if org_id:
+            query = query.filter(Patient.org_id == org_id)
+
+        query = query.group_by(
+            Patient.id,
+            Patient.org_id,
+            Patient.person_name,
+            Patient.birthdate,
+            Patient.created_at,
+            Sex.code,
+            Sex.label,
+            RiskLevel.code,
+            RiskLevel.label,
+        ).order_by(Patient.person_name.asc())
+
+        rows = query.all()
+        patient_ids = [row.id for row in rows]
+
+        alerts_by_patient: dict[uuid.UUID, List[PatientAlertSummary]] = defaultdict(list)
+        if patient_ids:
+            ranked_alerts = (
+                db.session.query(
+                    Alert.patient_id.label('patient_id'),
+                    Alert.created_at.label('created_at'),
+                    AlertLevel.code.label('level_code'),
+                    AlertStatus.code.label('status_code'),
+                    func.row_number()
+                    .over(partition_by=Alert.patient_id, order_by=Alert.created_at.desc())
+                    .label('rank'),
+                )
+                .join(AlertLevel, AlertLevel.id == Alert.alert_level_id)
+                .join(AlertStatus, AlertStatus.id == Alert.status_id)
+                .filter(Alert.patient_id.in_(patient_ids))
+            ).subquery()
+
+            recent_alerts = (
+                db.session.query(ranked_alerts)
+                .filter(ranked_alerts.c.rank <= cls.RECENT_ALERT_LIMIT)
+                .order_by(ranked_alerts.c.patient_id, ranked_alerts.c.created_at.desc())
+                .all()
+            )
+
+            for alert in recent_alerts:
+                alerts_by_patient[alert.patient_id].append(
+                    PatientAlertSummary(
+                        severity=alert.level_code,
+                        status=alert.status_code,
+                        created_at=_datetime_to_iso(alert.created_at) or '',
+                    )
+                )
+
+        summaries: List[Dict[str, Any]] = []
+        for row in rows:
+            summary = PatientSummary(
+                id=row.id,
+                org_id=row.org_id,
+                name=row.name,
+                gender=row.sex_label or row.sex_code or 'Sin dato',
+                age=_calculate_age(row.birthdate),
+                risk_level=row.risk_code,
+                risk_level_label=row.risk_label,
+                admission_date=_datetime_to_iso(row.created_at),
+                updated_at=_datetime_to_iso(row.updated_at),
+                alerts=alerts_by_patient.get(row.id, []),
+            )
+            summaries.append(summary.to_dict())
+
+        return summaries

--- a/Microservicios/patient_service/tests/test_patients.py
+++ b/Microservicios/patient_service/tests/test_patients.py
@@ -1,0 +1,211 @@
+import sys
+import types
+import uuid
+import xml.etree.ElementTree as ET
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+
+for path in (BASE_DIR, SERVICE_DIR):
+    if str(path) not in sys.path:
+        sys.path.append(str(path))
+
+if "flask_cors" not in sys.modules:
+    sys.modules["flask_cors"] = types.SimpleNamespace(CORS=lambda app, resources=None: None)
+
+if "dicttoxml" not in sys.modules:
+    import xml.etree.ElementTree as _ET
+
+    def _append_node(parent: _ET.Element, key: str, value, item_func):
+        if isinstance(value, dict):
+            node = _ET.SubElement(parent, key)
+            for sub_key, sub_value in value.items():
+                _append_node(node, sub_key, sub_value, item_func)
+        elif isinstance(value, list):
+            container = _ET.SubElement(parent, key)
+            for item in value:
+                tag = item_func(item) if item_func else "item"
+                child = _ET.SubElement(container, tag)
+                if isinstance(item, dict):
+                    for sub_key, sub_value in item.items():
+                        _append_node(child, sub_key, sub_value, item_func)
+                elif item is not None:
+                    child.text = str(item)
+                else:
+                    child.text = ""
+        else:
+            node = _ET.SubElement(parent, key)
+            node.text = "" if value is None else str(value)
+
+    def _dicttoxml(data, custom_root="root", attr_type=False, item_func=None):
+        root = _ET.Element(custom_root)
+        if isinstance(data, dict):
+            for key, value in data.items():
+                _append_node(root, key, value, item_func)
+        else:
+            _append_node(root, "item", data, item_func)
+        return _ET.tostring(root, encoding="utf-8")
+
+    sys.modules["dicttoxml"] = types.SimpleNamespace(dicttoxml=_dicttoxml)
+
+if "xmltodict" not in sys.modules:
+    import xml.etree.ElementTree as _ET
+
+    def _element_to_dict(element: _ET.Element):
+        children = list(element)
+        if not children:
+            return element.text or ""
+        result = {}
+        for child in children:
+            result[child.tag] = _element_to_dict(child)
+        return result
+
+    def _parse_xml(xml_string: str):
+        root = _ET.fromstring(xml_string)
+        return {root.tag: _element_to_dict(root)}
+
+    sys.modules["xmltodict"] = types.SimpleNamespace(parse=_parse_xml)
+
+from common import auth as common_auth
+from common.app_factory import create_app
+from common.database import db
+import models
+import routes
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    common_auth._jwt_manager = None
+
+    app = create_app("patient", routes.register_blueprint)
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db.create_all()
+
+    yield app
+
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _seed_catalogs(app):
+    with app.app_context():
+        sex = models.Sex(id=uuid.uuid4(), code="F", label="Femenino")
+        risk_high = models.RiskLevel(id=uuid.uuid4(), code="high", label="Alto")
+        risk_low = models.RiskLevel(id=uuid.uuid4(), code="low", label="Bajo")
+        level_high = models.AlertLevel(id=uuid.uuid4(), code="high", label="Alta")
+        level_critical = models.AlertLevel(id=uuid.uuid4(), code="critical", label="Crítica")
+        status_open = models.AlertStatus(id=uuid.uuid4(), code="open", description="Abierta")
+        status_ack = models.AlertStatus(id=uuid.uuid4(), code="ack", description="Reconocida")
+
+        db.session.add_all([
+            sex,
+            risk_high,
+            risk_low,
+            level_high,
+            level_critical,
+            status_open,
+            status_ack,
+        ])
+        db.session.commit()
+
+        return {
+            "sex_id": sex.id,
+            "risk_high_id": risk_high.id,
+            "risk_low_id": risk_low.id,
+            "level_high_id": level_high.id,
+            "level_critical_id": level_critical.id,
+            "status_open_id": status_open.id,
+            "status_ack_id": status_ack.id,
+        }
+
+
+def test_list_patients_returns_enriched_xml(app, client):
+    catalogs = _seed_catalogs(app)
+    org_id = uuid.uuid4()
+    other_org = uuid.uuid4()
+
+    with app.app_context():
+        patient = models.Patient(
+            id=uuid.uuid4(),
+            org_id=org_id,
+            person_name="Ana Gómez",
+            birthdate=date.today(),
+            sex_id=catalogs["sex_id"],
+            risk_level_id=catalogs["risk_high_id"],
+            created_at=datetime(2024, 1, 10, tzinfo=timezone.utc),
+        )
+        other_patient = models.Patient(
+            id=uuid.uuid4(),
+            org_id=other_org,
+            person_name="Luis Pérez",
+            birthdate=date(1990, 5, 15),
+            sex_id=catalogs["sex_id"],
+            risk_level_id=catalogs["risk_low_id"],
+            created_at=datetime(2024, 1, 5, tzinfo=timezone.utc),
+        )
+
+        alert_old = models.Alert(
+            patient_id=patient.id,
+            alert_level_id=catalogs["level_high_id"],
+            status_id=catalogs["status_open_id"],
+            created_at=datetime(2024, 2, 1, 12, 0, tzinfo=timezone.utc),
+        )
+        alert_recent = models.Alert(
+            patient_id=patient.id,
+            alert_level_id=catalogs["level_critical_id"],
+            status_id=catalogs["status_ack_id"],
+            created_at=datetime(2024, 3, 3, 9, 30, tzinfo=timezone.utc),
+        )
+
+        db.session.add_all([patient, other_patient, alert_old, alert_recent])
+        db.session.commit()
+
+    response = client.get(
+        f"/patients?org_id={org_id}",
+        headers={"Accept": "application/xml"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("application/xml")
+
+    xml_root = ET.fromstring(response.data)
+    patients_nodes = xml_root.findall(".//patients/Patient")
+    assert len(patients_nodes) == 1
+
+    patient_node = patients_nodes[0]
+    assert patient_node.findtext("name") == "Ana Gómez"
+    assert patient_node.findtext("gender") == "Femenino"
+    assert patient_node.findtext("risk_level") == "high"
+    assert patient_node.findtext("org_id") == str(org_id)
+    assert patient_node.findtext("admission_date") == "2024-01-10T00:00:00+00:00"
+    assert patient_node.findtext("updated_at") == "2024-03-03T09:30:00+00:00"
+
+    alerts_nodes = patient_node.findall("alerts/Alert")
+    assert len(alerts_nodes) == 2
+    assert alerts_nodes[0].findtext("severity") == "critical"
+    assert alerts_nodes[0].findtext("status") == "ack"
+    assert alerts_nodes[0].findtext("created_at") == "2024-03-03T09:30:00+00:00"
+    assert alerts_nodes[1].findtext("severity") == "high"
+    assert alerts_nodes[1].findtext("status") == "open"
+
+
+def test_list_patients_requires_org_id(client):
+    response = client.get("/patients", headers={"Accept": "application/json"})
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["error"]["id"] == "HG-PATIENT-ORG-ID-REQUIRED"


### PR DESCRIPTION
## Summary
- expand patient service data models to include catalog tables and alert aggregation helpers
- update the list endpoint to require org_id, join related catalog data, and emit nested alert nodes for XML consumers
- add targeted tests that validate the XML payload structure expected by the frontend

## Testing
- pytest Microservicios/patient_service/tests/test_patients.py

------
https://chatgpt.com/codex/tasks/task_e_6905acae371c8322a25c44f59315e32b