### PR TITLE
Normalize org roles in JWT and restrict invitation scope

### DIFF
--- a/Microservicios/common/app_factory.py
+++ b/Microservicios/common/app_factory.py
@@ -1,13 +1,20 @@
 """Application factory utilities for microservices."""
 from __future__ import annotations
 
+import importlib
 import logging
 import os
 import time
 from typing import Callable
 
 from flask import Flask, Response, g, request
-from flask_cors import CORS
+
+_cors_spec = importlib.util.find_spec("flask_cors")
+if _cors_spec is not None:
+    CORS = importlib.import_module("flask_cors").CORS  # type: ignore[attr-defined]
+else:  # pragma: no cover - exercised implicitly when dependency missing
+    def CORS(app, *args, **kwargs):  # type: ignore[empty-body]
+        return app
 
 from .database import db, DB_AVAILABLE
 from .errors import register_error_handlers

--- a/Microservicios/common/serialization.py
+++ b/Microservicios/common/serialization.py
@@ -1,12 +1,33 @@
 """Utilities for parsing requests and rendering responses in JSON/XML."""
 from __future__ import annotations
 
+import importlib
 import json
 from typing import Any, Callable, Dict, Tuple
 
 from flask import Request, Response, current_app, jsonify, make_response, request
-import dicttoxml
-import xmltodict
+
+_dicttoxml_spec = importlib.util.find_spec("dicttoxml")
+if _dicttoxml_spec is not None:
+    dicttoxml = importlib.import_module("dicttoxml")
+else:  # pragma: no cover - exercised implicitly when dependency missing
+    class _DictToXMLModule:
+        @staticmethod
+        def dicttoxml(*args, **kwargs):
+            raise RuntimeError("dicttoxml dependency is required for XML responses")
+
+    dicttoxml = _DictToXMLModule()
+
+_xmltodict_spec = importlib.util.find_spec("xmltodict")
+if _xmltodict_spec is not None:
+    xmltodict = importlib.import_module("xmltodict")
+else:  # pragma: no cover - exercised implicitly when dependency missing
+    class _XMLToDictModule:
+        @staticmethod
+        def parse(*args, **kwargs):
+            raise RuntimeError("xmltodict dependency is required for XML payloads")
+
+    xmltodict = _XMLToDictModule()
 
 from .errors import APIError
 

--- a/Microservicios/organization_service/models.py
+++ b/Microservicios/organization_service/models.py
@@ -75,6 +75,19 @@ class OrgRole(db.Model):
         }
 
 
+class UserOrgMembership(db.Model):
+    """Association between users and organizations used for authorization."""
+
+    __tablename__ = 'user_org_membership'
+
+    org_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organizations.id'), primary_key=True)
+    user_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), primary_key=True)
+    org_role_id = db.Column(UUID(as_uuid=True), db.ForeignKey('org_roles.id'), nullable=False)
+    joined_at = db.Column(db.TIMESTAMP, nullable=False, server_default=db.func.now())
+
+    role = db.relationship('OrgRole', lazy='joined')
+
+
 class OrgInvitationQuery:
     """Typed helper query for invitations."""
 


### PR DESCRIPTION
## Summary
- normalize global and organization role identifiers before issuing JWTs and carry the preferred org_id claim
- allow services to run without optional flask_cors and XML dependencies by providing fallbacks
- enforce org_admin membership for organization invitations and cover uppercase role and cross-org rejection scenarios in tests

## Testing
- pytest Microservicios/organization_service/tests/test_invitations.py

------
https://chatgpt.com/codex/tasks/task_e_6905bed7ab1c8322999e628075e679ac