### PR TITLE
Add Tkinter desktop client structure mirroring Java app

### DIFF
--- a/tkinter_app/api_client.py
+++ b/tkinter_app/api_client.py
@@ -1,0 +1,255 @@
+"""Cliente HTTP en Python equivalente al ``ApiClient`` de la app Java."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+from .config import API_SETTINGS
+from .models import auth as auth_models
+from .utils.async_utils import run_in_executor
+
+
+class ApiError(RuntimeError):
+    """Error lanzado cuando el backend responde con un código diferente de 2xx."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None, error_code: str = "unknown_error", payload: Any = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+        self.payload = payload
+
+
+@dataclass
+class _RequestContext:
+    method: str
+    path: str
+    requires_token: bool = True
+    params: Optional[Dict[str, Any]] = None
+    json_body: Optional[Dict[str, Any]] = None
+    token_override: Optional[str] = None
+
+
+class ApiClient:
+    """Cliente HTTP que encapsula todas las llamadas usadas por la app de escritorio."""
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = (base_url or API_SETTINGS.base_url).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Content-Type": "application/json"})
+        self.access_token: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def set_access_token(self, token: Optional[str]) -> None:
+        self.access_token = token or None
+
+    # Internal request helper
+    def _send(self, ctx: _RequestContext) -> Dict[str, Any]:
+        url = f"{self.base_url}{ctx.path}"
+        headers: Dict[str, str] = {}
+        token = ctx.token_override or self.access_token
+        if ctx.requires_token:
+            if not token:
+                raise ApiError("Token de acceso no proporcionado", status_code=401, error_code="unauthorized")
+            headers["Authorization"] = f"Bearer {token}"
+
+        timeout = (API_SETTINGS.connect_timeout, API_SETTINGS.read_timeout)
+        try:
+            response = self.session.request(
+                ctx.method,
+                url,
+                params=ctx.params,
+                json=ctx.json_body,
+                headers=headers or None,
+                timeout=timeout,
+            )
+        except requests.RequestException as exc:  # pragma: no cover - errores de red
+            raise ApiError(f"Error de conexión: {exc}") from exc
+
+        if response.status_code == 204 or not response.content:
+            payload: Dict[str, Any] = {}
+        else:
+            try:
+                payload = response.json()
+            except json.JSONDecodeError:
+                payload = {"raw": response.text}
+
+        if not response.ok:
+            error_code = "unknown_error"
+            message = payload.get("message") if isinstance(payload, dict) else None
+            if isinstance(payload, dict):
+                raw_error = payload.get("error")
+                if isinstance(raw_error, str):
+                    error_code = raw_error
+                elif isinstance(raw_error, dict) and "code" in raw_error:
+                    error_code = raw_error["code"]
+            if not message:
+                message = "Sesión expirada. Por favor, vuelve a iniciar sesión." if response.status_code == 401 else "Error en la petición"
+            raise ApiError(message, status_code=response.status_code, error_code=error_code, payload=payload)
+
+        return payload if isinstance(payload, dict) else {"data": payload}
+
+    # Convenience wrappers ------------------------------------------------
+    def _get(self, path: str, *, params: Optional[Dict[str, Any]] = None, token: Optional[str] = None, requires_token: bool = True) -> Dict[str, Any]:
+        return self._send(_RequestContext("GET", path, requires_token=requires_token, params=params, token_override=token))
+
+    def _post(self, path: str, *, body: Optional[Dict[str, Any]] = None, params: Optional[Dict[str, Any]] = None,
+              token: Optional[str] = None, requires_token: bool = True) -> Dict[str, Any]:
+        return self._send(_RequestContext("POST", path, requires_token=requires_token, params=params, json_body=body, token_override=token))
+
+    def _patch(self, path: str, *, body: Optional[Dict[str, Any]] = None, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._send(_RequestContext("PATCH", path, json_body=body, token_override=token))
+
+    # Autenticación -------------------------------------------------------
+    def login_user(self, email: str, password: str) -> auth_models.LoginResponse:
+        payload = self._post("/auth/login/user", body={"email": email, "password": password}, requires_token=False)
+        response = auth_models.LoginResponse.from_api(payload)
+        if response.access_token:
+            self.set_access_token(response.access_token)
+        return response
+
+    def login_patient(self, email: str, password: str) -> auth_models.LoginResponse:
+        payload = self._post("/auth/login/patient", body={"email": email, "password": password}, requires_token=False)
+        response = auth_models.LoginResponse.from_api(payload)
+        if response.access_token:
+            self.set_access_token(response.access_token)
+        return response
+
+    def register_user(self, email: str, password: str, name: str) -> Dict[str, Any]:
+        return self._post(
+            "/auth/register/user",
+            body={"email": email, "password": password, "name": name},
+            requires_token=False,
+        )
+
+    def register_patient(self, email: str, password: str, name: str, org_id_or_code: str, birthdate: str,
+                         sex_code: str, risk_level_code: Optional[str]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "email": email,
+            "password": password,
+            "name": name,
+            "birthdate": birthdate,
+            "sex_code": sex_code,
+        }
+        if org_id_or_code and len(org_id_or_code) == 36 and org_id_or_code.count("-") == 4:
+            payload["org_id"] = org_id_or_code
+        else:
+            payload["org_code"] = org_id_or_code
+        if risk_level_code:
+            payload["risk_level_code"] = risk_level_code
+        return self._post("/auth/register/patient", body=payload, requires_token=False)
+
+    def verify_token(self) -> bool:
+        try:
+            self._get("/auth/verify")
+            return True
+        except ApiError:
+            return False
+
+    def get_me(self) -> auth_models.LoginResponse:
+        payload = self._get("/auth/me")
+        return auth_models.LoginResponse.from_api(payload)
+
+    # Perfil del usuario ---------------------------------------------------
+    def get_current_user_profile(self, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/users/me", token=token)
+
+    def get_current_user_memberships(self, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/users/me/org-memberships", token=token)
+
+    def get_pending_invitations(self, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/users/me/invitations", token=token)
+
+    def accept_invitation(self, invitation_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._post(f"/users/me/invitations/{invitation_id}/accept", body={}, token=token)
+
+    def reject_invitation(self, invitation_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._post(f"/users/me/invitations/{invitation_id}/reject", body={}, token=token)
+
+    def update_current_user_profile(self, updates: Dict[str, Any], token: Optional[str] = None) -> Dict[str, Any]:
+        body = {key: value for key, value in updates.items()}
+        return self._patch("/users/me", body=body, token=token)
+
+    # Dashboard organizacional --------------------------------------------
+    def get_organization_dashboard(self, org_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get(f"/orgs/{org_id}/dashboard", token=token)
+
+    def get_organization_metrics(self, org_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get(f"/orgs/{org_id}/metrics", token=token)
+
+    def get_organization_care_teams(self, org_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get(f"/orgs/{org_id}/care-teams", token=token)
+
+    def get_organization_care_team_patients(self, org_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get(f"/orgs/{org_id}/care-team-patients", token=token)
+
+    def get_organization_patient_detail(self, org_id: str, patient_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get(f"/orgs/{org_id}/patients/{patient_id}", token=token)
+
+    def get_organization_patient_alerts(self, org_id: str, patient_id: str, limit: int = 20,
+                                        token: Optional[str] = None) -> Dict[str, Any]:
+        params = {"limit": max(1, limit)}
+        return self._get(f"/orgs/{org_id}/patients/{patient_id}/alerts", params=params, token=token)
+
+    def get_organization_patient_notes(self, org_id: str, patient_id: str, limit: int = 20,
+                                       token: Optional[str] = None) -> Dict[str, Any]:
+        params = {"limit": max(1, limit)}
+        return self._get(f"/orgs/{org_id}/patients/{patient_id}/notes", params=params, token=token)
+
+    # Pacientes asignados --------------------------------------------------
+    def get_caregiver_patients(self, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/caregiver/patients", token=token)
+
+    def get_caregiver_patient_locations(self, params: Optional[Dict[str, Any]] = None,
+                                        token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/caregiver/patients/locations", params=params, token=token)
+
+    def get_care_team_locations(self, params: Optional[Dict[str, Any]] = None, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/care-team/locations", params=params, token=token)
+
+    # Dispositivos ---------------------------------------------------------
+    def get_care_team_devices(self, org_id: str, team_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get(f"/orgs/{org_id}/care-teams/{team_id}/devices", token=token)
+
+    def get_care_team_disconnected_devices(self, org_id: str, team_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get(f"/orgs/{org_id}/care-teams/{team_id}/devices/disconnected", token=token)
+
+    def get_care_team_device_streams(self, org_id: str, team_id: str, device_id: str, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get(f"/orgs/{org_id}/care-teams/{team_id}/devices/{device_id}/streams", token=token)
+
+    # Dashboard del paciente -----------------------------------------------
+    def get_patient_dashboard(self, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/patient/dashboard", token=token)
+
+    def get_patient_alerts(self, limit: int = 100, offset: int = 0, status: Optional[str] = None,
+                           token: Optional[str] = None) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"limit": max(1, limit), "offset": max(0, offset)}
+        if status:
+            params["status"] = status
+        return self._get("/patient/alerts", params=params, token=token)
+
+    def get_patient_devices(self, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/patient/devices", token=token)
+
+    def get_patient_locations(self, limit: int = 6, offset: int = 0, token: Optional[str] = None) -> Dict[str, Any]:
+        params = {"limit": max(1, limit), "offset": max(0, offset)}
+        return self._get("/patient/locations", params=params, token=token)
+
+    def get_patient_caregivers(self, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/patient/caregivers", token=token)
+
+    def get_patient_care_team(self, token: Optional[str] = None) -> Dict[str, Any]:
+        return self._get("/patient/care-team", token=token)
+
+    # Métodos asíncronos ---------------------------------------------------
+    def async_call(self, func_name: str, *args: Any, **kwargs: Any):
+        func = getattr(self, func_name)
+        return run_in_executor(func, *args, **kwargs)
+
+    def close(self) -> None:  # pragma: no cover - limpieza opcional
+        self.session.close()

--- a/tkinter_app/config.py
+++ b/tkinter_app/config.py
@@ -1,0 +1,45 @@
+"""Configuración global para la app Tkinter de HeartGuard."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ApiSettings:
+    """Valores de configuración para el cliente HTTP."""
+
+    base_url: str = os.getenv("HEARTGUARD_GATEWAY_URL", "http://136.115.53.140:8080")
+    connect_timeout: float = float(os.getenv("HEARTGUARD_CONNECT_TIMEOUT", "10"))
+    read_timeout: float = float(os.getenv("HEARTGUARD_READ_TIMEOUT", "30"))
+    write_timeout: float = float(os.getenv("HEARTGUARD_WRITE_TIMEOUT", "10"))
+
+
+API_SETTINGS = ApiSettings()
+
+
+class Colors:
+    """Paleta reutilizable para la interfaz."""
+
+    PRIMARY = "#2196F3"
+    PRIMARY_DARK = "#1976D2"
+    ACCENT = "#00BCD4"
+    SUCCESS = "#2ECC71"
+    WARNING = "#FFB300"
+    DANGER = "#E74C3C"
+    BACKGROUND = "#F0F4F9"
+    SURFACE = "#FFFFFF"
+    TEXT_PRIMARY = "#233446"
+    TEXT_SECONDARY = "#68788A"
+    BORDER = "#E1E7EE"
+
+
+class Fonts:
+    """Fuentes comunes para mantener consistencia."""
+
+    TITLE = ("Segoe UI", 20, "bold")
+    SUBTITLE = ("Segoe UI", 12, "normal")
+    BODY = ("Segoe UI", 11, "normal")
+    BODY_BOLD = ("Segoe UI", 11, "bold")
+    CAPTION = ("Segoe UI", 9, "normal")

--- a/tkinter_app/main.py
+++ b/tkinter_app/main.py
@@ -1,0 +1,15 @@
+"""Punto de entrada para la aplicación HeartGuard en Tkinter."""
+
+from __future__ import annotations
+
+from .api_client import ApiClient
+from .ui.login import LoginWindow
+
+
+def main() -> None:
+    root = LoginWindow(ApiClient())
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tkinter_app/models/__init__.py
+++ b/tkinter_app/models/__init__.py
@@ -1,0 +1,15 @@
+"""Exporta modelos para fácil importación."""
+
+from .auth import LoginResponse, PatientLoginData, UserLoginData
+from .user import OrgMembership, UserProfile
+from .patient import PatientProfile, Alert
+
+__all__ = [
+    "LoginResponse",
+    "PatientLoginData",
+    "UserLoginData",
+    "OrgMembership",
+    "UserProfile",
+    "PatientProfile",
+    "Alert",
+]

--- a/tkinter_app/models/auth.py
+++ b/tkinter_app/models/auth.py
@@ -1,0 +1,90 @@
+"""Modelos de autenticación equivalentes a los usados en la app Java."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class UserLoginData:
+    id: Optional[str] = None
+    email: Optional[str] = None
+    name: Optional[str] = None
+    system_role: Optional[str] = None
+    org_count: Optional[str] = None
+
+
+@dataclass
+class PatientLoginData:
+    id: Optional[str] = None
+    email: Optional[str] = None
+    name: Optional[str] = None
+    org_name: Optional[str] = None
+    risk_level: Optional[str] = None
+
+
+@dataclass
+class LoginResponse:
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    token_type: str = "Bearer"
+    expires_in: Optional[int] = None
+    account_type: Optional[str] = None
+    user: Optional[UserLoginData] = None
+    patient: Optional[PatientLoginData] = None
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def full_name(self) -> str:
+        if self.user and self.user.name:
+            return self.user.name
+        if self.patient and self.patient.name:
+            return self.patient.name
+        return "Unknown"
+
+    @property
+    def email(self) -> Optional[str]:
+        if self.user and self.user.email:
+            return self.user.email
+        if self.patient and self.patient.email:
+            return self.patient.email
+        return None
+
+    @property
+    def patient_id(self) -> Optional[str]:
+        if self.patient and self.patient.id:
+            return self.patient.id
+        return None
+
+    @staticmethod
+    def from_api(payload: Dict[str, Any]) -> "LoginResponse":
+        user_data = payload.get("user") or {}
+        patient_data = payload.get("patient") or {}
+        response = LoginResponse(
+            access_token=payload.get("access_token"),
+            refresh_token=payload.get("refresh_token"),
+            token_type=payload.get("token_type", "Bearer"),
+            expires_in=payload.get("expires_in"),
+            account_type=payload.get("account_type"),
+            raw=payload,
+        )
+        if user_data:
+            response.user = UserLoginData(
+                id=user_data.get("id"),
+                email=user_data.get("email"),
+                name=user_data.get("name"),
+                system_role=user_data.get("system_role"),
+                org_count=user_data.get("org_count"),
+            )
+            response.account_type = response.account_type or "user"
+        if patient_data:
+            response.patient = PatientLoginData(
+                id=patient_data.get("id"),
+                email=patient_data.get("email"),
+                name=patient_data.get("name"),
+                org_name=patient_data.get("org_name"),
+                risk_level=patient_data.get("risk_level"),
+            )
+            response.account_type = response.account_type or "patient"
+        return response

--- a/tkinter_app/models/patient.py
+++ b/tkinter_app/models/patient.py
@@ -1,0 +1,57 @@
+"""Modelos para la vista de pacientes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class PatientProfile:
+    id: Optional[str] = None
+    name: Optional[str] = None
+    email: Optional[str] = None
+    birthdate: Optional[str] = None
+    risk_level: Optional[str] = None
+    org_name: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PatientProfile":
+        return cls(
+            id=data.get("id"),
+            name=data.get("name"),
+            email=data.get("email"),
+            birthdate=data.get("birthdate"),
+            risk_level=data.get("risk_level"),
+            org_name=data.get("org_name") or data.get("organization"),
+        )
+
+
+@dataclass
+class Alert:
+    id: Optional[str]
+    status: Optional[str]
+    message: Optional[str]
+    created_at: Optional[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Alert":
+        return cls(
+            id=data.get("id"),
+            status=data.get("status"),
+            message=data.get("message") or data.get("description"),
+            created_at=data.get("created_at"),
+        )
+
+
+def parse_alerts(payload: Dict[str, Any]) -> List[Alert]:
+    data = payload.get("data") or {}
+    alerts = data.get("alerts") if isinstance(data, dict) else None
+    if alerts is None:
+        alerts = payload.get("alerts")
+    result: List[Alert] = []
+    if isinstance(alerts, list):
+        for item in alerts:
+            if isinstance(item, dict):
+                result.append(Alert.from_dict(item))
+    return result

--- a/tkinter_app/models/user.py
+++ b/tkinter_app/models/user.py
@@ -1,0 +1,99 @@
+"""Modelos relacionados con usuarios staff."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class OrgMembership:
+    org_id: str
+    org_code: Optional[str]
+    org_name: Optional[str]
+    role_code: Optional[str]
+    role_label: Optional[str]
+    joined_at: Optional[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OrgMembership":
+        return cls(
+            org_id=data.get("org_id"),
+            org_code=data.get("org_code"),
+            org_name=data.get("org_name"),
+            role_code=data.get("role_code"),
+            role_label=data.get("role_label"),
+            joined_at=data.get("joined_at"),
+        )
+
+    def display_name(self) -> str:
+        if self.org_name:
+            return self.org_name
+        if self.org_code:
+            return self.org_code
+        return self.org_id
+
+    def __str__(self) -> str:  # pragma: no cover - usado por Tkinter
+        return self.display_name()
+
+
+@dataclass
+class UserProfileStatus:
+    code: Optional[str] = None
+    label: Optional[str] = None
+
+
+@dataclass
+class UserProfile:
+    id: Optional[str] = None
+    name: Optional[str] = None
+    email: Optional[str] = None
+    role_code: Optional[str] = None
+    status: Optional[UserProfileStatus] = None
+    two_factor_enabled: bool = False
+    profile_photo_url: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "UserProfile":
+        status_data = data.get("status") or {}
+        status = None
+        if status_data:
+            status = UserProfileStatus(
+                code=status_data.get("code"),
+                label=status_data.get("label"),
+            )
+        return cls(
+            id=data.get("id"),
+            name=data.get("name"),
+            email=data.get("email"),
+            role_code=data.get("role_code"),
+            status=status,
+            two_factor_enabled=bool(data.get("two_factor_enabled")),
+            profile_photo_url=data.get("profile_photo_url"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+        )
+
+
+def parse_memberships(payload: Dict[str, Any]) -> List[OrgMembership]:
+    data = payload.get("data") or {}
+    memberships = []
+    if isinstance(data, dict):
+        raw_memberships = data.get("memberships") or []
+    else:
+        raw_memberships = data
+    for item in raw_memberships:
+        if isinstance(item, dict):
+            memberships.append(OrgMembership.from_dict(item))
+    return memberships
+
+
+def parse_invitations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    data = payload.get("data") or {}
+    if isinstance(data, dict):
+        invitations = data.get("invitations") or []
+    else:
+        invitations = []
+    return [inv for inv in invitations if isinstance(inv, dict)]

--- a/tkinter_app/ui/__init__.py
+++ b/tkinter_app/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Paquete con las pantallas Tkinter."""

--- a/tkinter_app/ui/login.py
+++ b/tkinter_app/ui/login.py
@@ -1,0 +1,344 @@
+"""Ventana de inicio de sesión y registro equivalente a ``LoginFrame``."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Callable, Dict, Optional
+
+from ..api_client import ApiClient, ApiError
+from ..models.auth import LoginResponse
+from ..config import Colors, Fonts
+from .widgets import AsyncMixin, setup_styles, styled_button
+
+
+class LoginWindow(tk.Tk, AsyncMixin):
+    LOGIN_VIEW = "login"
+    REGISTER_USER_VIEW = "register_user"
+    REGISTER_PATIENT_VIEW = "register_patient"
+
+    def __init__(self, api_client: Optional[ApiClient] = None) -> None:
+        super().__init__()
+        self.title("HeartGuard - Sistema de Monitoreo Cardíaco")
+        self.geometry("560x720")
+        self.resizable(False, False)
+        setup_styles(self)
+
+        self.api_client = api_client or ApiClient()
+        self._views: Dict[str, tk.Frame] = {}
+
+        container = ttk.Frame(self, padding=24)
+        container.pack(fill="both", expand=True)
+
+        for view_cls in (_LoginFrame, _RegisterUserFrame, _RegisterPatientFrame):
+            view = view_cls(container, self.api_client, self)
+            view.grid(row=0, column=0, sticky="nsew")
+            self._views[view.name] = view
+
+        container.grid_rowconfigure(0, weight=1)
+        container.grid_columnconfigure(0, weight=1)
+
+        self.show_view(self.LOGIN_VIEW)
+
+    # AsyncMixin requiere after -> Tk lo provee
+
+    def show_view(self, name: str) -> None:
+        self._views[name].tkraise()
+
+    # Navegación a dashboards -------------------------------------------------
+    def open_dashboard(self, response: LoginResponse) -> None:
+        if response.account_type == "patient":
+            from .patient_dashboard import PatientDashboardWindow
+
+            dashboard = PatientDashboardWindow(self.api_client, response)
+            dashboard.focus_force()
+        else:
+            from .user_dashboard import UserDashboardWindow
+
+            dashboard = UserDashboardWindow(self.api_client, response)
+            dashboard.focus_force()
+        self.withdraw()
+
+
+class _BaseView(ttk.Frame, AsyncMixin):
+    name: str
+
+    def __init__(self, master: tk.Widget, api_client: ApiClient, controller: LoginWindow) -> None:
+        super().__init__(master)
+        self.api_client = api_client
+        self.controller = controller
+        self.configure(style="Card.TFrame")
+
+    def after(self, delay_ms: int, callback: Callable, *args):  # type: ignore[override]
+        return self.controller.after(delay_ms, callback, *args)
+
+    def show_login(self) -> None:
+        self.controller.show_view(LoginWindow.LOGIN_VIEW)
+
+
+class _LoginFrame(_BaseView):
+    name = LoginWindow.LOGIN_VIEW
+
+    def __init__(self, master: tk.Widget, api_client: ApiClient, controller: LoginWindow) -> None:
+        super().__init__(master, api_client, controller)
+        self._status = tk.StringVar(value=" ")
+        self._account_type = tk.StringVar(value="user")
+
+        title = ttk.Label(self, text="HeartGuard", font=("Arial", 28, "bold"), foreground=Colors.PRIMARY)
+        subtitle = ttk.Label(self, text="Sistema de Monitoreo Cardíaco", font=Fonts.SUBTITLE, foreground=Colors.TEXT_SECONDARY)
+        title.pack(pady=(10, 4))
+        subtitle.pack(pady=(0, 24))
+
+        form = ttk.Frame(self)
+        form.pack(fill="x", padx=8)
+
+        type_label = ttk.Label(form, text="Tipo de cuenta:", font=Fonts.BODY_BOLD)
+        type_label.grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 4))
+
+        ttk.Radiobutton(form, text="Usuario (Staff)", variable=self._account_type, value="user").grid(row=1, column=0, sticky="w")
+        ttk.Radiobutton(form, text="Paciente", variable=self._account_type, value="patient").grid(row=1, column=1, sticky="w")
+
+        ttk.Label(form, text="Email:").grid(row=2, column=0, sticky="w", pady=(12, 0))
+        self._email_entry = ttk.Entry(form, width=30)
+        self._email_entry.grid(row=2, column=1, sticky="ew", pady=(12, 0))
+
+        ttk.Label(form, text="Contraseña:").grid(row=3, column=0, sticky="w", pady=(12, 0))
+        self._password_entry = ttk.Entry(form, width=30, show="*")
+        self._password_entry.grid(row=3, column=1, sticky="ew", pady=(12, 0))
+
+        form.columnconfigure(1, weight=1)
+
+        buttons = ttk.Frame(self)
+        buttons.pack(pady=20)
+
+        login_button = styled_button(buttons, "Iniciar Sesión", self._on_login)
+        register_button = styled_button(buttons, "Registrarse", self._on_register, primary=False)
+        login_button.grid(row=0, column=0, padx=6)
+        register_button.grid(row=0, column=1, padx=6)
+
+        self._status_label = ttk.Label(self, textvariable=self._status, foreground=Colors.DANGER, anchor="center")
+        self._status_label.pack(fill="x")
+
+        self.bind("<Return>", lambda _e: self._on_login())
+
+    def _set_status(self, text: str, *, error: bool = False) -> None:
+        self._status.set(text)
+        self._status_label.configure(foreground=Colors.DANGER if error else Colors.PRIMARY)
+
+    def _on_register(self) -> None:
+        if self._account_type.get() == "user":
+            self.controller.show_view(LoginWindow.REGISTER_USER_VIEW)
+        else:
+            self.controller.show_view(LoginWindow.REGISTER_PATIENT_VIEW)
+
+    def _on_login(self) -> None:
+        email = self._email_entry.get().strip()
+        password = self._password_entry.get().strip()
+
+        if not email or not password:
+            self._set_status("Por favor complete todos los campos", error=True)
+            return
+
+        self._set_status("Iniciando sesión...", error=False)
+
+        def handle_success(response: LoginResponse) -> None:
+            self._set_status("¡Inicio de sesión exitoso!", error=False)
+            self.controller.open_dashboard(response)
+
+        def handle_error(exc: Exception) -> None:
+            if isinstance(exc, ApiError):
+                self._set_status(f"Error: {exc}", error=True)
+            else:
+                messagebox.showerror("Error", str(exc))
+                self._set_status("Error de conexión", error=True)
+
+        account_type = self._account_type.get()
+        func = self.api_client.login_user if account_type == "user" else self.api_client.login_patient
+        self.run_async(func, handle_success, handle_error, email, password)
+
+
+class _RegisterUserFrame(_BaseView):
+    name = LoginWindow.REGISTER_USER_VIEW
+
+    def __init__(self, master: tk.Widget, api_client: ApiClient, controller: LoginWindow) -> None:
+        super().__init__(master, api_client, controller)
+        self._status = tk.StringVar(value=" ")
+
+        title = ttk.Label(self, text="Registro de Usuario (Staff)", font=Fonts.TITLE)
+        title.pack(pady=(0, 16))
+
+        form = ttk.Frame(self)
+        form.pack(fill="x", padx=16)
+
+        self._email = ttk.Entry(form, width=30)
+        self._password = ttk.Entry(form, width=30, show="*")
+        self._confirm = ttk.Entry(form, width=30, show="*")
+        self._name = ttk.Entry(form, width=30)
+        self._name.insert(0, "Ej: Dr. Juan Pérez López")
+
+        self._add_field(form, 0, "*Email:", self._email)
+        self._add_field(form, 1, "*Contraseña:", self._password)
+        self._add_field(form, 2, "*Confirmar Contraseña:", self._confirm)
+        self._add_field(form, 3, "*Nombre Completo:", self._name)
+
+        ttk.Label(form, text="Nota: Se unirá a organizaciones mediante invitaciones", foreground=Colors.TEXT_SECONDARY).grid(row=4, column=0, columnspan=2, pady=(12, 0), sticky="w")
+
+        buttons = ttk.Frame(self)
+        buttons.pack(pady=24)
+
+        styled_button(buttons, "Registrar", self._on_register).grid(row=0, column=0, padx=6)
+        styled_button(buttons, "Volver", self.show_login, primary=False).grid(row=0, column=1, padx=6)
+
+        ttk.Label(self, textvariable=self._status, foreground=Colors.DANGER).pack(fill="x")
+
+    def _add_field(self, form: ttk.Frame, row: int, label: str, entry: ttk.Entry) -> None:
+        ttk.Label(form, text=label).grid(row=row, column=0, sticky="w", pady=6)
+        entry.grid(row=row, column=1, sticky="ew", pady=6)
+        form.columnconfigure(1, weight=1)
+
+    def _on_register(self) -> None:
+        email = self._email.get().strip()
+        password = self._password.get().strip()
+        confirm = self._confirm.get().strip()
+        name = self._name.get().strip()
+
+        if not email or not password or not name:
+            self._status.set("Por favor complete todos los campos obligatorios (*)")
+            return
+        if password != confirm:
+            self._status.set("Las contraseñas no coinciden")
+            return
+        if len(password) < 8:
+            self._status.set("La contraseña debe tener al menos 8 caracteres")
+            return
+
+        self._status.set("Registrando usuario...")
+
+        def handle_success(_payload: Dict[str, Any]) -> None:
+            messagebox.showinfo(
+                "Registro Exitoso",
+                "Usuario registrado exitosamente!\n\n"
+                f"Email: {email}\nNombre: {name}\n\nAhora puedes iniciar sesión.",
+            )
+            self._email.delete(0, tk.END)
+            self._password.delete(0, tk.END)
+            self._confirm.delete(0, tk.END)
+            self._name.delete(0, tk.END)
+            self._status.set("¡Registro exitoso!")
+            self.show_login()
+
+        def handle_error(exc: Exception) -> None:
+            if isinstance(exc, ApiError):
+                self._status.set(f"Error: {exc}")
+            else:
+                self._status.set("Error de conexión: {}".format(exc))
+
+        self.run_async(self.api_client.register_user, handle_success, handle_error, email, password, name)
+
+
+class _RegisterPatientFrame(_BaseView):
+    name = LoginWindow.REGISTER_PATIENT_VIEW
+
+    def __init__(self, master: tk.Widget, api_client: ApiClient, controller: LoginWindow) -> None:
+        super().__init__(master, api_client, controller)
+        self._status = tk.StringVar(value=" ")
+
+        title = ttk.Label(self, text="Registro de Paciente", font=Fonts.TITLE)
+        title.pack(pady=(0, 12))
+
+        note = ttk.Label(
+            self,
+            text="Ingrese el código o ID de la organización. Se detectará automáticamente el formato.",
+            wraplength=460,
+            foreground=Colors.TEXT_SECONDARY,
+        )
+        note.pack(pady=(0, 12))
+
+        form = ttk.Frame(self)
+        form.pack(fill="x", padx=16)
+
+        self._fields: Dict[str, ttk.Entry] = {
+            "email": ttk.Entry(form, width=30),
+            "password": ttk.Entry(form, width=30, show="*"),
+            "confirm": ttk.Entry(form, width=30, show="*"),
+            "name": ttk.Entry(form, width=30),
+            "org": ttk.Entry(form, width=30),
+            "birthdate": ttk.Entry(form, width=30),
+            "sex": ttk.Entry(form, width=30),
+            "risk": ttk.Entry(form, width=30),
+        }
+
+        labels = [
+            "*Email:",
+            "*Contraseña:",
+            "*Confirmar Contraseña:",
+            "*Nombre Completo:",
+            "*Código o ID de Organización:",
+            "*Fecha de Nacimiento (YYYY-MM-DD):",
+            "*Sexo (M/F/O):",
+            "Nivel de Riesgo (opcional):",
+        ]
+
+        for idx, (key, entry) in enumerate(self._fields.items()):
+            ttk.Label(form, text=labels[idx]).grid(row=idx, column=0, sticky="w", pady=5)
+            entry.grid(row=idx, column=1, sticky="ew", pady=5)
+        form.columnconfigure(1, weight=1)
+
+        buttons = ttk.Frame(self)
+        buttons.pack(pady=24)
+
+        styled_button(buttons, "Registrar Paciente", self._on_register).grid(row=0, column=0, padx=6)
+        styled_button(buttons, "Volver", self.show_login, primary=False).grid(row=0, column=1, padx=6)
+
+        ttk.Label(self, textvariable=self._status, foreground=Colors.DANGER).pack(fill="x")
+
+    def _on_register(self) -> None:
+        email = self._fields["email"].get().strip()
+        password = self._fields["password"].get().strip()
+        confirm = self._fields["confirm"].get().strip()
+        name = self._fields["name"].get().strip()
+        org = self._fields["org"].get().strip()
+        birthdate = self._fields["birthdate"].get().strip()
+        sex = self._fields["sex"].get().strip()
+        risk = self._fields["risk"].get().strip()
+
+        if not all([email, password, name, org, birthdate, sex]):
+            self._status.set("Por favor complete todos los campos obligatorios (*)")
+            return
+        if password != confirm:
+            self._status.set("Las contraseñas no coinciden")
+            return
+        if len(password) < 8:
+            self._status.set("La contraseña debe tener al menos 8 caracteres")
+            return
+
+        self._status.set("Registrando paciente...")
+
+        def handle_success(_payload: Dict[str, Any]) -> None:
+            messagebox.showinfo(
+                "Registro Exitoso",
+                "Paciente registrado exitosamente. Ahora puedes iniciar sesión.",
+            )
+            for entry in self._fields.values():
+                entry.delete(0, tk.END)
+            self._status.set("¡Registro exitoso!")
+            self.show_login()
+
+        def handle_error(exc: Exception) -> None:
+            if isinstance(exc, ApiError):
+                self._status.set(f"Error: {exc}")
+            else:
+                self._status.set(f"Error de conexión: {exc}")
+
+        self.run_async(
+            self.api_client.register_patient,
+            handle_success,
+            handle_error,
+            email,
+            password,
+            name,
+            org,
+            birthdate,
+            sex,
+            risk or None,
+        )

--- a/tkinter_app/ui/patient_dashboard.py
+++ b/tkinter_app/ui/patient_dashboard.py
@@ -1,0 +1,250 @@
+"""Ventana Tkinter que replica ``PatientDashboardPanel`` de Swing."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+from typing import Any, Dict, List, Optional
+
+from ..api_client import ApiClient
+from ..models import auth as auth_models
+from ..config import Colors, Fonts
+from .widgets import AsyncMixin, ScrollableFrame, setup_styles, styled_button
+
+
+class PatientDashboardWindow(tk.Toplevel, AsyncMixin):
+    def __init__(self, api_client: ApiClient, login_response: auth_models.LoginResponse) -> None:
+        super().__init__()
+        self.api_client = api_client
+        self.login_response = login_response
+        self.title("HeartGuard - Mi Portal de Salud")
+        self.geometry("1100x780")
+        self.configure(background=Colors.BACKGROUND)
+        setup_styles(self)
+
+        header = ttk.Frame(self, padding=24)
+        header.pack(fill="x")
+        ttk.Label(header, text="Mi Portal de Salud", font=("Segoe UI", 24, "bold"), foreground=Colors.PRIMARY).pack(anchor="w")
+        ttk.Label(
+            header,
+            text="Resumen personalizado de tu bienestar y seguimiento clínico",
+            font=Fonts.SUBTITLE,
+            foreground=Colors.TEXT_SECONDARY,
+        ).pack(anchor="w")
+
+        body = ScrollableFrame(self)
+        body.pack(fill="both", expand=True, padx=24, pady=(0, 24))
+
+        self.profile_section = _ProfileSection(body.content)
+        self.profile_section.frame.pack(fill="x", pady=8)
+
+        self.stats_section = _StatsSection(body.content)
+        self.stats_section.frame.pack(fill="x", pady=8)
+
+        self.alerts_section = _AlertsSection(body.content)
+        self.alerts_section.frame.pack(fill="x", pady=8)
+
+        self.care_team_section = _CareTeamSection(body.content)
+        self.care_team_section.frame.pack(fill="x", pady=8)
+
+        self.caregivers_section = _CaregiversSection(body.content)
+        self.caregivers_section.frame.pack(fill="x", pady=8)
+
+        self.locations_section = _LocationsSection(body.content)
+        self.locations_section.frame.pack(fill="x", pady=8)
+
+        actions = ttk.Frame(self, padding=(24, 0, 24, 24))
+        actions.pack(fill="x")
+        styled_button(actions, "Actualizar", self.refresh).pack(side="left")
+        styled_button(actions, "Cerrar Sesión", self.logout, primary=False).pack(side="right")
+
+        self.refresh()
+
+    # AsyncMixin -> after provisto por Tk
+
+    def refresh(self) -> None:
+        token = self.login_response.access_token
+
+        def on_success(payloads: Dict[str, Dict[str, Any]]) -> None:
+            dashboard = payloads["dashboard"]
+            self.profile_section.update(dashboard.get("profile") or {})
+            self.stats_section.update(dashboard.get("metrics") or {}, payloads.get("devices"))
+            self.alerts_section.update(payloads.get("alerts") or {})
+            self.care_team_section.update(payloads.get("care_team") or {})
+            self.caregivers_section.update(payloads.get("caregivers") or {})
+            self.locations_section.update(payloads.get("locations") or {})
+
+        def on_error(exc: Exception) -> None:
+            messagebox.showerror("Error", f"No se pudo actualizar el dashboard: {exc}")
+
+        def fetch_all() -> Dict[str, Dict[str, Any]]:
+            return {
+                "dashboard": self.api_client.get_patient_dashboard(token),
+                "alerts": self.api_client.get_patient_alerts(token=token, limit=6),
+                "devices": self.api_client.get_patient_devices(token=token),
+                "care_team": self.api_client.get_patient_care_team(token=token),
+                "caregivers": self.api_client.get_patient_caregivers(token=token),
+                "locations": self.api_client.get_patient_locations(token=token, limit=6),
+            }
+
+        self.run_async(fetch_all, on_success, on_error)
+
+    def logout(self) -> None:
+        self.destroy()
+
+
+class _Section:
+    def __init__(self, master: tk.Widget, title: str) -> None:
+        self.frame = ttk.LabelFrame(master, text=title, padding=16)
+        self.frame.configure(labelanchor="n")
+
+
+class _ProfileSection(_Section):
+    def __init__(self, master: tk.Widget) -> None:
+        super().__init__(master, "Información Personal")
+        self.labels: Dict[str, tk.StringVar] = {
+            "name": tk.StringVar(value="--"),
+            "email": tk.StringVar(value="--"),
+            "birthdate": tk.StringVar(value="--"),
+            "risk": tk.StringVar(value="--"),
+            "org": tk.StringVar(value="--"),
+        }
+        grid = ttk.Frame(self.frame)
+        grid.pack(fill="x")
+        for row, (label, var) in enumerate(self.labels.items()):
+            ttk.Label(grid, text={
+                "name": "Nombre",
+                "email": "Email",
+                "birthdate": "Fecha de Nacimiento",
+                "risk": "Nivel de Riesgo",
+                "org": "Organización",
+            }[label]).grid(row=row, column=0, sticky="w", pady=4)
+            ttk.Label(grid, textvariable=var, font=Fonts.BODY_BOLD).grid(row=row, column=1, sticky="w", pady=4)
+
+    def update(self, profile: Dict[str, Any]) -> None:
+        self.labels["name"].set(profile.get("name") or "--")
+        self.labels["email"].set(profile.get("email") or "--")
+        self.labels["birthdate"].set(profile.get("birthdate") or "--")
+        risk = profile.get("risk_level") or profile.get("risk") or "--"
+        self.labels["risk"].set(risk)
+        org = profile.get("org_name") or profile.get("organization") or "--"
+        self.labels["org"].set(org)
+
+
+class _StatsSection(_Section):
+    def __init__(self, master: tk.Widget) -> None:
+        super().__init__(master, "Métricas de Salud")
+        self.metrics = {
+            "alerts": tk.StringVar(value="0"),
+            "pending": tk.StringVar(value="0"),
+            "devices": tk.StringVar(value="0"),
+            "last_reading": tk.StringVar(value="--"),
+        }
+        grid = ttk.Frame(self.frame)
+        grid.pack(fill="x")
+        labels = {
+            "alerts": "Alertas totales",
+            "pending": "Alertas pendientes",
+            "devices": "Dispositivos activos",
+            "last_reading": "Última lectura",
+        }
+        for col, key in enumerate(labels):
+            card = ttk.Frame(grid, padding=12, borderwidth=1, relief="ridge")
+            card.grid(row=0, column=col, padx=6, sticky="nsew")
+            ttk.Label(card, text=labels[key], font=Fonts.SUBTITLE).pack()
+            ttk.Label(card, textvariable=self.metrics[key], font=("Segoe UI", 16, "bold"), foreground=Colors.PRIMARY).pack()
+        for col in range(len(labels)):
+            grid.columnconfigure(col, weight=1)
+
+    def update(self, metrics: Dict[str, Any], devices_payload: Optional[Dict[str, Any]]) -> None:
+        data = metrics.get("data") if isinstance(metrics.get("data"), dict) else metrics
+        alerts = data.get("alerts") if isinstance(data, dict) else {}
+        self.metrics["alerts"].set(str(alerts.get("total") or data.get("alerts_total") or "0"))
+        self.metrics["pending"].set(str(alerts.get("pending") or data.get("alerts_pending") or "0"))
+        if devices_payload:
+            devices_data = devices_payload.get("data") or {}
+            self.metrics["devices"].set(str(devices_data.get("count") or len(devices_data.get("devices") or [])))
+        last_reading = data.get("last_reading") or "--"
+        if isinstance(last_reading, dict):
+            last_reading = last_reading.get("measured_at") or last_reading.get("value")
+        self.metrics["last_reading"].set(str(last_reading or "--"))
+
+
+class _AlertsSection(_Section):
+    def __init__(self, master: tk.Widget) -> None:
+        super().__init__(master, "Alertas Recientes")
+        self.listbox = tk.Listbox(self.frame, height=6)
+        self.listbox.pack(fill="both", expand=True)
+
+    def update(self, payload: Dict[str, Any]) -> None:
+        self.listbox.delete(0, tk.END)
+        alerts = payload.get("data", {}).get("alerts") or payload.get("alerts") or []
+        for alert in alerts:
+            if isinstance(alert, dict):
+                item = f"[{alert.get('status', 'N/A')}] {alert.get('message') or alert.get('description', '')}"
+                self.listbox.insert(tk.END, item)
+        if not alerts:
+            self.listbox.insert(tk.END, "No hay alertas recientes")
+
+
+class _CareTeamSection(_Section):
+    def __init__(self, master: tk.Widget) -> None:
+        super().__init__(master, "Equipo de Cuidado")
+        self.tree = ttk.Treeview(self.frame, columns=("rol", "contacto"), show="headings")
+        self.tree.heading("rol", text="Rol")
+        self.tree.heading("contacto", text="Contacto")
+        self.tree.pack(fill="both", expand=True)
+
+    def update(self, payload: Dict[str, Any]) -> None:
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        members = payload.get("data", {}).get("members") or payload.get("members") or []
+        for member in members:
+            if isinstance(member, dict):
+                role = member.get("role_label") or member.get("role")
+                contact = member.get("email") or member.get("phone")
+                self.tree.insert("", tk.END, values=(role, contact))
+        if not members:
+            self.tree.insert("", tk.END, values=("--", "No hay equipo asignado"))
+
+
+class _CaregiversSection(_Section):
+    def __init__(self, master: tk.Widget) -> None:
+        super().__init__(master, "Cuidadores")
+        self.listbox = tk.Listbox(self.frame, height=5)
+        self.listbox.pack(fill="both", expand=True)
+
+    def update(self, payload: Dict[str, Any]) -> None:
+        self.listbox.delete(0, tk.END)
+        caregivers = payload.get("data", {}).get("caregivers") or payload.get("caregivers") or []
+        for caregiver in caregivers:
+            if isinstance(caregiver, dict):
+                name = caregiver.get("name") or caregiver.get("full_name")
+                role = caregiver.get("relationship") or caregiver.get("role")
+                self.listbox.insert(tk.END, f"{name} - {role}")
+        if not caregivers:
+            self.listbox.insert(tk.END, "No hay cuidadores registrados")
+
+
+class _LocationsSection(_Section):
+    def __init__(self, master: tk.Widget) -> None:
+        super().__init__(master, "Ubicaciones Recientes")
+        ttk.Label(
+            self.frame,
+            text="Por limitaciones de Tkinter, mostramos la lista de ubicaciones en lugar del mapa embebido de JavaFX.",
+            wraplength=720,
+            foreground=Colors.TEXT_SECONDARY,
+        ).pack(fill="x", pady=(0, 8))
+        self.listbox = tk.Listbox(self.frame, height=6)
+        self.listbox.pack(fill="both", expand=True)
+
+    def update(self, payload: Dict[str, Any]) -> None:
+        self.listbox.delete(0, tk.END)
+        locations = payload.get("data", {}).get("locations") or payload.get("locations") or []
+        for item in locations:
+            if isinstance(item, dict):
+                coord = item.get("latitude"), item.get("longitude")
+                timestamp = item.get("recorded_at") or item.get("created_at")
+                self.listbox.insert(tk.END, f"{timestamp} - {coord[0]}, {coord[1]}")
+        if not locations:
+            self.listbox.insert(tk.END, "No hay ubicaciones registradas")

--- a/tkinter_app/ui/user_dashboard.py
+++ b/tkinter_app/ui/user_dashboard.py
@@ -1,0 +1,711 @@
+"""Ventana Tkinter equivalente a ``UserDashboardFrame`` y paneles relacionados."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Any, Callable, Dict, List, Optional
+
+from ..api_client import ApiClient, ApiError
+from ..config import Colors, Fonts
+from ..models import auth as auth_models
+from ..models.user import OrgMembership, UserProfile, parse_invitations, parse_memberships
+from ..utils.async_utils import run_in_executor
+from .widgets import AsyncMixin, ScrollableFrame, setup_styles, styled_button
+
+
+class UserDashboardWindow(tk.Toplevel, AsyncMixin):
+    def __init__(self, api_client: ApiClient, login_response: auth_models.LoginResponse) -> None:
+        super().__init__()
+        self.api_client = api_client
+        self.login_response = login_response
+        self.token = login_response.access_token
+        self.title("HeartGuard - Command Center")
+        self.geometry("1280x840")
+        self.configure(background=Colors.BACKGROUND)
+        setup_styles(self)
+
+        self.profile: Optional[UserProfile] = None
+        self.memberships: List[OrgMembership] = []
+        self.selected_membership: Optional[OrgMembership] = None
+
+        self._build_header()
+        self._build_body()
+
+        self._load_initial_data()
+
+    def after(self, delay_ms: int, callback: Any, *args: Any) -> None:  # type: ignore[override]
+        return super().after(delay_ms, callback, *args)
+
+    # UI ------------------------------------------------------------------
+    def _build_header(self) -> None:
+        header = ttk.Frame(self, padding=24)
+        header.pack(fill="x")
+
+        left = ttk.Frame(header)
+        left.pack(side="left", anchor="w")
+        ttk.Label(left, text="💙", font=("Segoe UI Emoji", 28)).pack(side="left")
+        ttk.Label(left, text="HeartGuard", font=("Inter", 24, "bold"), foreground=Colors.PRIMARY).pack(side="left", padx=6)
+        ttk.Label(left, text="Command Center", font=Fonts.SUBTITLE, foreground=Colors.TEXT_SECONDARY).pack(side="left")
+
+        center = ttk.Frame(header)
+        center.pack(side="left", expand=True)
+        ttk.Label(center, text="Organización:", font=Fonts.BODY).pack(side="left")
+        self.org_var = tk.StringVar()
+        self.org_selector = ttk.Combobox(center, textvariable=self.org_var, state="readonly", width=40)
+        self.org_selector.pack(side="left", padx=12)
+        self.org_selector.bind("<<ComboboxSelected>>", lambda _e: self._on_membership_selected())
+
+        right = ttk.Frame(header)
+        right.pack(side="right")
+        self.name_label = ttk.Label(right, text=self.login_response.full_name, font=Fonts.BODY_BOLD)
+        self.name_label.pack(anchor="e")
+        ttk.Label(right, text=self.login_response.email or "", font=Fonts.CAPTION, foreground=Colors.TEXT_SECONDARY).pack(anchor="e")
+
+        buttons = ttk.Frame(right)
+        buttons.pack(anchor="e", pady=(12, 0))
+        styled_button(buttons, "Mi Perfil", self._open_profile_dialog, primary=False, width=14).pack(side="left", padx=4)
+        styled_button(buttons, "Invitaciones", self._open_invitations_dialog, primary=False, width=14).pack(side="left", padx=4)
+        styled_button(buttons, "Cerrar Sesión", self.destroy, primary=False, width=14).pack(side="left", padx=4)
+
+    def _build_body(self) -> None:
+        self.body = ScrollableFrame(self)
+        self.body.pack(fill="both", expand=True, padx=24, pady=(0, 24))
+
+        self.empty_state = ttk.Frame(self.body.content, padding=40)
+        ttk.Label(self.empty_state, text="Aún no perteneces a una organización", font=("Inter", 18, "bold")).pack(pady=8)
+        ttk.Label(
+            self.empty_state,
+            text="Solicita acceso o revisa tus invitaciones pendientes",
+            font=Fonts.BODY,
+            foreground=Colors.TEXT_SECONDARY,
+        ).pack(pady=8)
+        styled_button(self.empty_state, "Ver mis invitaciones", self._open_invitations_dialog).pack(pady=12)
+
+        self.dashboard_panel = UserDashboardPanel(self.body.content, self.api_client, self.token, self._handle_api_error)
+
+    # Data -----------------------------------------------------------------
+    def _load_initial_data(self) -> None:
+        def on_success(payload: Dict[str, Any]) -> None:
+            self.profile = payload["profile"]
+            self.memberships = payload["memberships"]
+            self.name_label.configure(text=self.profile.name or self.login_response.full_name)
+
+            if not self.memberships:
+                self.empty_state.pack(fill="both", expand=True)
+            else:
+                self.empty_state.pack_forget()
+                self.org_selector["values"] = [m.display_name() for m in self.memberships]
+                self.org_selector.current(0)
+                self.selected_membership = self.memberships[0]
+                self.dashboard_panel.frame.pack(fill="both", expand=True)
+                self.dashboard_panel.load_membership(self.selected_membership)
+
+        def on_error(exc: Exception) -> None:
+            messagebox.showerror("Error", f"No se pudo cargar la información inicial: {exc}")
+
+        def fetch() -> Dict[str, Any]:
+            profile_payload = self.api_client.get_current_user_profile(self.token)
+            memberships_payload = self.api_client.get_current_user_memberships(self.token)
+            return {
+                "profile": UserProfile.from_dict(profile_payload.get("data") or profile_payload),
+                "memberships": parse_memberships(memberships_payload),
+            }
+
+        self.run_async(fetch, on_success, on_error)
+
+    def _on_membership_selected(self) -> None:
+        index = self.org_selector.current()
+        if index < 0 or index >= len(self.memberships):
+            return
+        membership = self.memberships[index]
+        self.selected_membership = membership
+        self.dashboard_panel.load_membership(membership)
+
+    def _handle_api_error(self, exc: Exception) -> None:
+        if isinstance(exc, ApiError) and exc.status_code == 401:
+            messagebox.showwarning("Sesión expirada", "Sesión expirada. Por favor, vuelve a iniciar sesión.")
+            self.destroy()
+        else:
+            messagebox.showerror("Error", str(exc))
+
+    # Dialogs --------------------------------------------------------------
+    def _open_profile_dialog(self) -> None:
+        if not self.profile:
+            messagebox.showinfo("Perfil", "La información del perfil aún no está disponible.")
+            return
+        UserProfileDialog(self, self.api_client, self.token, self.profile, self._refresh_profile)
+
+    def _refresh_profile(self) -> None:
+        def fetch() -> UserProfile:
+            payload = self.api_client.get_current_user_profile(self.token)
+            return UserProfile.from_dict(payload.get("data") or payload)
+
+        def on_success(profile: UserProfile) -> None:
+            self.profile = profile
+            self.name_label.configure(text=profile.name or self.login_response.full_name)
+
+        self.run_async(fetch, on_success, self._handle_api_error)
+
+    def _open_invitations_dialog(self) -> None:
+        dialog = InvitationsDialog(self, self.api_client, self.token)
+        self.wait_window(dialog)
+        # Recargar membresías por si cambió algo
+        self._load_initial_data()
+
+
+class UserDashboardPanel:
+    def __init__(self, master: tk.Widget, api_client: ApiClient, token: str, error_handler: Callable[[Exception], None]) -> None:
+        self.api_client = api_client
+        self.token = token
+        self.error_handler = error_handler
+
+        self.frame = ttk.Frame(master)
+
+        self.metrics_section = _MetricsSection(self.frame)
+        self.metrics_section.frame.pack(fill="x", pady=8)
+
+        self.map_section = _MapSection(self.frame)
+        self.map_section.frame.pack(fill="x", pady=8)
+
+        self.patients_section = _PatientsSection(self.frame, self._open_patient_detail)
+        self.patients_section.frame.pack(fill="x", pady=8)
+
+        self.devices_section = _DevicesSection(self.frame)
+        self.devices_section.frame.pack(fill="x", pady=8)
+
+        self.alerts_section = _AlertsBoardSection(self.frame)
+        self.alerts_section.frame.pack(fill="x", pady=8)
+
+        self.current_membership: Optional[OrgMembership] = None
+
+    def load_membership(self, membership: OrgMembership) -> None:
+        self.current_membership = membership
+
+        def on_success(payload: Dict[str, Any]) -> None:
+            self.metrics_section.update(payload["dashboard"], payload["metrics"])
+            self.map_section.update(payload["caregiver_locations"], payload["care_team_locations"])
+            self.patients_section.update(
+                membership,
+                payload["caregiver_patients"],
+                payload["care_team_patients"],
+            )
+            self.devices_section.update(payload["care_teams"], membership, self._fetch_team_devices)
+            self.alerts_section.update(payload["caregiver_patients"], self._open_patient_detail, membership)
+
+        def on_error(exc: Exception) -> None:
+            self.error_handler(exc)
+
+        def fetch() -> Dict[str, Any]:
+            org_id = membership.org_id
+            return {
+                "dashboard": self.api_client.get_organization_dashboard(org_id, token=self.token),
+                "metrics": self.api_client.get_organization_metrics(org_id, token=self.token),
+                "care_teams": self.api_client.get_organization_care_teams(org_id, token=self.token),
+                "care_team_patients": self.api_client.get_organization_care_team_patients(org_id, token=self.token),
+                "caregiver_patients": self.api_client.get_caregiver_patients(token=self.token),
+                "care_team_locations": self.api_client.get_care_team_locations({"org_id": org_id}, token=self.token),
+                "caregiver_locations": self.api_client.get_caregiver_patient_locations({"org_id": org_id}, token=self.token),
+            }
+
+        future = run_in_executor(fetch)
+
+        def done(fut):
+            try:
+                payload = fut.result()
+            except Exception as exc:  # pragma: no cover - depende de IO
+                self.frame.after(0, lambda: on_error(exc))
+                return
+            self.frame.after(0, lambda: on_success(payload))
+
+        future.add_done_callback(done)
+
+    # ------------------------------------------------------------------
+    def _fetch_team_devices(self, membership: OrgMembership, team_id: str,
+                             on_success: Callable[[Dict[str, Any]], None],
+                             on_error: Callable[[Exception], None]) -> None:
+
+        def fetch() -> Dict[str, Any]:
+            active = self.api_client.get_care_team_devices(membership.org_id, team_id, token=self.token)
+            disconnected = self.api_client.get_care_team_disconnected_devices(membership.org_id, team_id, token=self.token)
+            return {"active": active, "disconnected": disconnected}
+
+        future = run_in_executor(fetch)
+
+        def done(fut):
+            try:
+                payload = fut.result()
+            except Exception as exc:  # pragma: no cover
+                self.frame.after(0, lambda: on_error(exc))
+                return
+            self.frame.after(0, lambda: on_success(payload))
+
+        future.add_done_callback(done)
+
+    def _open_patient_detail(self, membership: OrgMembership, patient_id: str, patient_name: str) -> None:
+        PatientDetailDialog(self.frame.winfo_toplevel(), self.api_client, self.token, membership, patient_id, patient_name)
+
+
+class _MetricsSection:
+    def __init__(self, master: tk.Widget) -> None:
+        self.frame = ttk.LabelFrame(master, text="Indicadores principales", padding=16)
+        self.vars = {
+            "patients": tk.StringVar(value="0"),
+            "alerts": tk.StringVar(value="0"),
+            "devices": tk.StringVar(value="0"),
+            "caregivers": tk.StringVar(value="0"),
+        }
+        grid = ttk.Frame(self.frame)
+        grid.pack(fill="x")
+        labels = {
+            "patients": "Pacientes activos",
+            "alerts": "Alertas abiertas",
+            "devices": "Dispositivos activos",
+            "caregivers": "Caregivers activos",
+        }
+        for col, key in enumerate(labels):
+            card = ttk.Frame(grid, padding=12, borderwidth=1, relief="ridge")
+            card.grid(row=0, column=col, padx=8, sticky="nsew")
+            ttk.Label(card, text=labels[key], font=Fonts.SUBTITLE).pack()
+            ttk.Label(card, textvariable=self.vars[key], font=("Segoe UI", 18, "bold"), foreground=Colors.PRIMARY).pack()
+            grid.columnconfigure(col, weight=1)
+
+    def update(self, dashboard_payload: Dict[str, Any], metrics_payload: Dict[str, Any]) -> None:
+        data = dashboard_payload.get("data") or dashboard_payload
+        self.vars["patients"].set(str(data.get("patients", {}).get("active") if isinstance(data.get("patients"), dict) else data.get("patients_active", 0)))
+        self.vars["alerts"].set(str(data.get("alerts", {}).get("open") if isinstance(data.get("alerts"), dict) else data.get("alerts_open", 0)))
+        metrics = metrics_payload.get("data") or metrics_payload
+        self.vars["devices"].set(str(metrics.get("devices", {}).get("active") if isinstance(metrics.get("devices"), dict) else metrics.get("devices_active", 0)))
+        caregivers = metrics.get("caregivers", {}) if isinstance(metrics.get("caregivers"), dict) else {}
+        self.vars["caregivers"].set(str(caregivers.get("active", metrics.get("caregivers_active", 0))))
+
+
+class _MapSection:
+    def __init__(self, master: tk.Widget) -> None:
+        self.frame = ttk.LabelFrame(master, text="Mapa de ubicaciones", padding=16)
+        ttk.Label(
+            self.frame,
+            text="Mostramos la lista de ubicaciones recientes debido a que Tkinter no soporta JavaFX WebView.",
+            foreground=Colors.TEXT_SECONDARY,
+            wraplength=820,
+        ).pack(fill="x", pady=(0, 10))
+        self.caregiver_list = tk.Listbox(self.frame, height=5)
+        self.care_team_list = tk.Listbox(self.frame, height=5)
+        ttk.Label(self.frame, text="Pacientes asignados").pack(anchor="w")
+        self.caregiver_list.pack(fill="x", pady=4)
+        ttk.Label(self.frame, text="Equipos de cuidado").pack(anchor="w", pady=(10, 0))
+        self.care_team_list.pack(fill="x", pady=4)
+
+    def update(self, caregiver_payload: Dict[str, Any], care_team_payload: Dict[str, Any]) -> None:
+        self.caregiver_list.delete(0, tk.END)
+        self.care_team_list.delete(0, tk.END)
+        caregiver_locations = caregiver_payload.get("data", {}).get("locations") or caregiver_payload.get("locations") or []
+        care_team_locations = care_team_payload.get("data", {}).get("locations") or care_team_payload.get("locations") or []
+        for loc in caregiver_locations:
+            if isinstance(loc, dict):
+                self.caregiver_list.insert(tk.END, f"{loc.get('patient_name', 'Paciente')} - {loc.get('latitude')}, {loc.get('longitude')}")
+        if not caregiver_locations:
+            self.caregiver_list.insert(tk.END, "Sin ubicaciones recientes")
+        for loc in care_team_locations:
+            if isinstance(loc, dict):
+                self.care_team_list.insert(tk.END, f"{loc.get('team_name', 'Equipo')} - {loc.get('latitude')}, {loc.get('longitude')}")
+        if not care_team_locations:
+            self.care_team_list.insert(tk.END, "Sin ubicaciones disponibles")
+
+
+class _PatientsSection:
+    def __init__(self, master: tk.Widget, open_detail: Callable[[OrgMembership, str, str], None]) -> None:
+        self.frame = ttk.LabelFrame(master, text="Gestión de pacientes", padding=16)
+        self.open_detail = open_detail
+        self.current_membership: Optional[OrgMembership] = None
+        self.notebook = ttk.Notebook(self.frame)
+        self.notebook.pack(fill="both", expand=True)
+
+        self.my_patients_list = tk.Listbox(self.notebook, height=8)
+        self.team_patients_tree = ttk.Treeview(self.notebook, columns=("equipo", "rol"), show="headings")
+        self.team_patients_tree.heading("equipo", text="Equipo")
+        self.team_patients_tree.heading("rol", text="Rol en el equipo")
+
+        self.notebook.add(self.my_patients_list, text="Mis pacientes")
+        self.notebook.add(self.team_patients_tree, text="Pacientes por equipo")
+
+        btn = styled_button(self.frame, "Ver detalles", self._on_view_detail)
+        btn.pack(pady=12)
+
+    def update(self, membership: OrgMembership, caregiver_payload: Dict[str, Any], team_payload: Dict[str, Any]) -> None:
+        self.current_membership = membership
+        self.my_patients_list.delete(0, tk.END)
+        patients = caregiver_payload.get("data", {}).get("patients") or caregiver_payload.get("patients") or []
+        self._caregiver_patients_cache: List[Dict[str, Any]] = []
+        for item in patients:
+            if isinstance(item, dict):
+                display = f"{item.get('name')} ({item.get('risk_level', 'N/A')})"
+                self.my_patients_list.insert(tk.END, display)
+                self._caregiver_patients_cache.append(item)
+        if not patients:
+            self.my_patients_list.insert(tk.END, "No tienes pacientes asignados")
+
+        for iid in self.team_patients_tree.get_children():
+            self.team_patients_tree.delete(iid)
+        self._team_patients_cache: List[Dict[str, Any]] = []
+        teams = team_payload.get("data", {}).get("patients") or team_payload.get("patients") or []
+        for item in teams:
+            if isinstance(item, dict):
+                self.team_patients_tree.insert("", tk.END, values=(item.get("team_name"), item.get("role_label")))
+                self._team_patients_cache.append(item)
+        if not teams:
+            self.team_patients_tree.insert("", tk.END, values=("--", "Sin pacientes"))
+
+    def _on_view_detail(self) -> None:
+        if not self.current_membership:
+            return
+        if self.notebook.index(self.notebook.select()) == 0:
+            selection = self.my_patients_list.curselection()
+            if not selection:
+                messagebox.showinfo("Pacientes", "Selecciona un paciente")
+                return
+            patient = self._caregiver_patients_cache[selection[0]] if selection[0] < len(self._caregiver_patients_cache) else None
+        else:
+            selection = self.team_patients_tree.selection()
+            if not selection:
+                messagebox.showinfo("Pacientes", "Selecciona un paciente")
+                return
+            index = self.team_patients_tree.index(selection[0])
+            patient = self._team_patients_cache[index] if index < len(self._team_patients_cache) else None
+        if not patient:
+            return
+        patient_id = patient.get("id") or patient.get("patient_id")
+        name = patient.get("name") or patient.get("patient_name") or "Paciente"
+        self.open_detail(self.current_membership, patient_id, name)
+
+
+class _DevicesSection:
+    def __init__(self, master: tk.Widget) -> None:
+        self.frame = ttk.LabelFrame(master, text="Dispositivos por equipo", padding=16)
+        self.combo = ttk.Combobox(self.frame, state="readonly")
+        self.combo.pack(fill="x")
+        columns = ("id", "estado", "tipo")
+        self.tree = ttk.Treeview(self.frame, columns=columns, show="headings")
+        for col in columns:
+            self.tree.heading(col, text=col.capitalize())
+        self.tree.pack(fill="both", expand=True, pady=8)
+        self.status_var = tk.StringVar(value="Selecciona un equipo para ver sus dispositivos")
+        ttk.Label(self.frame, textvariable=self.status_var, foreground=Colors.TEXT_SECONDARY).pack(anchor="w")
+        self._teams: List[Dict[str, Any]] = []
+        self._callback: Optional[Callable[[str, Callable[[Dict[str, Any]], None], Callable[[Exception], None]], None]] = None
+        self.combo.bind("<<ComboboxSelected>>", lambda _e: self._on_team_selected())
+
+    def update(self, care_teams_payload: Dict[str, Any], membership: OrgMembership,
+               fetch_callback: Callable[[OrgMembership, str, Callable[[Dict[str, Any]], None], Callable[[Exception], None]], None]) -> None:
+        self._teams = care_teams_payload.get("data", {}).get("teams") or care_teams_payload.get("teams") or []
+        self.combo["values"] = [team.get("name") for team in self._teams]
+        self._callback = lambda team_id, success, error: fetch_callback(membership, team_id, success, error)
+        if self._teams:
+            self.combo.current(0)
+            self._request_devices(self._teams[0].get("id"))
+        else:
+            self.combo.set("")
+            self.status_var.set("No hay equipos de cuidado configurados")
+            self._clear_tree()
+
+    def _clear_tree(self) -> None:
+        for iid in self.tree.get_children():
+            self.tree.delete(iid)
+
+    def _on_team_selected(self) -> None:
+        index = self.combo.current()
+        if index < 0 or index >= len(self._teams):
+            return
+        team_id = self._teams[index].get("id")
+        self._request_devices(team_id)
+
+    def _request_devices(self, team_id: Optional[str]) -> None:
+        if not team_id or not self._callback:
+            return
+
+        def success(payload: Dict[str, Any]) -> None:
+            self._clear_tree()
+            active = payload.get("active", {}).get("data") or payload.get("active", {})
+            devices = active.get("devices") if isinstance(active, dict) else []
+            for device in devices or []:
+                if isinstance(device, dict):
+                    self.tree.insert("", tk.END, values=(device.get("id"), "Activo", device.get("type")))
+            disconnected = payload.get("disconnected", {}).get("data") or payload.get("disconnected", {})
+            disc_devices = disconnected.get("devices") if isinstance(disconnected, dict) else []
+            for device in disc_devices or []:
+                if isinstance(device, dict):
+                    self.tree.insert("", tk.END, values=(device.get("id"), "Desconectado", device.get("type")))
+            if not devices and not disc_devices:
+                self.status_var.set("Sin dispositivos registrados")
+            else:
+                self.status_var.set("Dispositivos listados")
+
+        def error(exc: Exception) -> None:
+            messagebox.showerror("Dispositivos", str(exc))
+
+        self.status_var.set("Cargando dispositivos...")
+        self._callback(team_id, success, error)
+
+
+class _AlertsBoardSection:
+    def __init__(self, master: tk.Widget) -> None:
+        self.frame = ttk.LabelFrame(master, text="Alertas y seguimiento", padding=16)
+        self.listbox = tk.Listbox(self.frame, height=6)
+        self.listbox.pack(fill="both", expand=True)
+        self.listbox.bind("<Double-Button-1>", self._on_double_click)
+        self._patients: List[Dict[str, Any]] = []
+        self._callback: Optional[Callable[[OrgMembership, str, str], None]] = None
+        self._membership: Optional[OrgMembership] = None
+
+    def update(self, caregiver_payload: Dict[str, Any], callback: Callable[[OrgMembership, str, str], None],
+               membership: OrgMembership) -> None:
+        self._callback = callback
+        self._membership = membership
+        self.listbox.delete(0, tk.END)
+        self._patients = []
+        patients = caregiver_payload.get("data", {}).get("patients") or caregiver_payload.get("patients") or []
+        for patient in patients:
+            if isinstance(patient, dict):
+                alerts = patient.get("alerts_open") or patient.get("open_alerts")
+                self.listbox.insert(
+                    tk.END,
+                    f"{patient.get('name')} - Alertas abiertas: {alerts if alerts is not None else 'N/A'}",
+                )
+                self._patients.append(patient)
+        if not patients:
+            self.listbox.insert(tk.END, "No hay alertas para tus pacientes")
+
+    def _on_double_click(self, _event: tk.Event) -> None:
+        if not self._callback or not self._membership:
+            return
+        selection = self.listbox.curselection()
+        if not selection or selection[0] >= len(self._patients):
+            return
+        patient = self._patients[selection[0]]
+        patient_id = patient.get("id") or patient.get("patient_id")
+        name = patient.get("name") or "Paciente"
+        if patient_id:
+            self._callback(self._membership, patient_id, name)
+
+
+class UserProfileDialog(tk.Toplevel):
+    def __init__(self, master: tk.Widget, api_client: ApiClient, token: str, profile: UserProfile, on_saved: Callable[[], None]) -> None:
+        super().__init__(master)
+        self.api_client = api_client
+        self.token = token
+        self.profile = profile
+        self.on_saved = on_saved
+        self.title("Perfil de usuario")
+        self.resizable(False, False)
+        ttk.Label(self, text="Actualizar información personal", font=Fonts.TITLE).pack(pady=12, padx=16)
+        form = ttk.Frame(self, padding=16)
+        form.pack(fill="both", expand=True)
+        ttk.Label(form, text="Nombre completo:").grid(row=0, column=0, sticky="w", pady=6)
+        self.name_entry = ttk.Entry(form, width=40)
+        self.name_entry.grid(row=0, column=1, pady=6)
+        self.name_entry.insert(0, profile.name or "")
+        ttk.Label(form, text="Email (solo lectura):").grid(row=1, column=0, sticky="w", pady=6)
+        email_entry = ttk.Entry(form, width=40)
+        email_entry.grid(row=1, column=1, pady=6)
+        email_entry.insert(0, profile.email or "")
+        email_entry.configure(state="disabled")
+        ttk.Label(form, text="Foto de perfil (URL):").grid(row=2, column=0, sticky="w", pady=6)
+        self.photo_entry = ttk.Entry(form, width=40)
+        self.photo_entry.grid(row=2, column=1, pady=6)
+        self.photo_entry.insert(0, profile.profile_photo_url or "")
+
+        buttons = ttk.Frame(self, padding=(16, 0, 16, 16))
+        buttons.pack(fill="x")
+        styled_button(buttons, "Guardar", self._on_save).pack(side="left", padx=6)
+        styled_button(buttons, "Cerrar", self.destroy, primary=False).pack(side="right", padx=6)
+
+    def _on_save(self) -> None:
+        updates = {"name": self.name_entry.get().strip(), "profile_photo_url": self.photo_entry.get().strip() or None}
+
+        def success(_payload: Dict[str, Any]) -> None:
+            messagebox.showinfo("Perfil", "Perfil actualizado correctamente")
+            self.on_saved()
+            self.destroy()
+
+        def error(exc: Exception) -> None:
+            messagebox.showerror("Perfil", str(exc))
+
+        future = run_in_executor(lambda: self.api_client.update_current_user_profile(updates, token=self.token))
+
+        def done(fut):
+            try:
+                payload = fut.result()
+            except Exception as exc:  # pragma: no cover
+                self.after(0, lambda: error(exc))
+                return
+            self.after(0, lambda: success(payload))
+
+        future.add_done_callback(done)
+
+
+class InvitationsDialog(tk.Toplevel):
+    def __init__(self, master: tk.Widget, api_client: ApiClient, token: str) -> None:
+        super().__init__(master)
+        self.api_client = api_client
+        self.token = token
+        self.title("Invitaciones pendientes")
+        self.geometry("520x420")
+        ttk.Label(self, text="Invitaciones", font=Fonts.TITLE).pack(pady=12)
+        self.listbox = tk.Listbox(self, height=10)
+        self.listbox.pack(fill="both", expand=True, padx=16)
+        buttons = ttk.Frame(self, padding=16)
+        buttons.pack(fill="x")
+        styled_button(buttons, "Aceptar", self._on_accept).pack(side="left", padx=6)
+        styled_button(buttons, "Rechazar", self._on_reject, primary=False).pack(side="left", padx=6)
+        styled_button(buttons, "Cerrar", self.destroy, primary=False).pack(side="right", padx=6)
+        self._invitations: List[Dict[str, Any]] = []
+        self._load()
+
+    def _load(self) -> None:
+        def fetch() -> List[Dict[str, Any]]:
+            payload = self.api_client.get_pending_invitations(self.token)
+            return parse_invitations(payload)
+
+        def on_success(invitations: List[Dict[str, Any]]) -> None:
+            self._invitations = invitations
+            self.listbox.delete(0, tk.END)
+            for inv in invitations:
+                text = f"{inv.get('org_name')} - Rol: {inv.get('role_label')}"
+                self.listbox.insert(tk.END, text)
+            if not invitations:
+                self.listbox.insert(tk.END, "No tienes invitaciones pendientes")
+
+        def on_error(exc: Exception) -> None:
+            messagebox.showerror("Invitaciones", str(exc))
+
+        future = run_in_executor(fetch)
+
+        def done(fut):
+            try:
+                invitations = fut.result()
+            except Exception as exc:  # pragma: no cover
+                self.after(0, lambda: on_error(exc))
+                return
+            self.after(0, lambda: on_success(invitations))
+
+        future.add_done_callback(done)
+
+    def _resolve_selection(self) -> Optional[Dict[str, Any]]:
+        selection = self.listbox.curselection()
+        if not selection or selection[0] >= len(self._invitations):
+            messagebox.showinfo("Invitaciones", "Selecciona una invitación")
+            return None
+        return self._invitations[selection[0]]
+
+    def _on_accept(self) -> None:
+        invitation = self._resolve_selection()
+        if not invitation:
+            return
+
+        def run() -> Dict[str, Any]:
+            return self.api_client.accept_invitation(invitation.get("id"), token=self.token)
+
+        future = run_in_executor(run)
+
+        def done(fut):
+            try:
+                fut.result()
+            except Exception as exc:  # pragma: no cover
+                self.after(0, lambda: messagebox.showerror("Invitaciones", str(exc)))
+                return
+            self.after(0, self._load)
+
+        future.add_done_callback(done)
+
+    def _on_reject(self) -> None:
+        invitation = self._resolve_selection()
+        if not invitation:
+            return
+
+        def run() -> Dict[str, Any]:
+            return self.api_client.reject_invitation(invitation.get("id"), token=self.token)
+
+        future = run_in_executor(run)
+
+        def done(fut):
+            try:
+                fut.result()
+            except Exception as exc:  # pragma: no cover
+                self.after(0, lambda: messagebox.showerror("Invitaciones", str(exc)))
+                return
+            self.after(0, self._load)
+
+        future.add_done_callback(done)
+
+
+class PatientDetailDialog(tk.Toplevel):
+    def __init__(self, master: tk.Widget, api_client: ApiClient, token: str, membership: OrgMembership,
+                 patient_id: str, patient_name: str) -> None:
+        super().__init__(master)
+        self.api_client = api_client
+        self.token = token
+        self.membership = membership
+        self.patient_id = patient_id
+        self.title(f"Paciente: {patient_name}")
+        self.geometry("720x560")
+
+        header = ttk.Frame(self, padding=16)
+        header.pack(fill="x")
+        ttk.Label(header, text=patient_name, font=Fonts.TITLE).pack(anchor="w")
+
+        self.tabs = ttk.Notebook(self)
+        self.tabs.pack(fill="both", expand=True, padx=16, pady=12)
+        self.profile_text = tk.Text(self.tabs, state="disabled")
+        self.alerts_list = tk.Listbox(self.tabs)
+        self.notes_list = tk.Listbox(self.tabs)
+        self.tabs.add(self.profile_text, text="Perfil")
+        self.tabs.add(self.alerts_list, text="Alertas")
+        self.tabs.add(self.notes_list, text="Notas")
+
+        self._load()
+
+    def _load(self) -> None:
+        def fetch() -> Dict[str, Any]:
+            detail = self.api_client.get_organization_patient_detail(self.membership.org_id, self.patient_id, token=self.token)
+            alerts = self.api_client.get_organization_patient_alerts(self.membership.org_id, self.patient_id, token=self.token)
+            notes = self.api_client.get_organization_patient_notes(self.membership.org_id, self.patient_id, token=self.token)
+            return {"detail": detail, "alerts": alerts, "notes": notes}
+
+        def on_success(payload: Dict[str, Any]) -> None:
+            detail = payload["detail"].get("data") or payload["detail"]
+            self.profile_text.configure(state="normal")
+            self.profile_text.delete("1.0", tk.END)
+            for key, value in detail.items():
+                self.profile_text.insert(tk.END, f"{key}: {value}\n")
+            self.profile_text.configure(state="disabled")
+
+            self.alerts_list.delete(0, tk.END)
+            alerts = payload["alerts"].get("data", {}).get("alerts") or payload["alerts"].get("alerts") or []
+            for alert in alerts:
+                if isinstance(alert, dict):
+                    self.alerts_list.insert(tk.END, f"[{alert.get('status')}] {alert.get('message')}")
+            if not alerts:
+                self.alerts_list.insert(tk.END, "Sin alertas recientes")
+
+            self.notes_list.delete(0, tk.END)
+            notes = payload["notes"].get("data", {}).get("notes") or payload["notes"].get("notes") or []
+            for note in notes:
+                if isinstance(note, dict):
+                    self.notes_list.insert(tk.END, f"{note.get('created_at')}: {note.get('content')}")
+            if not notes:
+                self.notes_list.insert(tk.END, "No hay notas registradas")
+
+        def on_error(exc: Exception) -> None:
+            messagebox.showerror("Paciente", str(exc))
+
+        future = run_in_executor(fetch)
+
+        def done(fut):
+            try:
+                payload = fut.result()
+            except Exception as exc:  # pragma: no cover
+                self.after(0, lambda: on_error(exc))
+                return
+            self.after(0, lambda: on_success(payload))
+
+        future.add_done_callback(done)

--- a/tkinter_app/ui/widgets.py
+++ b/tkinter_app/ui/widgets.py
@@ -1,0 +1,93 @@
+"""Widgets reutilizables para la interfaz de HeartGuard en Tkinter."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+from typing import Any, Callable, Optional
+
+from ..utils.async_utils import run_in_executor
+
+
+class AsyncMixin:
+    """Mezcla que facilita ejecutar funciones en segundo plano."""
+
+    def run_async(self, func: Callable[..., Any], callback: Optional[Callable[[Any], None]] = None,
+                  error_callback: Optional[Callable[[Exception], None]] = None, *args: Any, **kwargs: Any) -> None:
+        future = run_in_executor(func, *args, **kwargs)
+
+        def _on_done(fut):
+            try:
+                result = fut.result()
+            except Exception as exc:  # pragma: no cover - depende de IO real
+                if error_callback:
+                    self.after(0, error_callback, exc)
+                else:
+                    self.after(0, lambda: messagebox.showerror("Error", str(exc)))
+                return
+            if callback:
+                self.after(0, callback, result)
+
+        future.add_done_callback(_on_done)
+
+    def after(self, delay_ms: int, callback: Callable[..., Any], *args: Any) -> None:  # pragma: no cover - implementado por Tk
+        raise NotImplementedError
+
+
+class ScrollableFrame(ttk.Frame):
+    """Contenedor con scroll vertical."""
+
+    def __init__(self, master: tk.Widget, **kwargs: Any) -> None:
+        super().__init__(master, **kwargs)
+        canvas = tk.Canvas(self, highlightthickness=0)
+        scrollbar = ttk.Scrollbar(self, orient="vertical", command=canvas.yview)
+        self._content = ttk.Frame(canvas)
+
+        self._content.bind(
+            "<Configure>",
+            lambda e: canvas.configure(scrollregion=canvas.bbox("all")),
+        )
+        canvas.create_window((0, 0), window=self._content, anchor="nw")
+        canvas.configure(yscrollcommand=scrollbar.set)
+
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+
+    @property
+    def content(self) -> ttk.Frame:
+        return self._content
+
+
+def styled_button(master: tk.Widget, text: str, command: Callable[[], Any], *, primary: bool = True, width: int = 18) -> ttk.Button:
+    style_name = "HeartGuard.Primary.TButton" if primary else "HeartGuard.Secondary.TButton"
+    button = ttk.Button(master, text=text, command=command, style=style_name, width=width)
+    return button
+
+
+def setup_styles(root: tk.Tk) -> None:
+    style = ttk.Style(root)
+    if style.theme_use() == "classic":
+        style.theme_use("clam")
+
+    style.configure(
+        "HeartGuard.Primary.TButton",
+        foreground="white",
+        background="#2196F3",
+        padding=8,
+        relief="flat",
+    )
+    style.map(
+        "HeartGuard.Primary.TButton",
+        background=[("active", "#1976D2"), ("disabled", "#90CAF9")],
+    )
+    style.configure(
+        "HeartGuard.Secondary.TButton",
+        foreground="#233446",
+        background="#ECEFF1",
+        padding=8,
+        relief="flat",
+    )
+    style.map(
+        "HeartGuard.Secondary.TButton",
+        background=[("active", "#CFD8DC"), ("disabled", "#ECEFF1")],
+    )

--- a/tkinter_app/utils/async_utils.py
+++ b/tkinter_app/utils/async_utils.py
@@ -1,0 +1,24 @@
+"""Utilidades para ejecutar operaciones en segundo plano y sincronizar con Tkinter."""
+
+from __future__ import annotations
+
+import concurrent.futures
+from typing import Any, Callable, Optional
+
+_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+
+
+def get_executor(max_workers: int = 8) -> concurrent.futures.ThreadPoolExecutor:
+    """Devuelve un ejecutor compartido para operaciones de red."""
+
+    global _executor
+    if _executor is None:
+        _executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="heartguard")
+    return _executor
+
+
+def run_in_executor(func: Callable[..., Any], *args: Any, **kwargs: Any) -> concurrent.futures.Future:
+    """Ejecuta ``func`` en el ejecutor de background y retorna el ``Future``."""
+
+    executor = get_executor()
+    return executor.submit(func, *args, **kwargs)


### PR DESCRIPTION
## Summary
- add a standalone `tkinter_app` package that mirrors the Swing desktop application's flows
- implement an HTTP API client, shared models, and asynchronous helpers for requests
- port login, patient dashboard, and staff dashboard (with dialogs) to Tkinter while preserving UX text and backend endpoints

## Testing
- python -m compileall tkinter_app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d422d391083239aba5f05dca066cb)