### PR TITLE
Implement invitation onboarding workflows

### DIFF
--- a/Microservicios/notification_service/requirements.txt
+++ b/Microservicios/notification_service/requirements.txt
@@ -4,5 +4,6 @@ PyJWT>=2.8
 dicttoxml>=1.7
 xmltodict>=0.13
 gunicorn>=21.2
+requests>=2.31
 Flask-SQLAlchemy>=3.0
 psycopg2-binary>=2.9

--- a/Microservicios/notification_service/routes.py
+++ b/Microservicios/notification_service/routes.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
 from typing import Dict, List
 
-from flask import Blueprint, request
+import requests
+from flask import Blueprint, current_app, request
 
 from common.auth import require_auth
 from common.errors import APIError
@@ -23,6 +25,7 @@ PUSH_DEVICES: Dict[str, Dict] = {
 }
 
 ALERT_DELIVERIES: List[Dict] = []
+INVITATION_NOTIFICATIONS: Dict[str, Dict] = {}
 
 
 @bp.route("/health", methods=["GET"])
@@ -73,6 +76,125 @@ def create_delivery() -> "Response":
     }
     ALERT_DELIVERIES.append(delivery)
     return render_response({"delivery": delivery}, status_code=201)
+
+
+def _organization_service_base_url() -> str:
+    base_url = current_app.config.get("ORGANIZATION_SERVICE_URL")
+    if base_url:
+        return base_url.rstrip("/")
+    env_url = os.getenv("ORGANIZATION_SERVICE_URL", "http://organization-service:5002/organization")
+    current_app.config["ORGANIZATION_SERVICE_URL"] = env_url
+    return env_url.rstrip("/")
+
+
+def _call_organization_service(method: str, path: str, **kwargs) -> requests.Response:
+    url = f"{_organization_service_base_url()}{path}"
+    timeout = current_app.config.get("ORGANIZATION_HTTP_TIMEOUT", 5)
+    try:
+        response = requests.request(method, url, timeout=timeout, **kwargs)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        raise APIError(
+            "Failed to contact organization service",
+            status_code=502,
+            error_id="HG-NOTIFY-ORG-SERVICE",
+        ) from exc
+
+    if response.status_code >= 400:
+        message = "Organization service error"
+        try:
+            payload = response.json()
+            message = (
+                payload.get("error", {}).get("message")
+                or payload.get("message")
+                or message
+            )
+        except ValueError:
+            if response.text:
+                message = response.text
+        raise APIError(message, status_code=response.status_code, error_id="HG-NOTIFY-ORG-SERVICE")
+
+    return response
+
+
+def _consume_invitation_token(signed_token: str) -> None:
+    _call_organization_service(
+        "POST",
+        f"/invitations/{signed_token}/consume",
+        headers={"Accept": "application/json"},
+        json={"action": "revoke"},
+    )
+
+
+def _parse_iso_datetime(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        return dt.datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise APIError("Invalid ISO datetime", status_code=400, error_id="HG-NOTIFY-ISO") from exc
+
+
+@bp.route("/invitations/send", methods=["POST"])
+@require_auth(optional=True)
+def send_invitation_notification() -> "Response":
+    payload, _ = parse_request_data(request)
+
+    signed_token = payload.get("invite_token") or payload.get("token")
+    email = payload.get("email")
+    link = payload.get("signed_url") or payload.get("link")
+    expires_at = payload.get("expires_at")
+    invitation_id = payload.get("invitation_id")
+
+    if not signed_token:
+        raise APIError("invite_token is required", status_code=400, error_id="HG-NOTIFY-INVITE-TOKEN")
+    if not email:
+        raise APIError("email is required", status_code=400, error_id="HG-NOTIFY-EMAIL")
+    if not link:
+        raise APIError("signed_url is required", status_code=400, error_id="HG-NOTIFY-LINK")
+
+    created_at = dt.datetime.utcnow().isoformat() + "Z"
+    record = {
+        "invite_token": signed_token,
+        "email": email,
+        "signed_url": link,
+        "expires_at": expires_at,
+        "invitation_id": invitation_id,
+        "status": "sent",
+        "created_at": created_at,
+        "sent_at": created_at,
+    }
+    INVITATION_NOTIFICATIONS[signed_token] = record
+    return render_response({"notification": record}, status_code=202)
+
+
+@bp.route("/invitations/sweep", methods=["POST"])
+@require_auth(optional=True)
+def sweep_invitation_expirations() -> "Response":
+    now = dt.datetime.now(dt.timezone.utc)
+    expired_tokens: List[str] = []
+
+    for token, record in list(INVITATION_NOTIFICATIONS.items()):
+        if record.get("revoked_at"):
+            continue
+        expires_at = record.get("expires_at")
+        try:
+            expires = _parse_iso_datetime(expires_at)
+        except APIError as exc:
+            record["error"] = exc.message
+            continue
+        if not expires:
+            continue
+        if expires <= now:
+            try:
+                _consume_invitation_token(token)
+                record["revoked_at"] = dt.datetime.utcnow().isoformat() + "Z"
+                expired_tokens.append(token)
+            except APIError as exc:
+                record["error"] = exc.message
+
+    meta = {"total": len(expired_tokens)}
+    return render_response({"expired_tokens": expired_tokens}, meta=meta)
 
 
 def register_blueprint(app):

--- a/Microservicios/notification_service/tests/test_invitation_notifications.py
+++ b/Microservicios/notification_service/tests/test_invitation_notifications.py
@@ -1,0 +1,135 @@
+"""Tests for invitation notification workflows."""
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+
+for path in (BASE_DIR, SERVICE_DIR):
+    if str(path) not in sys.path:
+        sys.path.append(str(path))
+
+if "flask_cors" not in sys.modules:
+    sys.modules["flask_cors"] = types.SimpleNamespace(CORS=lambda app, resources=None: None)
+
+if "dicttoxml" not in sys.modules:
+    import xml.etree.ElementTree as _ET
+
+    def _append_node(parent: _ET.Element, key: str, value, item_func):
+        if isinstance(value, dict):
+            node = _ET.SubElement(parent, key)
+            for sub_key, sub_value in value.items():
+                _append_node(node, sub_key, sub_value, item_func)
+        elif isinstance(value, list):
+            container = _ET.SubElement(parent, key)
+            for item in value:
+                tag = item_func(item) if item_func else "item"
+                child = _ET.SubElement(container, tag)
+                if isinstance(item, dict):
+                    for sub_key, sub_value in item.items():
+                        _append_node(child, sub_key, sub_value, item_func)
+                elif item is not None:
+                    child.text = str(item)
+                else:
+                    child.text = ""
+        else:
+            node = _ET.SubElement(parent, key)
+            node.text = "" if value is None else str(value)
+
+    def _dicttoxml(data, custom_root="root", attr_type=False, item_func=None):
+        root = _ET.Element(custom_root)
+        if isinstance(data, dict):
+            for key, value in data.items():
+                _append_node(root, key, value, item_func)
+        else:
+            _append_node(root, "item", data, item_func)
+        return _ET.tostring(root, encoding="utf-8")
+
+    sys.modules["dicttoxml"] = types.SimpleNamespace(dicttoxml=_dicttoxml)
+
+if "xmltodict" not in sys.modules:
+    import xml.etree.ElementTree as _ET
+
+    def _element_to_dict(element: _ET.Element):
+        children = list(element)
+        if not children:
+            return element.text or ""
+        result = {}
+        for child in children:
+            result[child.tag] = _element_to_dict(child)
+        return result
+
+    def _parse_xml(xml_string: str):
+        root = _ET.fromstring(xml_string)
+        return {root.tag: _element_to_dict(root)}
+
+    sys.modules["xmltodict"] = types.SimpleNamespace(parse=_parse_xml)
+
+from common.app_factory import create_app
+import routes
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    app = create_app("notification", routes.register_blueprint)
+    app.config["TESTING"] = True
+    yield app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_send_invitation_notification_records_payload(client):
+    xml_body = (
+        "<InvitationNotification>"
+        "<invite_token>signed-token</invite_token>"
+        "<email>invitee@example.com</email>"
+        "<signed_url>/invite/signed-token</signed_url>"
+        "<expires_at>2099-01-01T00:00:00Z</expires_at>"
+        "</InvitationNotification>"
+    )
+
+    response = client.post(
+        "/notifications/invitations/send",
+        data=xml_body,
+        headers={"Content-Type": "application/xml", "Accept": "application/json"},
+    )
+
+    assert response.status_code == 202
+    payload = response.get_json()["data"]["notification"]
+    assert payload["invite_token"] == "signed-token"
+    assert payload["email"] == "invitee@example.com"
+
+
+def test_sweep_invitation_expirations_revokes(client, monkeypatch):
+    token = "signed-token"
+    expires = (datetime.utcnow() - timedelta(hours=1)).isoformat() + "Z"
+    routes.INVITATION_NOTIFICATIONS[token] = {
+        "invite_token": token,
+        "email": "invitee@example.com",
+        "signed_url": "/invite/signed-token",
+        "expires_at": expires,
+        "status": "sent",
+    }
+    revoked_tokens: list[str] = []
+
+    monkeypatch.setattr(routes, "_consume_invitation_token", lambda signed: revoked_tokens.append(signed))
+
+    response = client.post(
+        "/notifications/invitations/sweep",
+        data="<SweepRequest />",
+        headers={"Content-Type": "application/xml", "Accept": "application/json"},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert token in data["expired_tokens"]
+    assert revoked_tokens == [token]

--- a/Microservicios/patient_service/requirements.txt
+++ b/Microservicios/patient_service/requirements.txt
@@ -6,3 +6,4 @@ xmltodict>=0.13
 gunicorn>=21.2
 Flask-SQLAlchemy>=3.0
 psycopg2-binary>=2.9
+requests>=2.31

--- a/Microservicios/patient_service/routes.py
+++ b/Microservicios/patient_service/routes.py
@@ -1,10 +1,12 @@
 """models.Patient service managing clinical subject data."""
 from __future__ import annotations
 
+import os
 import uuid
 from typing import Any
 
-from flask import Blueprint, request
+import requests
+from flask import Blueprint, current_app, request
 
 from common.auth import require_auth
 from common.database import db
@@ -61,6 +63,108 @@ def create_patient() -> "Response":
     db.session.commit()
 
     return render_response({"patient": new_patient.to_dict()}, status_code=201)
+
+
+def _organization_service_base_url() -> str:
+    base_url = current_app.config.get("ORGANIZATION_SERVICE_URL")
+    if base_url:
+        return base_url.rstrip("/")
+    env_url = os.getenv("ORGANIZATION_SERVICE_URL", "http://organization-service:5002/organization")
+    current_app.config["ORGANIZATION_SERVICE_URL"] = env_url
+    return env_url.rstrip("/")
+
+
+def _call_organization_service(method: str, path: str, **kwargs) -> requests.Response:
+    url = f"{_organization_service_base_url()}{path}"
+    timeout = current_app.config.get("ORGANIZATION_HTTP_TIMEOUT", 5)
+    try:
+        response = requests.request(method, url, timeout=timeout, **kwargs)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        raise APIError(
+            "Failed to contact organization service",
+            status_code=502,
+            error_id="HG-PATIENT-ORG-SERVICE",
+        ) from exc
+
+    if response.status_code >= 400:
+        message = "Organization service error"
+        try:
+            payload = response.json()
+            message = (
+                payload.get("error", {}).get("message")
+                or payload.get("message")
+                or message
+            )
+        except ValueError:
+            if response.text:
+                message = response.text
+        raise APIError(message, status_code=response.status_code, error_id="HG-PATIENT-ORG-SERVICE")
+
+    return response
+
+
+def _fetch_invitation_details(signed_token: str) -> dict:
+    response = _call_organization_service(
+        "GET",
+        f"/invitations/{signed_token}/validate",
+        headers={"Accept": "application/json"},
+    )
+    return response.json().get("data") or {}
+
+
+def _consume_invitation_token(signed_token: str, payload: dict) -> None:
+    _call_organization_service(
+        "POST",
+        f"/invitations/{signed_token}/consume",
+        headers={"Accept": "application/json"},
+        json=payload,
+    )
+
+
+@bp.route("/register", methods=["POST"])
+def register_from_invitation() -> "Response":
+    payload, _ = parse_request_data(request)
+
+    signed_token = payload.get("invite_token") or payload.get("token")
+    person_name = (payload.get("person_name") or payload.get("name") or "").strip()
+
+    if not signed_token:
+        raise APIError("invite_token is required", status_code=400, error_id="HG-PATIENT-INVITE-TOKEN")
+    if not person_name:
+        raise APIError("person_name is required", status_code=400, error_id="HG-PATIENT-VALIDATION")
+
+    invitation = _fetch_invitation_details(str(signed_token))
+    invitation_data = invitation.get("invitation") or {}
+
+    try:
+        org_uuid = uuid.UUID(str(invitation_data.get("org_id")))
+    except (TypeError, ValueError) as exc:
+        raise APIError("Invitation organization invalid", status_code=400, error_id="HG-PATIENT-INVITE-ORG") from exc
+
+    new_patient = models.Patient(person_name=person_name, org_id=org_uuid)
+    db.session.add(new_patient)
+    db.session.flush()
+
+    try:
+        _consume_invitation_token(
+            signed_token,
+            {
+                "action": "accept",
+                "consumer_type": "patient",
+                "consumer_id": str(new_patient.id),
+            },
+        )
+    except APIError:
+        db.session.rollback()
+        raise
+
+    db.session.commit()
+
+    response_payload = {
+        "patient": new_patient.to_dict(),
+        "metadata": invitation.get("metadata"),
+    }
+    return render_response(response_payload, status_code=201, xml_item_name=_patient_item_name)
 
 
 @bp.route("/<patient_id>", methods=["GET"])

--- a/Microservicios/user_service/models.py
+++ b/Microservicios/user_service/models.py
@@ -61,7 +61,7 @@ class UserOrgMembership(db.Model):
     __table_args__ = {"extend_existing": True}
 
     org_id = db.Column(UUID(as_uuid=True), primary_key=True)
-    user_id = db.Column(UUID(as_uuid=True), primary_key=True)
+    user_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id', ondelete='CASCADE'), primary_key=True)
     org_role_id = db.Column(UUID(as_uuid=True), db.ForeignKey("org_roles.id"), nullable=False)
     joined_at = db.Column(db.TIMESTAMP, nullable=False, server_default=db.func.now())
 

--- a/Microservicios/user_service/requirements.txt
+++ b/Microservicios/user_service/requirements.txt
@@ -6,3 +6,4 @@ xmltodict>=0.13
 gunicorn>=21.2
 Flask-SQLAlchemy>=3.0
 psycopg2-binary>=2.9
+requests>=2.31

--- a/Microservicios/user_service/tests/test_register_from_invite.py
+++ b/Microservicios/user_service/tests/test_register_from_invite.py
@@ -1,0 +1,163 @@
+"""Tests for registering users from organization invitations."""
+from __future__ import annotations
+
+import sys
+import types
+import uuid
+
+import pytest
+
+from datetime import datetime
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+
+for path in (BASE_DIR, SERVICE_DIR):
+    if str(path) not in sys.path:
+        sys.path.append(str(path))
+
+if "flask_cors" not in sys.modules:
+    sys.modules["flask_cors"] = types.SimpleNamespace(CORS=lambda app, resources=None: None)
+
+if "dicttoxml" not in sys.modules:
+    import xml.etree.ElementTree as _ET
+
+    def _append_node(parent: _ET.Element, key: str, value, item_func):
+        if isinstance(value, dict):
+            node = _ET.SubElement(parent, key)
+            for sub_key, sub_value in value.items():
+                _append_node(node, sub_key, sub_value, item_func)
+        elif isinstance(value, list):
+            container = _ET.SubElement(parent, key)
+            for item in value:
+                tag = item_func(item) if item_func else "item"
+                child = _ET.SubElement(container, tag)
+                if isinstance(item, dict):
+                    for sub_key, sub_value in item.items():
+                        _append_node(child, sub_key, sub_value, item_func)
+                elif item is not None:
+                    child.text = str(item)
+                else:
+                    child.text = ""
+        else:
+            node = _ET.SubElement(parent, key)
+            node.text = "" if value is None else str(value)
+
+    def _dicttoxml(data, custom_root="root", attr_type=False, item_func=None):
+        root = _ET.Element(custom_root)
+        if isinstance(data, dict):
+            for key, value in data.items():
+                _append_node(root, key, value, item_func)
+        else:
+            _append_node(root, "item", data, item_func)
+        return _ET.tostring(root, encoding="utf-8")
+
+    sys.modules["dicttoxml"] = types.SimpleNamespace(dicttoxml=_dicttoxml)
+
+if "xmltodict" not in sys.modules:
+    import xml.etree.ElementTree as _ET
+
+    def _element_to_dict(element: _ET.Element):
+        children = list(element)
+        if not children:
+            return element.text or ""
+        result = {}
+        for child in children:
+            result[child.tag] = _element_to_dict(child)
+        return result
+
+    def _parse_xml(xml_string: str):
+        root = _ET.fromstring(xml_string)
+        return {root.tag: _element_to_dict(root)}
+
+    sys.modules["xmltodict"] = types.SimpleNamespace(parse=_parse_xml)
+
+from common.app_factory import create_app
+from common.database import db
+import models
+import routes
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setattr(models.UserOrgMembership, "user", None, raising=False)
+    monkeypatch.setattr(models.UserOrgMembership, "role", None, raising=False)
+    app = create_app("user", routes.register_blueprint)
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db.create_all()
+        status = models.UserStatus(id=uuid.uuid4(), code="active", label="Active")
+        role = models.OrgRole(id=uuid.uuid4(), code="clinician", label="Clinician")
+        db.session.add_all([status, role])
+        db.session.commit()
+        app.config["_test_role_id"] = role.id
+
+    yield app
+
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_register_from_invitation_creates_user(app, client, monkeypatch):
+    org_id = uuid.uuid4()
+    role_id = app.config["_test_role_id"]
+    signed_token = "signed-token"
+    invitation_payload = {
+        "invitation": {
+            "org_id": str(org_id),
+            "org_role_id": str(role_id),
+            "email": "invitee@example.com",
+            "expires_at": datetime.utcnow().isoformat() + "Z",
+        },
+        "metadata": {
+            "organization": {"id": str(org_id), "name": "Acme"},
+            "suggested_role": {"id": str(role_id), "code": "clinician", "label": "Clinician"},
+            "expires_at": datetime.utcnow().isoformat() + "Z",
+        },
+    }
+    consumed_payload = {}
+
+    monkeypatch.setattr(routes, "_fetch_invitation_details", lambda token: invitation_payload)
+    monkeypatch.setattr(
+        routes,
+        "_consume_invitation_token",
+        lambda token, payload: consumed_payload.update({"token": token, "payload": payload}),
+    )
+
+    xml_body = (
+        "<UserRegistration>"
+        f"<invite_token>{signed_token}</invite_token>"
+        "<name>Jane Doe</name>"
+        "<email>invitee@example.com</email>"
+        "<password>s3cret!</password>"
+        "</UserRegistration>"
+    )
+
+    response = client.post(
+        "/users/register",
+        data=xml_body,
+        headers={"Content-Type": "application/xml", "Accept": "application/json"},
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()["data"]
+    assert data["user"]["email"] == "invitee@example.com"
+    assert consumed_payload["token"] == signed_token
+    assert consumed_payload["payload"]["action"] == "accept"
+
+    with app.app_context():
+        user = models.User.query.filter_by(email="invitee@example.com").first()
+        assert user is not None
+        membership = models.UserOrgMembership.query.filter_by(user_id=user.id).first()
+        assert membership is not None
+        assert membership.org_id == org_id
+        assert membership.org_role_id == role_id

--- a/frontend/invite.html
+++ b/frontend/invite.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HeartGuard · Invitación</title>
+    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/components.css" />
+    <link rel="stylesheet" href="css/responsive.css" />
+  </head>
+  <body class="standalone">
+    <main class="standalone__main" aria-labelledby="invite-heading">
+      <section class="card card--form invite-card">
+        <header class="card__header">
+          <span class="card__eyebrow">Acceso seguro</span>
+          <h1 id="invite-heading" class="card__title">Unirse a HeartGuard</h1>
+          <p class="card__subtitle" data-invite-subtitle>
+            Procesando la invitación, por favor espera…
+          </p>
+        </header>
+        <div id="invite-feedback" class="alert" role="status" hidden></div>
+        <dl class="definition-list" data-invite-summary hidden>
+          <div>
+            <dt>Organización</dt>
+            <dd data-org-name>—</dd>
+          </div>
+          <div>
+            <dt>Rol sugerido</dt>
+            <dd data-role-label>—</dd>
+          </div>
+          <div>
+            <dt>Expira</dt>
+            <dd data-expiration>—</dd>
+          </div>
+        </dl>
+        <form id="invite-choice" class="stack" hidden>
+          <fieldset>
+            <legend>¿Cómo deseas continuar?</legend>
+            <label class="radio-option">
+              <input type="radio" name="invite-mode" value="user" checked />
+              <span>Registrarme como usuario de la organización</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="invite-mode" value="patient" />
+              <span>Registrar a un paciente asociado</span>
+            </label>
+          </fieldset>
+        </form>
+        <form id="invite-user-form" class="stack" hidden aria-describedby="invite-feedback">
+          <h2 class="form-title">Crear cuenta de usuario</h2>
+          <label>
+            Nombre completo
+            <input id="invite-user-name" name="name" type="text" autocomplete="name" required />
+          </label>
+          <label>
+            Correo electrónico
+            <input id="invite-user-email" name="email" type="email" autocomplete="email" required />
+          </label>
+          <label>
+            Contraseña
+            <input id="invite-user-password" name="password" type="password" autocomplete="new-password" required />
+          </label>
+          <button class="button" type="submit">Crear cuenta</button>
+        </form>
+        <form id="invite-patient-form" class="stack" hidden aria-describedby="invite-feedback">
+          <h2 class="form-title">Registrar paciente</h2>
+          <label>
+            Nombre del paciente
+            <input id="invite-patient-name" name="person_name" type="text" required />
+          </label>
+          <button class="button" type="submit">Registrar paciente</button>
+        </form>
+      </section>
+    </main>
+    <script type="module" src="js/invite.js"></script>
+  </body>
+</html>

--- a/frontend/js/invite.js
+++ b/frontend/js/invite.js
@@ -1,0 +1,238 @@
+const API_BASE_URL = 'http://136.115.53.140:5000';
+
+import { parseXml, xmlNodeText, formatDateTime } from './utils.js';
+
+const feedback = document.querySelector('#invite-feedback');
+const subtitle = document.querySelector('[data-invite-subtitle]');
+const summary = document.querySelector('[data-invite-summary]');
+const orgNameEl = document.querySelector('[data-org-name]');
+const roleLabelEl = document.querySelector('[data-role-label]');
+const expirationEl = document.querySelector('[data-expiration]');
+const choiceForm = document.querySelector('#invite-choice');
+const userForm = document.querySelector('#invite-user-form');
+const patientForm = document.querySelector('#invite-patient-form');
+
+let currentToken = null;
+let invitationDetails = null;
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function showFeedback(message, variant = 'info') {
+  if (!feedback) return;
+  feedback.textContent = message;
+  feedback.className = `alert alert--${variant}`;
+  feedback.hidden = false;
+}
+
+function hideFeedback() {
+  if (!feedback) return;
+  feedback.hidden = true;
+}
+
+function extractToken() {
+  const pathMatch = window.location.pathname.match(/invite\/([^/]+)/);
+  if (pathMatch && pathMatch[1]) {
+    return decodeURIComponent(pathMatch[1]);
+  }
+  const url = new URL(window.location.href);
+  return url.searchParams.get('token');
+}
+
+async function request(path, { method = 'GET', body = null } = {}) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/xml',
+      Accept: 'application/xml'
+    },
+    body
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    let message = `Error ${response.status}`;
+    if (text) {
+      try {
+        const xml = parseXml(text);
+        message = xml.querySelector('message')?.textContent || message;
+      } catch (error) {
+        message = `${message}: ${text}`;
+      }
+    }
+    throw new Error(message);
+  }
+  return text ? parseXml(text) : null;
+}
+
+function toggleForms(mode) {
+  if (!choiceForm || !userForm || !patientForm) return;
+  userForm.hidden = mode !== 'user';
+  patientForm.hidden = mode !== 'patient';
+}
+
+function disableForms() {
+  [userForm, patientForm].forEach((form) => {
+    if (!form) return;
+    Array.from(form.elements).forEach((element) => {
+      if ('disabled' in element) {
+        element.disabled = true;
+      }
+    });
+  });
+}
+
+function populateSummary(xml) {
+  if (!summary) return;
+  const invitationNode = xml.querySelector('invitation');
+  const metadataNode = xml.querySelector('metadata');
+  invitationDetails = {
+    email: xmlNodeText(invitationNode, 'email'),
+    orgId: xmlNodeText(invitationNode, 'org_id'),
+    orgRoleId: xmlNodeText(invitationNode, 'org_role_id'),
+  };
+
+  const organizationName = xmlNodeText(metadataNode, 'organization > name') || xmlNodeText(metadataNode, 'organization name');
+  const roleLabel = xmlNodeText(metadataNode, 'suggested_role > label') || xmlNodeText(metadataNode, 'suggested_role label');
+  const expiresAt = xmlNodeText(metadataNode, 'expires_at');
+
+  if (subtitle) {
+    subtitle.textContent = 'Confirma los detalles y completa el registro.';
+  }
+  if (orgNameEl) {
+    orgNameEl.textContent = organizationName || '—';
+  }
+  if (roleLabelEl) {
+    roleLabelEl.textContent = roleLabel || '—';
+  }
+  if (expirationEl) {
+    expirationEl.textContent = expiresAt ? formatDateTime(expiresAt) : '—';
+  }
+
+  summary.hidden = false;
+  if (choiceForm) {
+    choiceForm.hidden = false;
+  }
+
+  if (userForm) {
+    userForm.hidden = false;
+    if (invitationDetails.email) {
+      userForm.querySelector('#invite-user-email').value = invitationDetails.email;
+    }
+  }
+}
+
+async function loadInvitation() {
+  try {
+    hideFeedback();
+    const xml = await request(`/organization/invitations/${encodeURIComponent(currentToken)}/validate`);
+    if (!xml) {
+      showFeedback('No se pudo cargar la invitación.', 'danger');
+      return;
+    }
+    populateSummary(xml);
+  } catch (error) {
+    console.error(error);
+    showFeedback(error.message, 'danger');
+    disableForms();
+  }
+}
+
+function serializeUserForm() {
+  const name = userForm.querySelector('#invite-user-name').value.trim();
+  const email = userForm.querySelector('#invite-user-email').value.trim();
+  const password = userForm.querySelector('#invite-user-password').value.trim();
+
+  if (!name || !email || !password) {
+    throw new Error('Completa todos los campos del usuario.');
+  }
+
+  return (
+    '<UserRegistration>' +
+    `<invite_token>${escapeXml(currentToken)}</invite_token>` +
+    `<name>${escapeXml(name)}</name>` +
+    `<email>${escapeXml(email)}</email>` +
+    `<password>${escapeXml(password)}</password>` +
+    '</UserRegistration>'
+  );
+}
+
+function serializePatientForm() {
+  const personName = patientForm.querySelector('#invite-patient-name').value.trim();
+  if (!personName) {
+    throw new Error('Indica el nombre del paciente.');
+  }
+  return (
+    '<PatientRegistration>' +
+    `<invite_token>${escapeXml(currentToken)}</invite_token>` +
+    `<person_name>${escapeXml(personName)}</person_name>` +
+    '</PatientRegistration>'
+  );
+}
+
+async function submitUser(event) {
+  event.preventDefault();
+  try {
+    const body = serializeUserForm();
+    await request('/users/register', { method: 'POST', body });
+    showFeedback('Cuenta creada correctamente. Ya puedes iniciar sesión.', 'success');
+    disableForms();
+  } catch (error) {
+    console.error(error);
+    showFeedback(error.message, 'danger');
+  }
+}
+
+async function submitPatient(event) {
+  event.preventDefault();
+  try {
+    const body = serializePatientForm();
+    await request('/patients/register', { method: 'POST', body });
+    showFeedback('Paciente registrado correctamente.', 'success');
+    disableForms();
+  } catch (error) {
+    console.error(error);
+    showFeedback(error.message, 'danger');
+  }
+}
+
+function initChoiceHandlers() {
+  if (!choiceForm) {
+    return;
+  }
+  choiceForm.addEventListener('change', (event) => {
+    if (event.target.name !== 'invite-mode') return;
+    toggleForms(event.target.value);
+  });
+}
+
+function initForms() {
+  if (userForm) {
+    userForm.addEventListener('submit', submitUser);
+  }
+  if (patientForm) {
+    patientForm.addEventListener('submit', submitPatient);
+  }
+}
+
+function initialize() {
+  currentToken = extractToken();
+  if (!currentToken) {
+    showFeedback('No se encontró token de invitación en la URL.', 'danger');
+    disableForms();
+    return;
+  }
+
+  initChoiceHandlers();
+  initForms();
+  toggleForms('user');
+  loadInvitation();
+}
+
+initialize();


### PR DESCRIPTION
## Summary
- sign organization invitations and expose validation/consumption endpoints that return XML metadata for clients
- accept invitation tokens in the user and patient services to create accounts, record memberships, and mark invitations as used
- add notification hooks for sending invitation links and revoking expired tokens, plus a public invite landing page that consumes the new APIs

## Testing
- pytest Microservicios/organization_service/tests/test_invitations.py
- pytest Microservicios/user_service/tests/test_register_from_invite.py
- pytest Microservicios/patient_service/tests/test_patients.py
- pytest Microservicios/notification_service/tests/test_invitation_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_6905bee4421883229a1c859af8f6a180